### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
 name: Python package
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/aws/aws-durable-execution-sdk-python/security/code-scanning/1](https://github.com/aws/aws-durable-execution-sdk-python/security/code-scanning/1)

To fix this problem, you should add an explicit `permissions` block to the workflow. The `permissions` block can be set at the root of the workflow (applies to all jobs), or on individual jobs. Since there is just one job (`build`) and no evidence that any additional permissions (such as `write` permissions) are needed, the safest minimal starting point is `contents: read`, which is recommended by GitHub. Place the following block directly after the `name:` field, before `on:`. This sets the minimum required permissions token for the job and prevents accidental over-provision of privileges.

**Steps:**

- Edit `.github/workflows/ci.yml`
- Insert these lines after the workflow `name:` field (after line 4), before the `on:` field:
  ```yaml
  permissions:
    contents: read
  ```

No new imports, methods, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
