### PR TITLE
feat: Add checkpoint at start of opreations

### DIFF
--- a/src/aws_durable_execution_sdk_python/operation/child.py
+++ b/src/aws_durable_execution_sdk_python/operation/child.py
@@ -68,7 +68,7 @@ def child_handler(
         config.sub_type if config.sub_type else OperationSubType.RUN_IN_CHILD_CONTEXT
     )
 
-    if not checkpointed_result.is_started():
+    if not checkpointed_result.is_existent():
         start_operation = OperationUpdate.create_context_start(
             identifier=operation_identifier,
             sub_type=sub_type,

--- a/src/aws_durable_execution_sdk_python/operation/wait_for_condition.py
+++ b/src/aws_durable_execution_sdk_python/operation/wait_for_condition.py
@@ -117,7 +117,7 @@ def wait_for_condition_handler(
         current_state = config.initial_state
 
     # Checkpoint START for observability.
-    if not checkpointed_result.is_existent():
+    if not checkpointed_result.is_started():
         start_operation: OperationUpdate = (
             OperationUpdate.create_wait_for_condition_start(
                 identifier=operation_identifier,

--- a/tests/e2e/execution_int_test.py
+++ b/tests/e2e/execution_int_test.py
@@ -120,7 +120,8 @@ def test_step_different_ways_to_pass_args():
             == '["from step 123 str", "from step no args", "from step plain"]'
         )
 
-        assert len(checkpoint_calls) == 3
+        # 3 START checkpoint, 3 SUCCEED checkpoint
+        assert len(checkpoint_calls) == 6
 
         checkpoint = checkpoint_calls[-1][0]
         assert checkpoint.operation_type is OperationType.STEP
@@ -205,10 +206,15 @@ def test_step_with_logger():
 
         assert result["Status"] == InvocationStatus.SUCCEEDED.value
 
-        assert len(checkpoint_calls) == 1
+        # 1 START checkpoint, 1 SUCCEED checkpoint
+        assert len(checkpoint_calls) == 2
 
-        # Check the wait checkpoint
         checkpoint = checkpoint_calls[0][0]
+        assert checkpoint.operation_type == OperationType.STEP
+        assert checkpoint.action == OperationAction.START
+        assert checkpoint.operation_id == "1"
+        # Check the wait checkpoint
+        checkpoint = checkpoint_calls[1][0]
         assert checkpoint.operation_type == OperationType.STEP
         assert checkpoint.action == OperationAction.SUCCEED
         assert checkpoint.operation_id == "1"

--- a/tests/operation/child_test.py
+++ b/tests/operation/child_test.py
@@ -43,6 +43,7 @@ def test_child_handler_not_started(
     mock_result.is_started.return_value = False
     mock_result.is_replay_children.return_value = False
     mock_result.is_replay_children.return_value = False
+    mock_result.is_existent.return_value = False
     mock_state.get_checkpoint_result.return_value = mock_result
     mock_callable = Mock(return_value="fresh_result")
 
@@ -203,6 +204,7 @@ def test_child_handler_callable_exception(
     mock_result.is_succeeded.return_value = False
     mock_result.is_failed.return_value = False
     mock_result.is_started.return_value = False
+    mock_result.is_existent.return_value = False
     mock_state.get_checkpoint_result.return_value = mock_result
     mock_callable = Mock(side_effect=ValueError("Test error"))
 
@@ -313,6 +315,7 @@ def test_child_handler_custom_serdes_not_start() -> None:
     mock_result.is_failed.return_value = False
     mock_result.is_started.return_value = False
     mock_result.is_replay_children.return_value = False
+    mock_result.is_existent.return_value = False
     mock_state.get_checkpoint_result.return_value = mock_result
     complex_result = {"key": "value", "number": 42, "list": [1, 2, 3]}
     mock_callable = Mock(return_value=complex_result)
@@ -372,6 +375,7 @@ def test_child_handler_large_payload_with_summary_generator() -> None:
     mock_result.is_failed.return_value = False
     mock_result.is_started.return_value = False
     mock_result.is_replay_children.return_value = False
+    mock_result.is_existent.return_value = False
     mock_state.get_checkpoint_result.return_value = mock_result
     large_result = "large" * 256 * 1024
     mock_callable = Mock(return_value=large_result)
@@ -406,6 +410,7 @@ def test_child_handler_large_payload_without_summary_generator() -> None:
     mock_result.is_failed.return_value = False
     mock_result.is_started.return_value = False
     mock_result.is_replay_children.return_value = False
+    mock_result.is_existent.return_value = False
     mock_state.get_checkpoint_result.return_value = mock_result
     large_result = "large" * 256 * 1024
     mock_callable = Mock(return_value=large_result)

--- a/tests/operation/wait_test.py
+++ b/tests/operation/wait_test.py
@@ -39,6 +39,7 @@ def test_wait_handler_not_completed():
     mock_state = Mock(spec=ExecutionState)
     mock_result = Mock(spec=CheckpointedResult)
     mock_result.is_succeeded.return_value = False
+    mock_result.is_existent.return_value = False
     mock_state.get_checkpoint_result.return_value = mock_result
 
     with pytest.raises(SuspendExecution, match="Wait for 30 seconds"):
@@ -68,6 +69,7 @@ def test_wait_handler_with_none_name():
     mock_state = Mock(spec=ExecutionState)
     mock_result = Mock(spec=CheckpointedResult)
     mock_result.is_succeeded.return_value = False
+    mock_result.is_existent.return_value = False
     mock_state.get_checkpoint_result.return_value = mock_result
 
     with pytest.raises(SuspendExecution, match="Wait for 5 seconds"):
@@ -88,3 +90,22 @@ def test_wait_handler_with_none_name():
     mock_state.create_checkpoint.assert_called_once_with(
         operation_update=expected_operation
     )
+
+
+def test_wait_handler_with_existent():
+    """Test wait_handler with existent operation."""
+    mock_state = Mock(spec=ExecutionState)
+    mock_result = Mock(spec=CheckpointedResult)
+    mock_result.is_succeeded.return_value = False
+    mock_result.is_existent.return_value = True
+    mock_state.get_checkpoint_result.return_value = mock_result
+
+    with pytest.raises(SuspendExecution, match="Wait for 5 seconds"):
+        wait_handler(
+            seconds=5,
+            state=mock_state,
+            operation_identifier=OperationIdentifier("wait4", None),
+        )
+
+    mock_state.get_checkpoint_result.assert_called_once_with("wait4")
+    mock_state.create_checkpoint.assert_not_called()


### PR DESCRIPTION
- Add checkpoint at start of operations for
  - wait
  - wait for condition
  - step
  - run in child context

- Modify logic
  - step:
    - AT_MOST_ONCE_PER_RETRY, : go retry logic - if retry, do retries, if out of retries checkpoint FAIL and raise StepInterrupted and fail
    - AT_LEAST_ONCE_PER_RETRY: continues execution normally
  - wait:
    - suspend if it's not a brand new execution