### PR TITLE
chore: remove DEX specific env vars and update local runner env vars

### DIFF
--- a/src/aws_durable_execution_sdk_python/lambda_service.py
+++ b/src/aws_durable_execution_sdk_python/lambda_service.py
@@ -839,9 +839,9 @@ class LambdaClient(DurableServiceClient):
     @staticmethod
     def initialize_local_runner_client() -> LambdaClient:
         endpoint = os.getenv(
-            "LOCAL_RUNNER_ENDPOINT", "http://host.docker.internal:5000"
+            "DURABLE_LOCAL_RUNNER_ENDPOINT", "http://host.docker.internal:5000"
         )
-        region = os.getenv("LOCAL_RUNNER_REGION", "us-west-2")
+        region = os.getenv("DURABLE_LOCAL_RUNNER_REGION", "us-west-2")
 
         # The local runner client needs execute-api as the signing service name,
         # so we have a second `lambdainternal-local` boto model with this.
@@ -860,28 +860,14 @@ class LambdaClient(DurableServiceClient):
         return LambdaClient(client=client)
 
     @staticmethod
-    def initialize_from_endpoint_and_region(endpoint: str, region: str) -> LambdaClient:
+    def initialize_from_env() -> LambdaClient:
         LambdaClient.load_preview_botocore_models()
         client = boto3.client(
             "lambdainternal",
-            endpoint_url=endpoint,
-            region_name=region,
         )
 
-        logger.debug(
-            "Initialized lambda client with endpoint: '%s', region: '%s'",
-            endpoint,
-            region,
-        )
+        logger.debug("Initialized lambda client")
         return LambdaClient(client=client)
-
-    @staticmethod
-    def initialize_from_env() -> LambdaClient:
-        return LambdaClient.initialize_from_endpoint_and_region(
-            # it'll prob end up being https://lambda.us-east-1.amazonaws.com or similar
-            endpoint=os.getenv("DEX_ENDPOINT", "http://host.docker.internal:5000"),
-            region=os.getenv("DEX_REGION", "us-east-1"),
-        )
 
     def checkpoint(
         self,

--- a/tests/e2e/execution_int_test.py
+++ b/tests/e2e/execution_int_test.py
@@ -18,7 +18,6 @@ from aws_durable_execution_sdk_python.lambda_context import LambdaContext
 from aws_durable_execution_sdk_python.lambda_service import (
     CheckpointOutput,
     CheckpointUpdatedExecutionState,
-    LambdaClient,
     OperationAction,
     OperationType,
 )
@@ -392,14 +391,3 @@ def test_wait_not_caught_by_exception():
         assert checkpoint.action is OperationAction.START
         assert checkpoint.operation_id == "1"
         assert checkpoint.wait_options.seconds == 1
-
-
-def test_lambda_client_initialization():
-    """Test initialization of real Lambda client with specified endpoint and region."""
-    endpoint = "https://durable.durable-functions.devo.us-west-2.lambda.aws.a2z.com"
-    region = "us-west-2"
-
-    client = LambdaClient.initialize_from_endpoint_and_region(endpoint, region)
-
-    assert client is not None
-    assert client.client is not None


### PR DESCRIPTION
*Issue #, if available:*
DAR-SDK-315

*Description of changes:*

Removing hardcoded `DEX_ENDPOINT`/`DEX_REGION`, and updating local runner env variables to be prefixed with `DURABLE_`. Same change on JS: https://github.com/aws/aws-durable-execution-sdk-js/pull/94

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
