### PR TITLE
fix: explicitly lookup AWS_ENDPOINT_URL_LAMBDA while using preview lambda model

### DIFF
--- a/src/aws_durable_execution_sdk_python/lambda_service.py
+++ b/src/aws_durable_execution_sdk_python/lambda_service.py
@@ -862,11 +862,19 @@ class LambdaClient(DurableServiceClient):
     @staticmethod
     def initialize_from_env() -> LambdaClient:
         LambdaClient.load_preview_botocore_models()
-        client = boto3.client(
-            "lambdainternal",
-        )
 
-        logger.debug("Initialized lambda client")
+        """
+        TODO - we can remove this when were using the actual lambda client,
+        but we need this with the preview model because boto won't match against lambdainternal.
+        """
+        endpoint_url = os.getenv("AWS_ENDPOINT_URL_LAMBDA", None)
+        if not endpoint_url:
+            client = boto3.client(
+                "lambdainternal",
+            )
+        else:
+            client = boto3.client("lambdainternal", endpoint_url=endpoint_url)
+
         return LambdaClient(client=client)
 
     def checkpoint(


### PR DESCRIPTION
*Description of changes:*
Since we're using a custom `lambdainternal` model during development, the functionality to match `AWS_ENDPOINT_URL_LAMBDA` wasn't working properly and our checkpoint calls weren't hitting the backend.

Tested it by building the python SDK and running an example against the backend.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
