### PR TITLE
Add cross-repo test triggering to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,29 @@ jobs:
       run: hatch run test:cov
     - name: Build distribution
       run: hatch build
+
+  trigger-tests:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          repositories: aws-durable-execution-sdk-python-testing
+      
+      - name: Trigger tests in aws-durable-execution-sdk-python-testing
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          repository: aws/aws-durable-execution-sdk-python-testing
+          event-type: test-pr
+          client-payload: |
+            {
+              "pr_number": "${{ github.event.number }}",
+              "pr_sha": "${{ github.event.pull_request.head.sha }}",
+              "pr_ref": "${{ github.event.pull_request.head.ref }}",
+              "source_repo": "${{ github.repository }}"
+            }


### PR DESCRIPTION
*Description of changes:*
Creating a cross-repo trigger to run the tests against the testing library when we make changes in the language SDK.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
