### PR TITLE
fix: StepDetails should deserialize unix timestamp to datetime

### DIFF
--- a/src/aws_durable_execution_sdk_python/lambda_service.py
+++ b/src/aws_durable_execution_sdk_python/lambda_service.py
@@ -158,9 +158,7 @@ class StepDetails:
         error_raw = data.get("Error")
         return cls(
             attempt=data.get("Attempt", 0),
-            next_attempt_timestamp=data.get(
-                "NextAttemptTimestamp"
-            ),  # TODO: how is this serialized? Unix or ISO 8601?
+            next_attempt_timestamp=data.get("NextAttemptTimestamp"),
             result=data.get("Result"),
             error=ErrorObject.from_dict(error_raw) if error_raw else None,
         )

--- a/tests/lambda_service_test.py
+++ b/tests/lambda_service_test.py
@@ -230,13 +230,17 @@ def test_step_details_from_dict():
     error_data = {"ErrorMessage": "Step error"}
     data = {
         "Attempt": 2,
-        "NextAttemptTimestamp": "2023-01-01T00:00:00Z",
+        "NextAttemptTimestamp": datetime.datetime(
+            2023, 1, 1, 0, 0, 0, tzinfo=datetime.UTC
+        ),
         "Result": "step_result",
         "Error": error_data,
     }
     details = StepDetails.from_dict(data)
     assert details.attempt == 2
-    assert details.next_attempt_timestamp == "2023-01-01T00:00:00Z"
+    assert details.next_attempt_timestamp == datetime.datetime(
+        2023, 1, 1, 0, 0, 0, tzinfo=datetime.UTC
+    )
     assert details.result == "step_result"
     assert details.error.message == "Step error"
 
@@ -246,13 +250,17 @@ def test_step_details_all_fields():
     error_data = {"ErrorMessage": "Step failed", "ErrorType": "StepError"}
     data = {
         "Attempt": 3,
-        "NextAttemptTimestamp": "2023-01-01T12:00:00Z",
+        "NextAttemptTimestamp": datetime.datetime(
+            2023, 1, 1, 12, 0, 0, tzinfo=datetime.UTC
+        ),
         "Result": "step_success",
         "Error": error_data,
     }
     details = StepDetails.from_dict(data)
     assert details.attempt == 3
-    assert details.next_attempt_timestamp == "2023-01-01T12:00:00Z"
+    assert details.next_attempt_timestamp == datetime.datetime(
+        2023, 1, 1, 12, 0, 0, tzinfo=datetime.UTC
+    )
     assert details.result == "step_success"
     assert details.error.message == "Step failed"
     assert details.error.type == "StepError"


### PR DESCRIPTION
*Issue #, if available:*
#42 

*Description of changes:*
Updating the `.from_dict()` method for StepDetails to handle deserializing the NextAttemptTimestamp from unix timestamp to a datetime object.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
