### PR TITLE
fix: handle null ErrorObject in raise_callable_error

### DIFF
--- a/src/aws_durable_execution_sdk_python/state.py
+++ b/src/aws_durable_execution_sdk_python/state.py
@@ -6,7 +6,9 @@ from dataclasses import dataclass
 from threading import Lock
 from typing import TYPE_CHECKING
 
-from aws_durable_execution_sdk_python.exceptions import DurableExecutionsError
+from aws_durable_execution_sdk_python.exceptions import (
+    CallableRuntimeError,
+)
 from aws_durable_execution_sdk_python.lambda_service import (
     CheckpointOutput,
     DurableServiceClient,
@@ -140,10 +142,18 @@ class CheckpointedResult:
             return False
         return op.context_details.replay_children if op.context_details else False
 
-    def raise_callable_error(self) -> None:
+    def raise_callable_error(self, msg: str | None = None) -> None:
         if self.error is None:
-            msg: str = "Attempted to throw exception, but no ErrorObject exists on the Checkpoint Operation."
-            raise DurableExecutionsError(msg)
+            err_msg = (
+                msg
+                or "Unknown error. No ErrorObject exists on the Checkpoint Operation."
+            )
+            raise CallableRuntimeError(
+                message=err_msg,
+                error_type=None,
+                data=None,
+                stack_trace=None,
+            )
 
         raise self.error.to_callable_runtime_error()
 

--- a/tests/state_test.py
+++ b/tests/state_test.py
@@ -4,7 +4,9 @@ from unittest.mock import Mock, call
 
 import pytest
 
-from aws_durable_execution_sdk_python.exceptions import DurableExecutionsError
+from aws_durable_execution_sdk_python.exceptions import (
+    CallableRuntimeError,
+)
 from aws_durable_execution_sdk_python.lambda_service import (
     CallbackDetails,
     ChainedInvokeDetails,
@@ -325,8 +327,16 @@ def test_checkpointed_result_raise_callable_error_no_error():
     """Test CheckpointedResult.raise_callable_error with no error."""
     result = CheckpointedResult()
 
-    with pytest.raises(DurableExecutionsError, match="no ErrorObject exists"):
+    with pytest.raises(CallableRuntimeError, match="Unknown error"):
         result.raise_callable_error()
+
+
+def test_checkpointed_result_raise_callable_error_no_error_with_message():
+    """Test CheckpointedResult.raise_callable_error with no error and custom message."""
+    result = CheckpointedResult()
+
+    with pytest.raises(CallableRuntimeError, match="Custom error message"):
+        result.raise_callable_error("Custom error message")
 
 
 def test_checkpointed_result_immutable():


### PR DESCRIPTION
Update raise_callable_error method to accept optional message parameter and raise CallableRuntimeError when error is None.

*Issue #, if available:*
closes #35 
*Description of changes:*
- Updated raise_callable_error() method 
  - Now accepts optional msg parameter and raises CallableRuntimeError instead of DurableExecutionsError when ErrorObject is None
- Added null-safe error handling 
  - Method provides default "Unknown error" message or uses custom message when no ErrorObject exists
- Updated tests 
  - Modified existing test and added new test case for custom message parameter functionality
  
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.