### PR TITLE
feat(sdk): add replay-aware logging to suppress logs during execution replay

### DIFF
--- a/src/aws_durable_execution_sdk_python/logger.py
+++ b/src/aws_durable_execution_sdk_python/logger.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from aws_durable_execution_sdk_python.lambda_service import OperationType
 from aws_durable_execution_sdk_python.types import LoggerInterface
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, MutableMapping
 
     from aws_durable_execution_sdk_python.identifier import OperationIdentifier
+    from aws_durable_execution_sdk_python.state import ExecutionState
 
 
 @dataclass(frozen=True)
@@ -44,13 +46,25 @@ class LogInfo:
 
 class Logger(LoggerInterface):
     def __init__(
-        self, logger: LoggerInterface, default_extra: Mapping[str, object]
+        self,
+        logger: LoggerInterface,
+        default_extra: Mapping[str, object],
+        execution_state: ExecutionState | None = None,
+        visited_operations: set[str] | None = None,
     ) -> None:
         self._logger = logger
         self._default_extra = default_extra
+        self._execution_state = execution_state
+        self._visited_operations = visited_operations or set()
 
     @classmethod
-    def from_log_info(cls, logger: LoggerInterface, info: LogInfo) -> Logger:
+    def from_log_info(
+        cls,
+        logger: LoggerInterface,
+        info: LogInfo,
+        execution_state: ExecutionState | None = None,
+        visited_operations: set[str] | None = None,
+    ) -> Logger:
         """Create a new logger with the given LogInfo."""
         extra: MutableMapping[str, object] = {"execution_arn": info.execution_arn}
         if info.parent_id:
@@ -59,45 +73,118 @@ class Logger(LoggerInterface):
             extra["name"] = info.name
         if info.attempt:
             extra["attempt"] = info.attempt
-        return cls(logger, extra)
+        return cls(logger, extra, execution_state, visited_operations)
 
     def with_log_info(self, info: LogInfo) -> Logger:
         """Clone the existing logger with new LogInfo."""
         return Logger.from_log_info(
             logger=self._logger,
             info=info,
+            execution_state=self._execution_state,
+            visited_operations=self._visited_operations,
         )
 
     def get_logger(self) -> LoggerInterface:
         """Get the underlying logger."""
         return self._logger
 
+    def is_replay(self) -> bool:
+        """Check if we are currently in replay mode.
+
+        Returns True if there are operations in the execution state that haven't been visited yet.
+        This indicates we are replaying previously executed operations.
+        """
+        if not self._execution_state:
+            return False
+
+        # If there are no operations, we're not in replay
+        if not self._execution_state.operations:
+            return False
+
+        # Check if there are any operations in the execution state that we haven't visited
+        # Only consider operations that are not EXECUTION type (which are system operations)
+        for operation_id, operation in self._execution_state.operations.items():
+            # Skip EXECUTION operations as they are system operations, not user operations
+            if operation.operation_type == OperationType.EXECUTION:
+                continue
+            if operation_id not in self._visited_operations:
+                return True
+        return False
+
+    def mark_operation_visited(self, operation_id: str) -> None:
+        """Mark an operation as visited."""
+        self._visited_operations.add(operation_id)
+
+    def _should_log(self) -> bool:
+        """Determine if logging should occur based on replay state."""
+        # For the default logger, only log when not in replay
+        return not self.is_replay()
+
     def debug(
         self, msg: object, *args: object, extra: Mapping[str, object] | None = None
     ) -> None:
+        if not self._should_log():
+            return
         merged_extra = {**self._default_extra, **(extra or {})}
         self._logger.debug(msg, *args, extra=merged_extra)
 
     def info(
         self, msg: object, *args: object, extra: Mapping[str, object] | None = None
     ) -> None:
+        if not self._should_log():
+            return
         merged_extra = {**self._default_extra, **(extra or {})}
         self._logger.info(msg, *args, extra=merged_extra)
 
     def warning(
         self, msg: object, *args: object, extra: Mapping[str, object] | None = None
     ) -> None:
+        if not self._should_log():
+            return
         merged_extra = {**self._default_extra, **(extra or {})}
         self._logger.warning(msg, *args, extra=merged_extra)
 
     def error(
         self, msg: object, *args: object, extra: Mapping[str, object] | None = None
     ) -> None:
+        if not self._should_log():
+            return
         merged_extra = {**self._default_extra, **(extra or {})}
         self._logger.error(msg, *args, extra=merged_extra)
 
     def exception(
         self, msg: object, *args: object, extra: Mapping[str, object] | None = None
     ) -> None:
+        if not self._should_log():
+            return
         merged_extra = {**self._default_extra, **(extra or {})}
         self._logger.exception(msg, *args, extra=merged_extra)
+
+    @property
+    def visited_operations(self):
+        return self._visited_operations
+
+
+class ReplayAwareLogger(Logger):
+    """A logger that provides custom replay behavior for advanced users.
+
+    This logger allows users to customize logging behavior during replay by overriding
+    the _should_log method. By default, it behaves the same as the base Logger.
+    """
+
+    def _should_log(self) -> bool:
+        """Override this method to customize replay logging behavior.
+
+        Returns:
+            bool: True if logging should occur, False otherwise.
+
+        Example:
+            def _should_log(self) -> bool:
+                # Always log, even during replay
+                return True
+
+            def _should_log(self) -> bool:
+                # Only log errors during replay
+                return not self.is_replay() or self._current_log_level == 'error'
+        """
+        return super()._should_log()


### PR DESCRIPTION


*Issue #, if available:*
closes #50 
*Description of changes:*
- Track visited operations in DurableContext logger
- Suppress default logger output when replaying existing operations
- Add ReplayAwareLogger class for custom replay behavior
- Provide is_replay() method to check current execution state
- Ignore EXECUTION type operations in replay detection

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
