### PR TITLE
chore: remove @durable_handler

### DIFF
--- a/src/aws_durable_execution_sdk_python/execution.py
+++ b/src/aws_durable_execution_sdk_python/execution.py
@@ -4,9 +4,7 @@ import json
 import logging
 from dataclasses import dataclass
 from enum import Enum
-from functools import wraps
 from typing import TYPE_CHECKING, Any
-from warnings import warn
 
 from aws_durable_execution_sdk_python.context import DurableContext, ExecutionState
 from aws_durable_execution_sdk_python.exceptions import (
@@ -317,9 +315,3 @@ def durable_execution(
             ).to_dict()
 
     return wrapper
-
-
-@wraps(durable_execution)
-def durable_handler(*args, **kwargs):
-    warn("Deprecated, use `durable_execution`.", DeprecationWarning, stacklevel=2)
-    return durable_execution(*args, **kwargs)

--- a/src/aws_durable_execution_sdk_python/operation/step.py
+++ b/src/aws_durable_execution_sdk_python/operation/step.py
@@ -158,7 +158,7 @@ def step_handler(
                 operation_identifier.operation_id,
                 operation_identifier.name,
             )
-            # this bubbles up to execution.durable_handler, where it will exit with FAILED
+            # this bubbles up to execution.durable_execution, where it will exit with FAILED
             raise
 
         logger.exception(


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-durable-execution-sdk-python/issues/99

*Description of changes:*
Removing the deprecated `@durable_handler`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
