### PR TITLE
ci: CODEOWNERS and conv commits remove scope

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @yaythomas @wangyb-A

--- a/.github/workflows/lintcommit.js
+++ b/.github/workflows/lintcommit.js
@@ -55,8 +55,6 @@ function validateTitle(title) {
     return `invalid type "${type}"`;
   } else if (!scope && typeScope.includes("(")) {
     return `must be formatted like type(scope):`;
-  } else if (!scope && ["feat", "fix"].includes(type)) {
-    return `"${type}" type must include a scope (example: "${type}(sdk)")`;
   } else if (scope && scope.length > 30) {
     return "invalid scope (must be <=30 chars)";
   } else if (scope && /[^- a-z0-9]+/.test(scope)) {
@@ -65,8 +63,8 @@ function validateTitle(title) {
     return `invalid scope "${scope}" (valid scopes are ${Array.from(scopes).join(", ")})`;
   } else if (subject.length === 0) {
     return "empty subject";
-  } else if (subject.length > 100) {
-    return "invalid subject (must be <=100 chars)";
+  } else if (subject.length > 50) {
+    return "invalid subject (must be <=50 chars)";
   }
 
   return undefined;
@@ -96,7 +94,7 @@ Invalid pull request title: \`${title}\`
 * Expected format: \`type(scope): subject...\`
     * type: one of (${Array.from(types).join(", ")})
     * scope: optional, lowercase, <30 chars
-    * subject: must be <100 chars
+    * subject: must be <50 chars
 * Hint: *close and re-open the PR* to re-trigger CI (after fixing the PR title).
 `
     : `Pull request title matches the expected format`;
@@ -120,7 +118,7 @@ function _test() {
     "chore: update dependencies": undefined,
     "ci: configure CI/CD": undefined,
     "config: update configuration files": undefined,
-    "deps: bump the aws-sdk group across 1 directory with 5 updates": undefined,
+    "deps: bump aws-sdk group with 5 updates": undefined,
     "docs: update documentation": undefined,
     "feat(sdk): add new feature": undefined,
     "feat(sdk):": "empty subject",
@@ -131,9 +129,9 @@ function _test() {
       'invalid scope (must be lowercase, ascii only): "Q Foo Bar"',
     "feat(sdk): bar": undefined,
     "feat(sdk): x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x ":
-      "invalid subject (must be <=100 chars)",
-    "feat: foo": '"feat" type must include a scope (example: "feat(sdk)")',
-    "fix: foo": '"fix" type must include a scope (example: "fix(sdk)")',
+      "invalid subject (must be <=50 chars)",
+    "feat: foo": undefined,
+    "fix: foo": undefined,
     "fix(sdk): resolve issue": undefined,
     "foo (scope): bar": 'type contains whitespace: "foo "',
     "invalid title": "missing colon (:) char",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -245,6 +245,62 @@ To send us a pull request, please:
 5. Send us a pull request, answering any default questions in the pull request interface.
 6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
 
+### Pull Request Title and Commit Message Format
+
+We follow the [Conventional Commits](https://www.conventionalcommits.org/) specification for PR titles and commit messages. This helps us maintain a clear project history and enables automated tooling.
+
+**Format:** `type: subject`
+
+- **type**: The type of change (required)  
+- **subject**: Brief description of the change (required, max 50 characters)
+
+**Valid types:**
+- `feat`: New features
+- `fix`: Bug fixes
+- `docs`: Documentation changes
+- `test`: Adding or updating tests
+- `refactor`: Code refactoring without functional changes
+- `perf`: Performance improvements
+- `style`: Code style/formatting changes
+- `chore`: Maintenance tasks
+- `ci`: CI/CD changes
+- `build`: Build system changes
+- `deps`: Dependency updates
+
+**Examples:**
+```
+feat: add retry mechanism for operations
+fix: resolve memory leak in execution state
+docs: update API documentation for context
+test: add integration tests for parallel exec
+feat(sdk): implement new callback functionality
+fix(examples): correct timeout handling
+```
+
+**Requirements:**
+- Subject line must be 50 characters or less
+- Body text should wrap at 72 characters for good terminal display
+- Use lowercase for type and scope
+- Use imperative mood in subject ("add" not "added" or "adds")
+- No period at the end of the subject line
+- Use conventional commit message format with clear, concise descriptions
+- Body should provide detailed explanation of changes with bullet points when helpful
+
+**Full commit message example:**
+```
+feat: add retry mechanism for operations
+
+- Implement exponential backoff strategy for transient failures
+- Add configurable retry limits and timeout settings
+- Include comprehensive error logging for debugging
+- Update documentation with retry configuration examples
+
+Resolves issue with intermittent network failures causing
+execution interruptions in production environments.
+```
+
+The PR title will be used as the commit message when your PR is merged, so please ensure it follows this format.
+
 GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
 [creating a pull request](https://help.github.com/articles/creating-a-pull-request/).
 


### PR DESCRIPTION
- Add a CODEOWNERS file.
- Amend conventional commits CI validation for shorter line lengths on subject and remove type(scope): subject the scope requirement.
- Amend CONTRIBUTING guide with details and examples of conventional commits

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
