### PR TITLE
feat: add BatchResult serialization support

### DIFF
--- a/src/aws_durable_execution_sdk_python/operation/parallel.py
+++ b/src/aws_durable_execution_sdk_python/operation/parallel.py
@@ -12,12 +12,11 @@ from aws_durable_execution_sdk_python.config import ParallelConfig
 from aws_durable_execution_sdk_python.lambda_service import OperationSubType
 
 if TYPE_CHECKING:
-    from aws_durable_execution_sdk_python.concurrency import BatchResult
     from aws_durable_execution_sdk_python.context import DurableContext
     from aws_durable_execution_sdk_python.identifier import OperationIdentifier
     from aws_durable_execution_sdk_python.serdes import SerDes
     from aws_durable_execution_sdk_python.state import ExecutionState
-    from aws_durable_execution_sdk_python.types import SummaryGenerator
+    from aws_durable_execution_sdk_python.types import BatchResult, SummaryGenerator
 
 logger = logging.getLogger(__name__)
 

--- a/tests/operation/map_test.py
+++ b/tests/operation/map_test.py
@@ -1,17 +1,12 @@
 """Tests for map operation."""
 
+import json
 from unittest.mock import Mock, patch
 
 import pytest
 
 # Mock the executor.execute method
-from aws_durable_execution_sdk_python.concurrency import (
-    BatchItem,
-    BatchItemStatus,
-    BatchResult,
-    CompletionReason,
-    Executable,
-)
+from aws_durable_execution_sdk_python.concurrency import Executable
 from aws_durable_execution_sdk_python.config import (
     CompletionConfig,
     ItemBatcher,
@@ -21,6 +16,12 @@ from aws_durable_execution_sdk_python.context import DurableContext
 from aws_durable_execution_sdk_python.identifier import OperationIdentifier
 from aws_durable_execution_sdk_python.lambda_service import OperationSubType
 from aws_durable_execution_sdk_python.operation.map import MapExecutor, map_handler
+from aws_durable_execution_sdk_python.types import (
+    BatchItem,
+    BatchItemStatus,
+    BatchResult,
+    CompletionReason,
+)
 from tests.serdes_test import CustomStrSerDes
 
 
@@ -753,6 +754,48 @@ def test_map_handler_first_execution_then_replay_integration():
         # Verify replay was called, execute was not
         mock_replay.assert_called_once()
         mock_execute.assert_not_called()
+
+
+def test_map_result_serialization_roundtrip():
+    """Test that map operation BatchResult can be serialized and deserialized."""
+
+    items = ["a", "b", "c"]
+
+    def func(ctx, item, idx, items):
+        return {"item": item.upper(), "index": idx}
+
+    class MockExecutionState:
+        durable_execution_arn = "arn:test"
+
+        def get_checkpoint_result(self, operation_id):
+            mock_result = Mock()
+            mock_result.is_succeeded.return_value = False
+            return mock_result
+
+    execution_state = MockExecutionState()
+    map_context = Mock()
+    map_context._create_step_id_for_logical_step = Mock(side_effect=["1", "2", "3"])  # noqa SLF001
+    map_context.create_child_context = Mock(return_value=Mock())
+    operation_identifier = OperationIdentifier("test_op", "parent", "test_map")
+
+    # Execute map
+    result = map_handler(
+        items, func, MapConfig(), execution_state, map_context, operation_identifier
+    )
+
+    # Serialize the BatchResult
+    serialized = json.dumps(result.to_dict())
+
+    # Deserialize
+    deserialized = BatchResult.from_dict(json.loads(serialized))
+
+    # Verify all data preserved
+    assert len(deserialized.all) == 3
+    assert deserialized.all[0].result == {"item": "A", "index": 0}
+    assert deserialized.all[1].result == {"item": "B", "index": 1}
+    assert deserialized.all[2].result == {"item": "C", "index": 2}
+    assert deserialized.completion_reason == result.completion_reason
+    assert all(item.status == BatchItemStatus.SUCCEEDED for item in deserialized.all)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
*Issue #, if available:*

- Add BatchResult serialization/deserialization support
- Fix is_complete() logic in ExecutionCounters

> The Issue with current logic:
> For 5 tasks,
> 1. When `tolerated_failure_count=2`, but `min_successful` is NOT explicitly set, the code defaults `min_successful` to `len(executables)` (5 tasks)
> 2. With 3 successes and 2 failures (expected) (all 5 tasks completed), the completion check fails:
>    - `tolerated_failure_count is None` → False (we have tolerance set)
>    - `failure_count == 0` → False (we have 2 failures)
>    - `success_count >= min_successful` → `3 >= 5` → False ❌
> 3. Result: `is_complete()` returned False even though all tasks were done, causing an infinite wait



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
