### PR TITLE
feat(sdk): add package-level common exports

### DIFF
--- a/src/aws_durable_execution_sdk_python/__init__.py
+++ b/src/aws_durable_execution_sdk_python/__init__.py
@@ -11,7 +11,7 @@ from aws_durable_execution_sdk_python.context import (
 # Most common exceptions - users need to handle these exceptions
 from aws_durable_execution_sdk_python.exceptions import (
     DurableExecutionsError,
-    DurableOperationError,
+    InvocationError,
     ValidationError,
 )
 
@@ -25,7 +25,7 @@ __all__ = [
     "BatchResult",
     "DurableContext",
     "DurableExecutionsError",
-    "DurableOperationError",
+    "InvocationError",
     "StepContext",
     "ValidationError",
     "durable_execution",


### PR DESCRIPTION
Closes #121 

### Description of changes

Adds flattened convenience imports at the package level for the most commonly used items in the AWS Durable Execution SDK.

### Changes
- Added top-level exports in `src/aws_durable_execution_sdk_python/__init__.py`
- Exports core decorator, context, helper decorators, essential types, and common exceptions
- Enables simpler imports for SDK consumers

### Usage example

```py
from aws_durable_execution_sdk_python import (
    durable_execution,
    DurableContext,
    durable_step,
    ValidationError,
)

@durable_execution
def my_durable_function(context: DurableContext):
    try:
        result = context.step(my_step_function)
        return result
    except ValidationError as e:
        print(f"Validation error: {e}")

@durable_step
def my_step_function():
    return "step result"
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
