### PR TITLE
fix: concurrent execuion completion logic

### DIFF
--- a/src/aws_durable_execution_sdk_python/concurrency/executor.py
+++ b/src/aws_durable_execution_sdk_python/concurrency/executor.py
@@ -154,7 +154,8 @@ class ConcurrentExecutor(ABC, Generic[CallableType, ResultType]):
         self._suspend_exception: SuspendExecution | None = None
 
         # ExecutionCounters will keep track of completion criteria and on-going counters
-        min_successful = self.completion_config.min_successful or len(self.executables)
+        # Pass None if min_successful not explicitly set to distinguish from "require all"
+        min_successful = self.completion_config.min_successful
         tolerated_failure_count = self.completion_config.tolerated_failure_count
         tolerated_failure_percentage = (
             self.completion_config.tolerated_failure_percentage


### PR DESCRIPTION
*Issue #, if available:*

- Fix is_complete() logic:
> The Issue with current logic:
> For 5 tasks,
> 1. When `tolerated_failure_count=2`, but `min_successful` is NOT explicitly set, the code defaults `min_successful` to `len(executables)` (5 tasks)
> 2. With 3 successes and 2 failures (expected) (all 5 tasks completed), the completion check fails:
>    - `tolerated_failure_count is None` → False (we have tolerance set)
>    - `failure_count == 0` → False (we have 2 failures)
>    - `success_count >= min_successful` → `3 >= 5` → False ❌
> 3. Result: `is_complete()` returned False even though all tasks were done, causing an infinite wait


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
