### PR TITLE
docs(sdk): add callback page

### DIFF
--- a/docs/core/callbacks.md
+++ b/docs/core/callbacks.md
@@ -727,7 +727,7 @@ A: No, you can create a callback, send its ID to an external system, perform oth
 
 **Q: Can callbacks be used with steps?**
 
-A: Yes, you can create and wait for callbacks inside step functions. This is useful for combining retry logic with callback operations.
+A: Yes, you can create and wait for callbacks inside step functions. However, `context.wait_for_callback()` is a convenience method that already wraps the callback in a step with retry logic for you.
 
 **Q: What happens if the external system sends a result after the timeout?**
 


### PR DESCRIPTION
closes #153 

### Description of changes:

This PR adds `docs/core/callbacks.md` documentation for callback operations. The guide explains how to use `context.create_callback()` to integrate with external systems, how to configure timeouts with `CallbackConfig`, and how to wait for responses with `context.wait_for_callback()`. It includes integration patterns showing how to pass `callback.callback_id` to external systems, best practices for timeout configuration, and a testing section showing how to verify callback operations in tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
