### PR TITLE
fix: fix callback serdes

### DIFF
--- a/src/aws_durable_execution_sdk_python/context.py
+++ b/src/aws_durable_execution_sdk_python/context.py
@@ -36,7 +36,11 @@ from aws_durable_execution_sdk_python.operation.wait import wait_handler
 from aws_durable_execution_sdk_python.operation.wait_for_condition import (
     wait_for_condition_handler,
 )
-from aws_durable_execution_sdk_python.serdes import SerDes, deserialize
+from aws_durable_execution_sdk_python.serdes import (
+    PassThroughSerDes,
+    SerDes,
+    deserialize,
+)
 from aws_durable_execution_sdk_python.state import ExecutionState  # noqa: TCH001
 from aws_durable_execution_sdk_python.threading import OrderedCounter
 from aws_durable_execution_sdk_python.types import (
@@ -65,6 +69,8 @@ Params = ParamSpec("Params")
 
 
 logger = logging.getLogger(__name__)
+
+PASS_THROUGH_SERDES: SerDes[Any] = PassThroughSerDes()
 
 
 def durable_step(
@@ -144,7 +150,7 @@ class Callback(Generic[T], CallbackProtocol[T]):  # noqa: PYI059
                 return None  # type: ignore
 
             return deserialize(
-                serdes=self.serdes,
+                serdes=self.serdes if self.serdes is not None else PASS_THROUGH_SERDES,
                 data=checkpointed_result.result,
                 operation_id=self.operation_id,
                 durable_execution_arn=self.state.durable_execution_arn,

--- a/src/aws_durable_execution_sdk_python/serdes.py
+++ b/src/aws_durable_execution_sdk_python/serdes.py
@@ -372,6 +372,14 @@ class SerDes(ABC, Generic[T]):
         return False
 
 
+class PassThroughSerDes(SerDes[T]):
+    def serialize(self, value: T, _: SerDesContext) -> str:  # noqa: PLR6301
+        return value  # type: ignore
+
+    def deserialize(self, data: str, _: SerDesContext) -> T:  # noqa: PLR6301
+        return data  # type: ignore
+
+
 class JsonSerDes(SerDes[T]):
     def serialize(self, value: T, _: SerDesContext) -> str:  # noqa: PLR6301
         return json.dumps(value)

--- a/tests/context_test.py
+++ b/tests/context_test.py
@@ -75,6 +75,28 @@ def test_callback_result_succeeded():
     callback = Callback("callback1", "op1", mock_state)
     result = callback.result()
 
+    assert result == '"success_result"'
+    mock_state.get_checkpoint_result.assert_called_once_with("op1")
+
+
+def test_callback_result_succeeded_with_plain_str():
+    """Test Callback.result() when operation succeeded."""
+    mock_state = Mock(spec=ExecutionState)
+    mock_state.durable_execution_arn = "test_arn"
+    operation = Operation(
+        operation_id="op1",
+        operation_type=OperationType.CALLBACK,
+        status=OperationStatus.SUCCEEDED,
+        callback_details=CallbackDetails(
+            callback_id="callback1", result="success_result"
+        ),
+    )
+    mock_result = CheckpointedResult.create_from_operation(operation)
+    mock_state.get_checkpoint_result.return_value = mock_result
+
+    callback = Callback("callback1", "op1", mock_state)
+    result = callback.result()
+
     assert result == "success_result"
     mock_state.get_checkpoint_result.assert_called_once_with("op1")
 

--- a/tests/serdes_test.py
+++ b/tests/serdes_test.py
@@ -28,6 +28,7 @@ from aws_durable_execution_sdk_python.serdes import (
     EncodedValue,
     ExtendedTypeSerDes,
     JsonSerDes,
+    PassThroughSerDes,
     PrimitiveCodec,
     SerDes,
     SerDesContext,
@@ -735,6 +736,18 @@ def test_extended_serdes_errors():
 
 
 # endregion
+
+
+def test_pass_through_serdes():
+    serdes = PassThroughSerDes()
+
+    data = '"name": "test", "value": 123'
+    serialized = serialize(serdes, data, "test-op", "test-arn")
+    assert isinstance(serialized, str)
+    assert serialized == '"name": "test", "value": 123'
+    # Dict uses envelope format, so roundtrip through deserialize
+    deserialized = deserialize(serdes, serialized, "test-op", "test-arn")
+    assert deserialized == data
 
 
 # region EnvelopeSerDes Performance and Edge Cases


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*

- Add a new passthrough serdes
- If the customer does not provide customized serdes for callback handler, use passthrough serdes for callback result because they are not created by sdk, instead, they are created by backend with customer data.
- TS ref: https://github.com/aws/aws-durable-execution-sdk-js/blob/development/packages/aws-durable-execution-sdk-js/src/handlers/callback-handler/callback.ts#L178
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
