### PR TITLE
refactor(sdk): make sure the input is a durable input

### DIFF
--- a/src/aws_durable_execution_sdk_python/execution.py
+++ b/src/aws_durable_execution_sdk_python/execution.py
@@ -224,11 +224,10 @@ def durable_execution(
                 invocation_input = DurableExecutionInvocationInput.from_dict(event)
             except (KeyError, TypeError, AttributeError) as e:
                 msg = (
-                    "The function is not being invoked as a durable function. "
-                    "Please check the function configuration to ensure durability is turned on, "
-                    "or use the testing SDK for local testing."
+                    "The payload is not the correct Durable Function input. "
+                    "Please set DurableConfig on the AWS Lambda to invoke it as a Durable Function."
                 )
-                raise ValueError(msg) from e
+                raise ExecutionError(msg) from e
 
             # Local runner always uses its own client, otherwise use custom or default
             if invocation_input.is_local_runner:

--- a/tests/execution_test.py
+++ b/tests/execution_test.py
@@ -2036,8 +2036,8 @@ def test_durable_execution_with_non_durable_payload_raises_error():
     # WHEN the handler is invoked with a non-durable payload
     # THEN it raises a ValueError with a helpful message
     with pytest.raises(
-        ValueError,
-        match="The function is not being invoked as a durable function",
+        ExecutionError,
+        match="The payload is not the correct Durable Function input",
     ):
         test_handler(regular_event, lambda_context)
 
@@ -2064,7 +2064,7 @@ def test_durable_execution_with_non_dict_event_raises_error():
     # WHEN the handler is invoked with a non-dict event
     # THEN it raises a ValueError with a helpful message
     with pytest.raises(
-        ValueError,
-        match="The function is not being invoked as a durable function",
+        ExecutionError,
+        match="The payload is not the correct Durable Function input",
     ):
         test_handler(non_dict_event, lambda_context)


### PR DESCRIPTION
closes #187 

### Description of changes:

This PR improves the error message when a durable function is invoked with a non-durable payload. Previously, users would see a confusing `KeyError: 'DurableExecutionArn'` that didn't explain the problem or how to fix it.

Now, when the payload conversion fails, the SDK catches the error and provides a message:

```
ValueError: The function is not being invoked as a durable function. Please check the function configuration to ensure durability is turned on, or use the testing SDK for local testing.
```
### Why am I using try/except?

The solution wraps the payload conversion in a try/except block that catches `KeyError`, `TypeError`, and `AttributeError`. I think it is more secure than checking for specific keys in the JSON because:

- It validates the entire payload structure during conversion, not just the presence of specific keys
- It catches any malformed or tampered payloads, including wrong data types and malformed nested structures
- It's resilient against attempts to bypass validation by providing partial payloads with the right keys but wrong values
- It handles edge cases that simple key checking would miss

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
