### PR TITLE
fix: dont fail invocations on throttling exceptions

### DIFF
--- a/src/aws_durable_execution_sdk_python/exceptions.py
+++ b/src/aws_durable_execution_sdk_python/exceptions.py
@@ -11,6 +11,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Self, TypedDict
 
 BAD_REQUEST_ERROR: int = 400
+TOO_MANY_REQUESTS_ERROR: int = 429
 SERVICE_ERROR: int = 500
 
 if TYPE_CHECKING:
@@ -160,10 +161,11 @@ class CheckpointError(BotoClientError):
         status_code: int | None = (metadata and metadata.get("HTTPStatusCode")) or None
         if (
             status_code
-            # if we are in 4xx range and is not an InvalidParameterValueException with Invalid Checkpoint Token
+            # if we are in 4xx range (except 429) and is not an InvalidParameterValueException with Invalid Checkpoint Token
             # then it's an execution error
             and status_code < SERVICE_ERROR
             and status_code >= BAD_REQUEST_ERROR
+            and status_code != TOO_MANY_REQUESTS_ERROR
             and error
             and (
                 # is not InvalidParam => Execution

--- a/tests/exceptions_test.py
+++ b/tests/exceptions_test.py
@@ -83,6 +83,20 @@ def test_checkpoint_error_classification_other_4xx_execution():
     assert result.is_retriable()
 
 
+def test_checkpoint_error_classification_429_invocation():
+    """Test 429 errors are invocation errors (retryable)."""
+    error_response = {
+        "Error": {"Code": "TooManyRequestsException", "Message": "Rate limit exceeded"},
+        "ResponseMetadata": {"HTTPStatusCode": 429},
+    }
+    client_error = ClientError(error_response, "Checkpoint")
+
+    result = CheckpointError.from_exception(client_error)
+
+    assert result.error_category == CheckpointErrorCategory.INVOCATION
+    assert not result.is_retriable()
+
+
 def test_checkpoint_error_classification_invalid_param_without_token_execution():
     """Test 4xx InvalidParameterValueException without Invalid Checkpoint Token is execution error."""
     error_response = {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We shouldn't be failing executions on throttling exceptions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
