### PR TITLE
ci: add pypi-publish workflow

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.11"
       - name: Install Hatch 
         run: |
           python -m pip install --upgrade hatch


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Adding pypi-publish Github Actions Workflow. This was tested originally as part of the squat-name-pypi-branch. It's difficult to merge from that branch since it's a dummy repository. I've included the only required file here. I believe prior to actually creating a release on the main branch, we need to update the version of the package to 1.0.0.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
