### PR TITLE
feat: set ChainInvoke to default to json serdes

### DIFF
--- a/ops/__tests__/test_parse_sdk_branch.py
+++ b/ops/__tests__/test_parse_sdk_branch.py
@@ -73,12 +73,12 @@ TESTING_SDK_BRANCH = second-branch""",
 
     for input_text, expected in test_cases:
         result = parse_sdk_branch(input_text)
-        if result != expected:
-            return False
-
-    return True
+        # Assert is expected in test functions
+        assert result == expected, (  # noqa: S101
+            f"Expected '{expected}' but got '{result}' for input: {input_text[:50]}..."
+        )
 
 
 if __name__ == "__main__":
-    success = test_parse_sdk_branch()
-    sys.exit(0 if success else 1)
+    test_parse_sdk_branch()
+    sys.exit(0)

--- a/src/aws_durable_execution_sdk_python/config.py
+++ b/src/aws_durable_execution_sdk_python/config.py
@@ -392,10 +392,12 @@ class InvokeConfig(Generic[P, R]):
             from blocking execution indefinitely.
 
         serdes_payload: Custom serialization/deserialization for the payload
-            sent to the invoked function. If None, uses default JSON serialization.
+            sent to the invoked function. Defaults to DEFAULT_JSON_SERDES when
+            not set.
 
         serdes_result: Custom serialization/deserialization for the result
-            returned from the invoked function. If None, uses default JSON serialization.
+            returned from the invoked function. Defaults to DEFAULT_JSON_SERDES when
+            not set.
 
         tenant_id: Optional tenant identifier for multi-tenant isolation.
             If provided, the invocation will be scoped to this tenant.

--- a/src/aws_durable_execution_sdk_python/operation/invoke.py
+++ b/src/aws_durable_execution_sdk_python/operation/invoke.py
@@ -11,7 +11,11 @@ from aws_durable_execution_sdk_python.lambda_service import (
     ChainedInvokeOptions,
     OperationUpdate,
 )
-from aws_durable_execution_sdk_python.serdes import deserialize, serialize
+from aws_durable_execution_sdk_python.serdes import (
+    DEFAULT_JSON_SERDES,
+    deserialize,
+    serialize,
+)
 from aws_durable_execution_sdk_python.suspend import suspend_with_optional_resume_delay
 
 if TYPE_CHECKING:
@@ -53,7 +57,7 @@ def invoke_handler(
             and checkpointed_result.operation.chained_invoke_details.result
         ):
             return deserialize(
-                serdes=config.serdes_result,
+                serdes=config.serdes_result or DEFAULT_JSON_SERDES,
                 data=checkpointed_result.operation.chained_invoke_details.result,
                 operation_id=operation_identifier.operation_id,
                 durable_execution_arn=state.durable_execution_arn,
@@ -78,7 +82,7 @@ def invoke_handler(
         suspend_with_optional_resume_delay(msg, config.timeout_seconds)
 
     serialized_payload: str = serialize(
-        serdes=config.serdes_payload,
+        serdes=config.serdes_payload or DEFAULT_JSON_SERDES,
         value=payload,
         operation_id=operation_identifier.operation_id,
         durable_execution_arn=state.durable_execution_arn,

--- a/src/aws_durable_execution_sdk_python/serdes.py
+++ b/src/aws_durable_execution_sdk_python/serdes.py
@@ -441,8 +441,8 @@ class ExtendedTypeSerDes(SerDes[T]):
                 return obj
 
 
-_DEFAULT_JSON_SERDES: SerDes[Any] = JsonSerDes()
-_EXTENDED_TYPES_SERDES: SerDes[Any] = ExtendedTypeSerDes()
+DEFAULT_JSON_SERDES: SerDes[Any] = JsonSerDes()
+EXTENDED_TYPES_SERDES: SerDes[Any] = ExtendedTypeSerDes()
 
 
 def serialize(
@@ -463,7 +463,7 @@ def serialize(
         FatalError: If serialization fails
     """
     serdes_context: SerDesContext = SerDesContext(operation_id, durable_execution_arn)
-    active_serdes: SerDes[T] = serdes or _EXTENDED_TYPES_SERDES
+    active_serdes: SerDes[T] = serdes or EXTENDED_TYPES_SERDES
     try:
         return active_serdes.serialize(value, serdes_context)
     except Exception as e:
@@ -493,7 +493,7 @@ def deserialize(
         FatalError: If deserialization fails
     """
     serdes_context: SerDesContext = SerDesContext(operation_id, durable_execution_arn)
-    active_serdes: SerDes[T] = serdes or _EXTENDED_TYPES_SERDES
+    active_serdes: SerDes[T] = serdes or EXTENDED_TYPES_SERDES
     try:
         return active_serdes.deserialize(data, serdes_context)
     except Exception as e:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. set ChainInvoke to default to json serdes
2. make Json and Extended serializer convenience singletons pubiic
3. Minor linter warning fix for ops/__tests__/test_parse_sdk_branch.py

Aligns w TS here: https://github.com/aws/aws-durable-execution-sdk-js/blob/main/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.ts#L102

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
