### PR TITLE
feat: cherry-pick add WaitForCallbackContext to submitter 

### DIFF
--- a/src/aws_durable_execution_sdk_python/context.py
+++ b/src/aws_durable_execution_sdk_python/context.py
@@ -47,6 +47,7 @@ from aws_durable_execution_sdk_python.types import (
     BatchResult,
     LoggerInterface,
     StepContext,
+    WaitForCallbackContext,
     WaitForConditionCheckContext,
 )
 from aws_durable_execution_sdk_python.types import Callback as CallbackProtocol
@@ -489,7 +490,7 @@ class DurableContext(DurableContextProtocol):
 
     def wait_for_callback(
         self,
-        submitter: Callable[[str], None],
+        submitter: Callable[[str, WaitForCallbackContext], None],
         name: str | None = None,
         config: WaitForCallbackConfig | None = None,
     ) -> Any:

--- a/src/aws_durable_execution_sdk_python/operation/callback.py
+++ b/src/aws_durable_execution_sdk_python/operation/callback.py
@@ -10,6 +10,7 @@ from aws_durable_execution_sdk_python.lambda_service import (
     CallbackOptions,
     OperationUpdate,
 )
+from aws_durable_execution_sdk_python.types import WaitForCallbackContext
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -23,7 +24,11 @@ if TYPE_CHECKING:
         CheckpointedResult,
         ExecutionState,
     )
-    from aws_durable_execution_sdk_python.types import Callback, DurableContext
+    from aws_durable_execution_sdk_python.types import (
+        Callback,
+        DurableContext,
+        StepContext,
+    )
 
 
 def create_callback_handler(
@@ -85,7 +90,7 @@ def create_callback_handler(
 
 def wait_for_callback_handler(
     context: DurableContext,
-    submitter: Callable[[str], None],
+    submitter: Callable[[str, WaitForCallbackContext], None],
     name: str | None = None,
     config: WaitForCallbackConfig | None = None,
 ) -> Any:
@@ -98,8 +103,10 @@ def wait_for_callback_handler(
         name=f"{name_with_space}create callback id", config=config
     )
 
-    def submitter_step(step_context):  # noqa: ARG001
-        return submitter(callback.callback_id)
+    def submitter_step(step_context: StepContext):
+        return submitter(
+            callback.callback_id, WaitForCallbackContext(logger=step_context.logger)
+        )
 
     step_config = (
         StepConfig(

--- a/src/aws_durable_execution_sdk_python/types.py
+++ b/src/aws_durable_execution_sdk_python/types.py
@@ -58,6 +58,11 @@ class StepContext(OperationContext):
 
 
 @dataclass(frozen=True)
+class WaitForCallbackContext(OperationContext):
+    """Context provided to waitForCallback submitter functions."""
+
+
+@dataclass(frozen=True)
 class WaitForConditionCheckContext(OperationContext):
     pass
 


### PR DESCRIPTION
*Description of changes:*
Cherry-picked single commit for WaitForCallback submitter signature change, with the hatch CI runtime pinned to avoid unrelated hatch formatting/linting errors.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
