### PR TITLE
feat: add durable_wait_for_callback decorator

### DIFF
--- a/src/aws_durable_execution_sdk_python/__init__.py
+++ b/src/aws_durable_execution_sdk_python/__init__.py
@@ -5,6 +5,7 @@
 from aws_durable_execution_sdk_python.context import (
     DurableContext,
     durable_step,
+    durable_wait_for_callback,
     durable_with_child_context,
 )
 
@@ -30,5 +31,6 @@ __all__ = [
     "ValidationError",
     "durable_execution",
     "durable_step",
+    "durable_wait_for_callback",
     "durable_with_child_context",
 ]


### PR DESCRIPTION

*Description of changes:*

Add a new decorator that enables cleaner API for wait_for_callback operations by allowing submitter functions to accept additional parameters that are bound at call time.

The decorator wraps callables that take callback_id, context, and additional parameters, returning a function that binds those extra parameters and produces a submitter compatible with wait_for_callback.

Changes:
* Add durable_wait_for_callback decorator to context module
* Export decorator from package __init__ for public API
* Add integration test validating parameter binding and name propagation
* Verify operation names are correctly set on STEP and CALLBACK operations

Example usage:
  @durable_wait_for_callback def submit_task(callback_id, context, task_name, priority): external_api.submit(task_name, priority, callback_id)

  result = context.wait_for_callback(submit_task(my_task, priority=5))



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
