### PR TITLE
fix: use CallbackError for non-successful callback

### DIFF
--- a/src/aws_durable_execution_sdk_python/context.py
+++ b/src/aws_durable_execution_sdk_python/context.py
@@ -182,7 +182,7 @@ class Callback(Generic[T], CallbackProtocol[T]):  # noqa: PYI059
 
         if not checkpointed_result.is_existent():
             msg = "Callback operation must exist"
-            raise CallbackError(msg)
+            raise CallbackError(message=msg, callback_id=self.callback_id)
 
         if (
             checkpointed_result.is_failed()
@@ -190,7 +190,12 @@ class Callback(Generic[T], CallbackProtocol[T]):  # noqa: PYI059
             or checkpointed_result.is_timed_out()
             or checkpointed_result.is_stopped()
         ):
-            checkpointed_result.raise_callable_error()
+            msg = (
+                checkpointed_result.error.message
+                if checkpointed_result.error and checkpointed_result.error.message
+                else "Callback failed"
+            )
+            raise CallbackError(message=msg, callback_id=self.callback_id)
 
         if checkpointed_result.is_succeeded():
             if checkpointed_result.result is None:

--- a/tests/context_test.py
+++ b/tests/context_test.py
@@ -18,7 +18,6 @@ from aws_durable_execution_sdk_python.config import (
 )
 from aws_durable_execution_sdk_python.context import Callback, DurableContext
 from aws_durable_execution_sdk_python.exceptions import (
-    CallableRuntimeError,
     CallbackError,
     SuspendExecution,
     ValidationError,
@@ -172,7 +171,7 @@ def test_callback_result_failed():
 
     callback = Callback("callback5", "op5", mock_state)
 
-    with pytest.raises(CallableRuntimeError):
+    with pytest.raises(CallbackError):
         callback.result()
 
 
@@ -231,7 +230,7 @@ def test_callback_result_timed_out():
 
     callback = Callback("callback_timeout", "op_timeout", mock_state)
 
-    with pytest.raises(CallableRuntimeError):
+    with pytest.raises(CallbackError):
         callback.result()
 
 


### PR DESCRIPTION
*Issue #, if available:*
close #206 

*Description of changes:*

- TS sdk raises CallbackError for non-successful callbacks, we should match this behaviour.
- https://github.com/aws/aws-durable-execution-sdk-js/blob/main/packages/aws-durable-execution-sdk-js/src/handlers/callback-handler/callback.ts


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
