### PR TITLE
fix: sdist should also contain the src/ folder

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,6 @@ Documentation = "https://github.com/aws/aws-durable-execution-sdk-python#readme"
 Issues = "https://github.com/aws/aws-durable-execution-sdk-python/issues"
 Source = "https://github.com/aws/aws-durable-execution-sdk-python"
 
-[tool.hatch.build.targets.sdist]
-packages = ["src/aws_durable_execution_sdk_python"]
-
 [tool.hatch.build.targets.wheel]
 packages = ["src/aws_durable_execution_sdk_python"]
 


### PR DESCRIPTION
*Issue #, if available:*

The `sdist` package on PyPI cannot currently be installed because the `aws_durable_execution_sdk_python` is placed at the top level, whereas in the source tree, it is located in `src/`. Thus, if you install from the sdist, you don't get an error but an empty installation.

*Description of changes:*

This removes the package configuration for an `sdist`, resulting in the sdist having the same directory layout as the source tree.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
