### PR TITLE
fix: correct ChainedInvokeDetails key in from_dict

### DIFF
--- a/src/aws_durable_execution_sdk_python/lambda_service.py
+++ b/src/aws_durable_execution_sdk_python/lambda_service.py
@@ -749,7 +749,7 @@ class Operation:
             callback_details = CallbackDetails.from_dict(callback_details_input)
 
         chained_invoke_details = None
-        if chained_invoke_details := data.get("chained_invoke_details"):
+        if chained_invoke_details := data.get("ChainedInvokeDetails"):
             chained_invoke_details = ChainedInvokeDetails.from_dict(
                 chained_invoke_details
             )

--- a/tests/lambda_service_test.py
+++ b/tests/lambda_service_test.py
@@ -1481,6 +1481,8 @@ def test_operation_from_dict_complete():
     assert operation.step_details.result == "step_result"
     assert operation.wait_details.scheduled_end_timestamp == start_time
     assert operation.callback_details.callback_id == "cb1"
+    assert operation.chained_invoke_details is not None
+    assert operation.chained_invoke_details.result == "invoke_result"
 
 
 def test_operation_to_dict_with_subtype():


### PR DESCRIPTION
 ## Summary

  - Fix incorrect key name in `Operation.from_dict()` that caused `invoke()` to return `None`
  - Changed key from snake_case `"chained_invoke_details"` to PascalCase `"ChainedInvokeDetails"` to match API response format
  - Added missing assertions in `test_operation_from_dict_complete` to prevent regression

  ## Root Cause

  In `src/aws_durable_execution_sdk_python/lambda_service.py` at line 752, the deserialization method used `"chained_invoke_details"` (snake_case) instead
  of `"ChainedInvokeDetails"` (PascalCase), which is inconsistent with:
  1. Other detail fields that correctly use PascalCase: `"StepDetails"`, `"WaitDetails"`, `"CallbackDetails"`
  2. The corresponding `to_dict()` method which correctly uses `"ChainedInvokeDetails"`
  3. The API response format

  ## Test plan

  - [x] All existing tests pass (924 tests)
  - [x] Coverage maintained at 98.67% (above required 98%)
  - [x] Added assertion to verify `chained_invoke_details` is properly deserialized
  - [x] Linting passes (`ruff check` and `ruff format --check` on changed files)

  Fixes #237