### PR TITLE
feat: add early exit for concurrency

### DIFF
--- a/src/aws_durable_execution_sdk_python/state.py
+++ b/src/aws_durable_execution_sdk_python/state.py
@@ -16,6 +16,7 @@ from aws_durable_execution_sdk_python.exceptions import (
     BackgroundThreadError,
     CallableRuntimeError,
     DurableExecutionsError,
+    OrphanedChildException,
 )
 from aws_durable_execution_sdk_python.lambda_service import (
     CheckpointOutput,
@@ -449,7 +450,13 @@ class ExecutionState:
                         "Rejecting checkpoint for operation %s - parent is done",
                         operation_update.operation_id,
                     )
-                    return
+                    error_msg = (
+                        "Parent context completed, child operation cannot checkpoint"
+                    )
+                    raise OrphanedChildException(
+                        error_msg,
+                        operation_id=operation_update.operation_id,
+                    )
 
         # Check if background checkpointing has failed
         if self._checkpointing_failed.is_set():


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*

- Add OrphanedChildException (BaseException) to terminate orphaned children when parent completes early
- Modify ThreadPoolExecutor to shutdown without waiting (wait=False) when completion criteria met
- Raise exception when orphaned children attempt to checkpoint, preventing subsequent operations from executing
- Update state.py to reject orphaned child checkpoints with exception instead of silent return
- Add comprehensive tests for early exit behavior and orphaned child handling

When min_successful or error threshold is reached in parallel/map operations, the parent now returns immediately without waiting for remaining branches to complete. Orphaned branches are terminated on their next checkpoint attempt, preventing wasted work and ensuring correct semantics for completion criteria.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
