### PR TITLE
refactor: reuse the Lambda client

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,5 +76,4 @@ preview = true
   "PLR6301",
   "SIM117",
   "TRY301",
-  "SLF001",
 ]

--- a/tests/lambda_service_test.py
+++ b/tests/lambda_service_test.py
@@ -47,9 +47,9 @@ from aws_durable_execution_sdk_python.lambda_service import (
 @pytest.fixture
 def reset_lambda_client_cache():
     """Reset the class-level boto3 client cache before and after each test."""
-    LambdaClient._cached_boto_client = None
+    LambdaClient._cached_boto_client = None  # noqa: SLF001
     yield
-    LambdaClient._cached_boto_client = None
+    LambdaClient._cached_boto_client = None  # noqa: SLF001
 
 
 # =============================================================================
@@ -2117,7 +2117,9 @@ def test_lambda_client_cache_is_class_level(
     LambdaClient.initialize_client()
 
     # Verify the boto3 client is cached at class level
-    assert LambdaClient._cached_boto_client is mock_client
+    assert LambdaClient._cached_boto_client is mock_client  # noqa: SLF001
+
+
 # Tests for Operation JSON Serialization Methods
 # =============================================================================
 


### PR DESCRIPTION
closes #249 

*Description of changes:*

This PR refactor the Lambda client creation to reuse the same client when the execution happens in a existing sandbox.

I went with a simple module-level global variable for caching the boto3 client. Lambda sandboxes process one request at a time (and in LMI multi-concurrency) is per process, so there's no real concurrent access to worry about. Adding a lock would just introduce overhead on every call without any practical benefit. In the unlikely event of a race condition, the worst that happens is we create two clients and one gets garbage collected - no corruption or crashes.

Please let me know if this implementation make sense.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
