### PR TITLE
refactor: adding type annotations from mypy stubs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = ["coverage[toml]", "pytest", "pytest-cov"]
 cov = "pytest --cov-report=term-missing --cov-config=pyproject.toml --cov=src/aws_durable_execution_sdk_python --cov-fail-under=98"
 
 [tool.hatch.envs.types]
-extra-dependencies = ["mypy>=1.0.0", "pytest"]
+extra-dependencies = ["mypy>=1.0.0", "pytest", "boto3-stubs[lambda]"]
 [tool.hatch.envs.types.scripts]
 check = "mypy --install-types --non-interactive {args:src/aws_durable_execution_sdk_python tests}"
 

--- a/src/aws_durable_execution_sdk_python/execution.py
+++ b/src/aws_durable_execution_sdk_python/execution.py
@@ -32,7 +32,7 @@ from aws_durable_execution_sdk_python.state import ExecutionState, ReplayStatus
 if TYPE_CHECKING:
     from collections.abc import Callable, MutableMapping
 
-    import boto3  # type: ignore
+    from mypy_boto3_lambda import LambdaClient as Boto3LambdaClient
 
     from aws_durable_execution_sdk_python.types import LambdaContext
 
@@ -237,7 +237,7 @@ class DurableExecutionInvocationOutput:
 def durable_execution(
     func: Callable[[Any, DurableContext], Any] | None = None,
     *,
-    boto3_client: boto3.client | None = None,
+    boto3_client: Boto3LambdaClient | None = None,
 ) -> Callable[[Any, LambdaContext], Any]:
     # Decorator called with parameters
     if func is None:


### PR DESCRIPTION
Closes #255 

*Description of changes:*

I added `boto3-stubs[lambda]` as a dev dependency for type checking. The boto3 client is now typed as `Boto3LambdaClient` and API responses use the proper TypeDefs to make it type safe.

boto3-stubs[lambda] downloads - https://pypistats.org/packages/mypy-boto3-lambda


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
