### PR TITLE
fix: Add TIMED_OUT to terminal states for replay

### DIFF
--- a/src/aws_durable_execution_sdk_python/state.py
+++ b/src/aws_durable_execution_sdk_python/state.py
@@ -314,6 +314,7 @@ class ExecutionState:
                         OperationStatus.FAILED,
                         OperationStatus.CANCELLED,
                         OperationStatus.STOPPED,
+                        OperationStatus.TIMED_OUT,
                     }
                 }
                 if completed_ops.issubset(self._visited_operations):


### PR DESCRIPTION
Closes #262

*Description of changes:*

Added `OperationStatus.TIMED_OUT` to the set of terminal states in `track_replay()`. This ensures logging is correctly enabled after an operation times out during replay.

Also added a test.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
