### PR TITLE
ci: remove version when syncing file

### DIFF
--- a/.github/workflows/sync-package.yml
+++ b/.github/workflows/sync-package.yml
@@ -2,7 +2,7 @@ name: Sync package
 
 on:
   push:
-    branches: [ "main", "ci/remove-sync-version" ]
+    branches: [ "main" ]
 env:
   AWS_REGION : "us-west-2"
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Changes package sync to use fixed filenames (aws-durable-execution-sdk-python.tar.gz and .whl) instead of versioned names. This allows developers to push fixes without manually updating version references in config - the latest build automatically overwrites the previous one.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
