### PR TITLE
fix: convert Unix timestamps in Lambda input

### DIFF
--- a/src/aws_durable_execution_sdk_python/execution.py
+++ b/src/aws_durable_execution_sdk_python/execution.py
@@ -260,7 +260,7 @@ def durable_execution(
                 logger.debug(
                     "durableExecutionArn: %s", event.get("DurableExecutionArn")
                 )
-                invocation_input = DurableExecutionInvocationInput.from_dict(event)
+                invocation_input = DurableExecutionInvocationInput.from_json_dict(event)
             except (KeyError, TypeError, AttributeError) as e:
                 msg = (
                     "Unexpected payload provided to start the durable execution. "


### PR DESCRIPTION
Fix TypeError when parsing Lambda invocation events containing Unix millisecond timestamps. The backend sends timestamps as integers, but the code expected datetime objects for comparison operations.

Note this problem does NOT occur on Checkpoint and Get Execution State, because these benefit from the boto deserializer creating DateTime objects. It only impacts the input to the lambda.

The bug manifested in concurrent execution (map/parallel) when operations had PENDING status with NextAttemptTimestamp. The code attempted to compare the integer timestamp with datetime.now(), causing: TypeError: '<' not supported between instances of 'int' and 'datetime.datetime'

Changed execution.py to use from_json_dict() instead of from_dict() when parsing Lambda events. The from_json_dict() method properly converts Unix millisecond timestamps to datetime objects using TimestampConverter.

Added regression tests covering all timestamp fields:
- StartTimestamp
- EndTimestamp
- StepDetails.NextAttemptTimestamp
- WaitDetails.ScheduledEndTimestamp

The bug only affected Lambda invocations, not unit tests, because tests inject pre-constructed objects that bypass event parsing.

closes #269

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
