### PR TITLE
chore: version 1.1.1 -> 1.1.2

### DIFF
--- a/src/aws_durable_execution_sdk_python/__about__.py
+++ b/src/aws_durable_execution_sdk_python/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2025-present Amazon.com, Inc. or its affiliates.
 #
 # SPDX-License-Identifier: Apache-2.0
-__version__ = "1.1.1"
+__version__ = "1.1.2"


### PR DESCRIPTION
*Description of changes:*
New patch release. Contains:
chore: version 1.1.1 -> 1.1.2
4cf8806 (origin/main, origin/HEAD, main) chore: remove CODEOWNERS
cd818e5 fix: concurrency TypeError on identical resume times
8e762fd fix: convert Unix timestamps in Lambda input
228ae59 docs: add BatchResult to parallel docs
120c97e chore(deps): bump actions-deps
71d71f1 ci: remove version when syncing ci output to s3
ffc5f8e docs: add agents.md
6fbc007 docs: fix parallel description
a52ab08 fix: honor timed_out terminal state
637a1a8 chore(deps): bump the actions-deps group with 2 updates
93a1f53 docs: fix duration format in examples
f835016 refactor: adding proper type annotations
beb8d2f refactor: reuse the Lambda client (#251)
dc76c71 chore(deps): bump the actions-deps group with 3 updates (#243)
2891cd3 docs: refresh readme and fix docs links
ecccefd bump version to 1.1.1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
