### PR TITLE
fix: Import concrete BatchResult

### DIFF
--- a/src/aws_durable_execution_sdk_python/context.py
+++ b/src/aws_durable_execution_sdk_python/context.py
@@ -44,21 +44,21 @@ from aws_durable_execution_sdk_python.serdes import (
 )
 from aws_durable_execution_sdk_python.state import ExecutionState  # noqa: TCH001
 from aws_durable_execution_sdk_python.threading import OrderedCounter
+from aws_durable_execution_sdk_python.types import Callback as CallbackProtocol
 from aws_durable_execution_sdk_python.types import (
-    BatchResult,
+    DurableContext as DurableContextProtocol,
+)
+from aws_durable_execution_sdk_python.types import (
     LoggerInterface,
     StepContext,
     WaitForCallbackContext,
     WaitForConditionCheckContext,
 )
-from aws_durable_execution_sdk_python.types import Callback as CallbackProtocol
-from aws_durable_execution_sdk_python.types import (
-    DurableContext as DurableContextProtocol,
-)
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
 
+    from aws_durable_execution_sdk_python.concurrency.models import BatchResult
     from aws_durable_execution_sdk_python.state import CheckpointedResult
     from aws_durable_execution_sdk_python.types import LambdaContext
     from aws_durable_execution_sdk_python.waits import WaitForConditionConfig


### PR DESCRIPTION
Previously, context.py imported BatchResult from the types module, which only exposed the Protocol interface with the get_results() method. This prevented client-side type checkers and IDEs from discovering the full set of methods available on BatchResult objects returned by map() and parallel() operations.

Changed to import the concrete BatchResult class from concurrency.models, which exposes all available methods including:
- throw_if_error()
- succeeded(), failed(), started()
- has_failure, status properties
- success_count, failure_count, started_count properties
- get_errors()

This improves developer experience by providing accurate type hints and autocomplete for all BatchResult methods without introducing circular dependencies.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
