### PR TITLE
docs: Fix getting started example.

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -168,13 +168,14 @@ pip install aws-durable-execution-sdk-python-testing
 
 ```python
 import pytest
+from aws_durable_execution_sdk_python.execution import InvocationStatus
 from my_function import handler
 
 @pytest.mark.durable_execution(handler=handler, lambda_function_name="my_function")
 def test_my_function(durable_runner):
     with durable_runner:
         result = durable_runner.run(input={"data": "test"}, timeout=10)
-    assert result.status == "SUCCEEDED"
+    assert result.status == InvocationStatus.SUCCEEDED
 ```
 
 Run tests without AWS credentials:


### PR DESCRIPTION
The PR adjust the example test within the getting startet section, which causes an error right now.

Error:
```
Expected :'SUCCEEDED'
Actual   :<InvocationStatus.SUCCEEDED: 'SUCCEEDED'>
```

> The getting startet section also misses the fixture which is required, I wonder if it would make sense to add it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
