### PR TITLE
test: Remove token when pulling repo

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -33,7 +33,6 @@ jobs:
       with:
         repository: aws/aws-durable-execution-sdk-python-testing
         ref: ${{ steps.parse.outputs.testing_ref }}
-        token: ${{ secrets.CROSS_REPO_PAT }}
         path: testing-sdk
 
     - name: Set up Python ${{ matrix.python-version }}
@@ -82,7 +81,6 @@ jobs:
       with:
         repository: aws/aws-durable-execution-sdk-python-testing
         ref: ${{ steps.parse.outputs.testing_ref }}
-        token: ${{ secrets.CROSS_REPO_PAT }}
         path: testing-sdk
 
     - name: Set up Python 3.13


### PR DESCRIPTION
*Issue #, if available:*
n/a


*Description of changes:*
The pull action on `aws/aws-durable-execution-sdk-python-testing` was using an expired personal access token.  Since this repository is now public, no token is needed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
