### PR TITLE
chore: remove unused invoke timeout

### DIFF
--- a/src/aws_durable_execution_sdk_python/config.py
+++ b/src/aws_durable_execution_sdk_python/config.py
@@ -384,13 +384,9 @@ class InvokeConfig(Generic[P, R]):
     Configuration for invoke operations.
 
     This class configures how function invocations are executed, including
-    timeout behavior, serialization, and tenant isolation.
+    serialization and tenant isolation.
 
     Args:
-        timeout: Maximum duration to wait for the invoked function to complete.
-            Default is no timeout. Use this to prevent long-running invocations
-            from blocking execution indefinitely.
-
         serdes_payload: Custom serialization/deserialization for the payload
             sent to the invoked function. Defaults to DEFAULT_JSON_SERDES when
             not set.
@@ -404,15 +400,9 @@ class InvokeConfig(Generic[P, R]):
     """
 
     # retry_strategy: Callable[[Exception, int], RetryDecision] | None = None
-    timeout: Duration = field(default_factory=Duration)
     serdes_payload: SerDes[P] | None = None
     serdes_result: SerDes[R] | None = None
     tenant_id: str | None = None
-
-    @property
-    def timeout_seconds(self) -> int:
-        """Get timeout in seconds."""
-        return self.timeout.to_seconds()
 
 
 @dataclass(frozen=True)

--- a/src/aws_durable_execution_sdk_python/operation/invoke.py
+++ b/src/aws_durable_execution_sdk_python/operation/invoke.py
@@ -166,7 +166,7 @@ class InvokeOperationExecutor(OperationExecutor[R]):
             ExecutionError: If suspend doesn't raise (should never happen)
         """
         msg: str = f"Invoke {self.operation_identifier.operation_id} started, suspending for completion"
-        suspend_with_optional_resume_delay(msg, self.config.timeout_seconds)
+        suspend_with_optional_resume_delay(msg, None)
         # This line should never be reached since suspend_with_optional_resume_delay always raises
         error_msg: str = "suspend_with_optional_resume_delay should have raised an exception, but did not."
         raise ExecutionError(error_msg) from None

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -282,7 +282,6 @@ def test_invoke_config_defaults():
     """Test InvokeConfig defaults."""
     config = InvokeConfig()
     assert config.tenant_id is None
-    assert config.timeout_seconds == 0
 
 
 def test_invoke_config_with_tenant_id():

--- a/tests/context_test.py
+++ b/tests/context_test.py
@@ -616,7 +616,7 @@ def test_invoke_with_name_and_config(mock_executor_class):
     mock_state.durable_execution_arn = (
         "arn:aws:durable:us-east-1:123456789012:execution/test"
     )
-    config = InvokeConfig[str, str](timeout=Duration.from_seconds(30))
+    config = InvokeConfig[str, str]()
 
     context = create_test_context(state=mock_state)
     [context._create_step_id() for _ in range(5)]  # Set counter to 5 # noqa: SLF001
@@ -756,7 +756,6 @@ def test_invoke_with_custom_serdes(mock_executor_class):
     config = InvokeConfig[dict, dict](
         serdes_payload=payload_serdes,
         serdes_result=result_serdes,
-        timeout=Duration.from_minutes(1),
     )
 
     context = create_test_context(state=mock_state)

--- a/tests/operation/invoke_test.py
+++ b/tests/operation/invoke_test.py
@@ -219,9 +219,9 @@ def test_invoke_handler_already_started_with_timeout(status):
     mock_result = CheckpointedResult.create_from_operation(operation)
     mock_state.get_checkpoint_result.return_value = mock_result
 
-    config = InvokeConfig[str, str](timeout=Duration.from_seconds(30))
+    config = InvokeConfig[str, str]()
 
-    with pytest.raises(TimedSuspendExecution):
+    with pytest.raises(SuspendExecution):
         invoke_handler(
             function_name="test_function",
             payload="test_input",
@@ -246,7 +246,7 @@ def test_invoke_handler_new_operation():
     started = CheckpointedResult.create_from_operation(started_op)
     mock_state.get_checkpoint_result.side_effect = [not_found, started]
 
-    config = InvokeConfig[str, str](timeout=Duration.from_minutes(1))
+    config = InvokeConfig[str, str]()
 
     with pytest.raises(
         SuspendExecution, match="Invoke invoke8 started, suspending for completion"
@@ -285,9 +285,9 @@ def test_invoke_handler_new_operation_with_timeout():
     started = CheckpointedResult.create_from_operation(started_op)
     mock_state.get_checkpoint_result.side_effect = [not_found, started]
 
-    config = InvokeConfig[str, str](timeout=Duration.from_seconds(30))
+    config = InvokeConfig[str, str]()
 
-    with pytest.raises(TimedSuspendExecution):
+    with pytest.raises(SuspendExecution):
         invoke_handler(
             function_name="test_function",
             payload="test_input",
@@ -311,7 +311,7 @@ def test_invoke_handler_new_operation_no_timeout():
     started = CheckpointedResult.create_from_operation(started_op)
     mock_state.get_checkpoint_result.side_effect = [not_found, started]
 
-    config = InvokeConfig[str, str](timeout=Duration.from_seconds(0))
+    config = InvokeConfig[str, str]()
 
     with pytest.raises(SuspendExecution):
         invoke_handler(
@@ -1026,7 +1026,7 @@ def test_invoke_immediate_response_with_timeout_immediate_success():
     succeeded = CheckpointedResult.create_from_operation(succeeded_op)
     mock_state.get_checkpoint_result.side_effect = [not_found, succeeded]
 
-    config = InvokeConfig[str, str](timeout=Duration.from_seconds(30))
+    config = InvokeConfig[str, str]()
 
     result = invoke_handler(
         function_name="test_function",
@@ -1061,10 +1061,10 @@ def test_invoke_immediate_response_with_timeout_no_immediate_response():
     started = CheckpointedResult.create_from_operation(started_op)
     mock_state.get_checkpoint_result.side_effect = [not_found, started]
 
-    config = InvokeConfig[str, str](timeout=Duration.from_seconds(30))
+    config = InvokeConfig[str, str]()
 
-    # Verify operation suspends with timeout
-    with pytest.raises(TimedSuspendExecution):
+    # Verify operation suspends
+    with pytest.raises(SuspendExecution):
         invoke_handler(
             function_name="test_function",
             payload="test_input",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We realized today that this field on invoke config isn't used for anything, removing it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
