### PR TITLE
feat: expand RetryPresets with fixed, linear, and slow strategies

### DIFF
--- a/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/retries.py
+++ b/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/retries.py
@@ -125,6 +125,34 @@ def create_retry_strategy(
     return retry_strategy
 
 
+def create_linear_retry_strategy(
+    max_attempts: int = 6,
+    initial_delay: Duration | None = None,
+    increment: Duration | None = None,
+) -> Callable[[Exception, int], RetryDecision]:
+    """Linearly increasing delay between retries: initial + increment * (attempts_made - 1).
+
+    Mirrors the JS SDK's ``createLinearRetryStrategy``. With the defaults this
+    yields delays of 1s, 2s, 3s, 4s, 5s. No jitter is applied and there is no
+    upper cap on the delay; callers who need either can build their own
+    strategy via ``create_retry_strategy``.
+    """
+    initial: Duration = (
+        initial_delay if initial_delay is not None else Duration.from_seconds(1)
+    )
+    step: Duration = increment if increment is not None else Duration.from_seconds(1)
+
+    def linear_retry_strategy(_error: Exception, attempts_made: int) -> RetryDecision:
+        if attempts_made >= max_attempts:
+            return RetryDecision.no_retry()
+        delay_seconds: int = initial.to_seconds() + step.to_seconds() * (
+            attempts_made - 1
+        )
+        return RetryDecision.retry(Duration(seconds=delay_seconds))
+
+    return linear_retry_strategy
+
+
 class RetryPresets:
     """Default retry presets."""
 
@@ -176,6 +204,31 @@ class RetryPresets:
                 initial_delay=Duration.from_seconds(1),
                 max_delay=Duration.from_minutes(1),
                 backoff_rate=1.5,
+                jitter_strategy=JitterStrategy.NONE,
+            )
+        )
+
+    @classmethod
+    def linear(cls) -> Callable[[Exception, int], RetryDecision]:
+        """Linearly increasing delay between retries: 1s, 2s, 3s, 4s, 5s."""
+        return create_linear_retry_strategy(
+            max_attempts=6,
+            initial_delay=Duration.from_seconds(1),
+            increment=Duration.from_seconds(1),
+        )
+
+    @classmethod
+    def fixed(
+        cls, interval: Duration | None = None
+    ) -> Callable[[Exception, int], RetryDecision]:
+        """Constant delay between retries (5s by default, no jitter)."""
+        delay: Duration = interval if interval is not None else Duration.from_seconds(5)
+        return create_retry_strategy(
+            RetryStrategyConfig(
+                max_attempts=5,
+                initial_delay=delay,
+                max_delay=delay,
+                backoff_rate=1,
                 jitter_strategy=JitterStrategy.NONE,
             )
         )

--- a/packages/aws-durable-execution-sdk-python/tests/retries_test.py
+++ b/packages/aws-durable-execution-sdk-python/tests/retries_test.py
@@ -11,6 +11,7 @@ from aws_durable_execution_sdk_python.retries import (
     RetryDecision,
     RetryPresets,
     RetryStrategyConfig,
+    create_linear_retry_strategy,
     create_retry_strategy,
 )
 
@@ -571,6 +572,91 @@ def test_mixed_error_types_and_patterns():
     error = ValueError("some value error")
     decision = strategy(error, 1)
     assert decision.should_retry is True
+
+
+# endregion
+
+
+# region create_linear_retry_strategy
+
+
+def test_linear_retry_strategy_uses_additive_formula():
+    """Default config yields delays of 1s, 2s, 3s, 4s, 5s with no jitter."""
+    strategy = create_linear_retry_strategy()
+
+    delays = [
+        strategy(Exception("e"), attempt).delay_seconds for attempt in range(1, 6)
+    ]
+
+    assert delays == [1, 2, 3, 4, 5]
+
+
+def test_linear_retry_strategy_stops_at_max_attempts():
+    """No retry once attempts_made reaches max_attempts."""
+    strategy = create_linear_retry_strategy(max_attempts=3)
+
+    assert strategy(Exception("e"), 1).should_retry is True
+    assert strategy(Exception("e"), 2).should_retry is True
+    assert strategy(Exception("e"), 3).should_retry is False
+
+
+def test_linear_retry_strategy_respects_custom_initial_and_increment():
+    """Custom initial_delay and increment shift the additive sequence."""
+    strategy = create_linear_retry_strategy(
+        max_attempts=10,
+        initial_delay=Duration.from_seconds(2),
+        increment=Duration.from_seconds(3),
+    )
+
+    delays = [
+        strategy(Exception("e"), attempt).delay_seconds for attempt in range(1, 5)
+    ]
+
+    # 2 + 3*0, 2 + 3*1, 2 + 3*2, 2 + 3*3
+    assert delays == [2, 5, 8, 11]
+
+
+# endregion
+
+
+# region RetryPresets.linear / RetryPresets.fixed
+
+
+def test_retry_presets_linear_matches_js_defaults():
+    """RetryPresets.linear() yields 1s, 2s, 3s, 4s, 5s and stops after 6 attempts."""
+    strategy = RetryPresets.linear()
+
+    delays = [
+        strategy(Exception("e"), attempt).delay_seconds for attempt in range(1, 6)
+    ]
+    assert delays == [1, 2, 3, 4, 5]
+    assert strategy(Exception("e"), 6).should_retry is False
+
+
+def test_retry_presets_fixed_uses_default_interval():
+    """RetryPresets.fixed() defaults to a 5s constant delay with no jitter."""
+    strategy = RetryPresets.fixed()
+
+    for attempt in range(1, 5):
+        decision = strategy(Exception("e"), attempt)
+        assert decision.should_retry is True
+        assert decision.delay_seconds == 5
+
+
+def test_retry_presets_fixed_respects_custom_interval():
+    """A caller-supplied interval is used as the constant delay."""
+    strategy = RetryPresets.fixed(interval=Duration.from_seconds(12))
+
+    assert strategy(Exception("e"), 1).delay_seconds == 12
+    assert strategy(Exception("e"), 3).delay_seconds == 12
+
+
+def test_retry_presets_fixed_stops_at_max_attempts():
+    """RetryPresets.fixed() stops retrying after 5 attempts."""
+    strategy = RetryPresets.fixed()
+
+    assert strategy(Exception("e"), 4).should_retry is True
+    assert strategy(Exception("e"), 5).should_retry is False
 
 
 # endregion


### PR DESCRIPTION
Adds linear and fixed retry strategies aligned with the JS SDK, as requested in #328.
                                                                                                                                                                
                                                                                                                                                                
* `create_linear_retry_strategy()`                                                                                                                                                                                                                                                                                
  * Top-level creator mirroring the JS SDK's `createLinearRetryStrategy`.                                                                                       
  * Uses a linearly increasing delay: `initial + increment * (attempts_made - 1)`.                                                                            
  * Defaults to `max_attempts=6` with retry delays of `1s, 2s, 3s, 4s, 5s`.                                                                                     
  * No jitter or `max_delay` cap; callers requiring those behaviors can compose a custom strategy via `create_retry_strategy()`.                              
* `RetryPresets.linear()`                                                                                                                                                                
  * Thin wrapper around `create_linear_retry_strategy()` with JS-aligned defaults.
* `RetryPresets.fixed(interval=None)`                                                                                                                                                                                                                                                                          
  * Uses a constant delay between retries (`5s` by default, no jitter).                                                                                         
  * Useful for polling-style workloads where consistent retry spacing is preferred.                                                                             
                                                                                                                                                                `create_retry_strategy()` continues to provide exponential backoff unchanged, resulting in the same retry-strategy creator shape as the JS SDK.                 
                                                                                                                                                                
## Test Plan                                    
                                                                                                                                                                
* [x] `hatch run dev-core:test` -> 1262 tests pass (0 regressions)                                                                                             
* [x] `hatch fmt --check` -> all lint/format checks pass                                                                                                         
* [x] `hatch run dev-core:typecheck` -> mypy clean, no issues in 63 source files
                                                                                                                                                                
Resolves #328                                                                                                                                                   