### PR TITLE
feat: add sdk name/version to user agent header

### DIFF
--- a/src/aws_durable_execution_sdk_python/lambda_service.py
+++ b/src/aws_durable_execution_sdk_python/lambda_service.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, Protocol, TypeAlias, cast
 import boto3
 from botocore.config import Config
 
+from aws_durable_execution_sdk_python.__about__ import __version__
 from aws_durable_execution_sdk_python.exceptions import (
     CallableRuntimeError,
     CheckpointError,
@@ -1059,6 +1060,7 @@ class LambdaClient(DurableServiceClient):
                 config=Config(
                     connect_timeout=5,
                     read_timeout=50,
+                    user_agent_extra=f"@aws/durable-execution-sdk-python/{__version__}",
                 ),
             )
         return cls(client=cls._cached_boto_client)

--- a/tests/lambda_service_test.py
+++ b/tests/lambda_service_test.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+from aws_durable_execution_sdk_python.__about__ import __version__
 from aws_durable_execution_sdk_python.exceptions import (
     CallableRuntimeError,
     CheckpointError,
@@ -1940,6 +1941,7 @@ def test_lambda_client_initialize_client_default(
     config = call_args[1]["config"]
     assert config.connect_timeout == 5
     assert config.read_timeout == 50
+    assert config.user_agent_extra == f"@aws/durable-execution-sdk-python/{__version__}"
     assert isinstance(client, LambdaClient)
 
 
@@ -1963,6 +1965,7 @@ def test_lambda_client_initialize_client_with_endpoint(
     config = call_args[1]["config"]
     assert config.connect_timeout == 5
     assert config.read_timeout == 50
+    assert config.user_agent_extra == f"@aws/durable-execution-sdk-python/{__version__}"
     assert isinstance(client, LambdaClient)
 
 
@@ -2038,6 +2041,8 @@ def test_lambda_client_initialize_client_no_endpoint(
     call_args = mock_boto_client.call_args
     assert call_args[0] == ("lambda",)
     assert "config" in call_args[1]
+    config = call_args[1]["config"]
+    assert config.user_agent_extra == f"@aws/durable-execution-sdk-python/{__version__}"
     assert isinstance(client, LambdaClient)
 
 


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-durable-execution-sdk-python/issues/300

*Description of changes:*

- Added a `user_agent_extra` field to the default LambdaClient config, to pass the SDK name/version into UserAgent headers.
  - `user_agent_extra` is appended to the existing UserAgent header value ([reference](https://docs.aws.amazon.com/botocore/latest/reference/config.html)).
- Updated LambdaClient initialization tests to verify `user_agent_extra`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
