### PR TITLE
[feature]: add nesting_type to concurrency operations

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -50,7 +50,7 @@ jobs:
       run: |
         echo "Running Testing SDK tests against Language SDK PR changes..."
         echo "Using Language SDK from: $AWS_DURABLE_SDK_URL"
-        python -m pip install -e .
+        hatch run -- test:pip install -e ../language-sdk
         hatch fmt --check
         hatch run types:check
         hatch run test:cov

--- a/src/aws_durable_execution_sdk_python/concurrency/executor.py
+++ b/src/aws_durable_execution_sdk_python/concurrency/executor.py
@@ -20,7 +20,10 @@ from aws_durable_execution_sdk_python.concurrency.models import (
     ExecutionCounters,
     SuspendResult,
 )
-from aws_durable_execution_sdk_python.config import ChildConfig
+from aws_durable_execution_sdk_python.config import (
+    ChildConfig,
+    NestingType,
+)
 from aws_durable_execution_sdk_python.exceptions import (
     OrphanedChildException,
     SuspendExecution,
@@ -134,6 +137,7 @@ class ConcurrentExecutor(ABC, Generic[CallableType, ResultType]):
 
     def __init__(
         self,
+        operation_identifier: OperationIdentifier,
         executables: list[Executable[CallableType]],
         max_concurrency: int | None,
         completion_config: CompletionConfig,
@@ -143,6 +147,7 @@ class ConcurrentExecutor(ABC, Generic[CallableType, ResultType]):
         serdes: SerDes | None,
         item_serdes: SerDes | None = None,
         summary_generator: SummaryGenerator | None = None,
+        nesting_type: NestingType = NestingType.NESTED,
     ):
         """Initialize ConcurrentExecutor.
 
@@ -153,6 +158,7 @@ class ConcurrentExecutor(ABC, Generic[CallableType, ResultType]):
                 handle large BatchResult payloads efficiently. Matches TypeScript behavior in
                 run-in-child-context-handler.ts.
         """
+        self.operation_identifier = operation_identifier
         self.executables = executables
         self.max_concurrency = max_concurrency
         self.completion_config = completion_config
@@ -160,6 +166,7 @@ class ConcurrentExecutor(ABC, Generic[CallableType, ResultType]):
         self.sub_type_iteration = sub_type_iteration
         self.name_prefix = name_prefix
         self.summary_generator = summary_generator
+        self.nesting_type = nesting_type
 
         # Event-driven state tracking for when the executor is done
         self._completion_event = threading.Event()
@@ -406,7 +413,14 @@ class ConcurrentExecutor(ABC, Generic[CallableType, ResultType]):
             executable.index
         )
         name = f"{self.name_prefix}{executable.index}"
-        child_context = executor_context.create_child_context(operation_id)
+        non_virtual_parent_id = (
+            self.operation_identifier.operation_id
+            if self.nesting_type is NestingType.FLAT
+            else None
+        )
+        child_context = executor_context.create_child_context(
+            operation_id, non_virtual_parent_id
+        )
         operation_identifier = OperationIdentifier(
             operation_id,
             executor_context._parent_id,  # noqa: SLF001
@@ -424,6 +438,7 @@ class ConcurrentExecutor(ABC, Generic[CallableType, ResultType]):
                 serdes=self.item_serdes or self.serdes,
                 sub_type=self.sub_type_iteration,
                 summary_generator=self.summary_generator,
+                is_virtual=self.nesting_type is NestingType.FLAT,
             ),
         )
         child_context.state.track_replay(operation_id=operation_id)

--- a/src/aws_durable_execution_sdk_python/config.py
+++ b/src/aws_durable_execution_sdk_python/config.py
@@ -76,6 +76,18 @@ class TerminationMode(Enum):
     ABANDON = "ABANDON"
 
 
+class NestingType(Enum):
+    """
+    How child operations should inherit context from their parent.
+
+    - NESTED: Each child operation runs in its own isolated context
+    - FLAT: All child operations share the same parent context
+    """
+
+    NESTED = "NESTED"
+    FLAT = "FLAT"
+
+
 @dataclass(frozen=True)
 class CompletionConfig:
     """Configuration for determining when parallel/map operations complete.
@@ -187,6 +199,10 @@ class ParallelConfig:
             Used internally by map/parallel operations to handle large BatchResult payloads.
             Signature: (result: T) -> str
 
+        nesting_type: How child operations should inherit context from their parent.
+            - NESTED: Each branch runs in its own isolated context (default)
+            - FLAT: All branches share the same parent context
+
     Example:
         # Run at most 3 branches concurrently, succeed if any one succeeds
         config = ParallelConfig(
@@ -202,6 +218,7 @@ class ParallelConfig:
     serdes: SerDes | None = None
     item_serdes: SerDes | None = None
     summary_generator: SummaryGenerator | None = None
+    nesting_type: NestingType = NestingType.NESTED
 
 
 class StepSemantics(Enum):
@@ -216,12 +233,6 @@ class StepConfig:
     retry_strategy: Callable[[Exception, int], RetryDecision] | None = None
     step_semantics: StepSemantics = StepSemantics.AT_LEAST_ONCE_PER_RETRY
     serdes: SerDes | None = None
-
-
-class CheckpointMode(Enum):
-    NO_CHECKPOINT = ("NO_CHECKPOINT",)
-    CHECKPOINT_AT_FINISH = ("CHECKPOINT_AT_FINISH",)
-    CHECKPOINT_AT_START_AND_FINISH = "CHECKPOINT_AT_START_AND_FINISH"
 
 
 @dataclass(frozen=True)
@@ -259,21 +270,19 @@ class ChildConfig(Generic[T]):
 
             Used internally by map/parallel operations to handle large BatchResult payloads.
             Signature: (result: T) -> str
-    Note:
-        checkpoint_mode field is commented out as it's not currently implemented.
-        When implemented, it will control when checkpoints are created:
-        - CHECKPOINT_AT_START_AND_FINISH: Checkpoint at both start and completion (default)
-        - CHECKPOINT_AT_FINISH: Only checkpoint when operation completes
-        - NO_CHECKPOINT: No automatic checkpointing
+
+        is_virtual: Whether the child operation is virtual (doesn't represent a real operation).
+            Virtual contexts are used for concurrency operations and don't appear in
+            the final execution history. Default is False.
 
     See TypeScript reference: aws-durable-execution-sdk-js/src/types/index.ts
     """
 
-    # checkpoint_mode: CheckpointMode = CheckpointMode.CHECKPOINT_AT_START_AND_FINISH
     serdes: SerDes | None = None
     item_serdes: SerDes | None = None
     sub_type: OperationSubType | None = None
     summary_generator: SummaryGenerator | None = None
+    is_virtual: bool = False
 
 
 class ItemsPerBatchUnit(Enum):
@@ -361,6 +370,10 @@ class MapConfig:
             Used internally by map/parallel operations to handle large BatchResult payloads.
             Signature: (result: T) -> str
 
+        nesting_type: How child operations should inherit context from their parent.
+            - NESTED: Each item runs in its own isolated context (default)
+            - FLAT: All items share the same parent context
+
     Example:
         # Process 5 items at a time, batch by count, require all to succeed
         config = MapConfig(
@@ -376,6 +389,7 @@ class MapConfig:
     serdes: SerDes | None = None
     item_serdes: SerDes | None = None
     summary_generator: SummaryGenerator | None = None
+    nesting_type: NestingType = NestingType.NESTED
 
 
 @dataclass(frozen=True)

--- a/src/aws_durable_execution_sdk_python/context.py
+++ b/src/aws_durable_execution_sdk_python/context.py
@@ -237,12 +237,14 @@ class DurableContext(DurableContextProtocol):
         lambda_context: LambdaContext | None = None,
         parent_id: str | None = None,
         logger: Logger | None = None,
+        non_virtual_parent_id: str | None = None,
     ) -> None:
         self.state: ExecutionState = state
         self.execution_context: ExecutionContext = execution_context
         self.lambda_context = lambda_context
         self._parent_id: str | None = parent_id
         self._step_counter: OrderedCounter = OrderedCounter()
+        self._non_virtual_parent_id = non_virtual_parent_id or parent_id
 
         log_info = LogInfo(
             execution_state=state,
@@ -269,7 +271,9 @@ class DurableContext(DurableContextProtocol):
             parent_id=None,
         )
 
-    def create_child_context(self, parent_id: str) -> DurableContext:
+    def create_child_context(
+        self, parent_id: str, non_virtual_parent_id=None
+    ) -> DurableContext:
         """Create a child context from the given parent."""
         logger.debug("Creating child context for parent %s", parent_id)
         return DurableContext(
@@ -283,6 +287,7 @@ class DurableContext(DurableContextProtocol):
                     parent_id=parent_id,
                 )
             ),
+            non_virtual_parent_id=non_virtual_parent_id,
         )
 
     # endregion factories
@@ -347,7 +352,9 @@ class DurableContext(DurableContextProtocol):
         executor: CallbackOperationExecutor = CallbackOperationExecutor(
             state=self.state,
             operation_identifier=OperationIdentifier(
-                operation_id=operation_id, parent_id=self._parent_id, name=name
+                operation_id=operation_id,
+                parent_id=self._non_virtual_parent_id,
+                name=name,
             ),
             config=config,
         )
@@ -388,7 +395,7 @@ class DurableContext(DurableContextProtocol):
             state=self.state,
             operation_identifier=OperationIdentifier(
                 operation_id=operation_id,
-                parent_id=self._parent_id,
+                parent_id=self._non_virtual_parent_id,
                 name=name,
             ),
             config=config,
@@ -409,7 +416,9 @@ class DurableContext(DurableContextProtocol):
 
         operation_id = self._create_step_id()
         operation_identifier = OperationIdentifier(
-            operation_id=operation_id, parent_id=self._parent_id, name=map_name
+            operation_id=operation_id,
+            parent_id=self._non_virtual_parent_id,
+            name=map_name,
         )
         map_context = self.create_child_context(parent_id=operation_id)
 
@@ -454,7 +463,7 @@ class DurableContext(DurableContextProtocol):
         operation_id = self._create_step_id()
         parallel_context = self.create_child_context(parent_id=operation_id)
         operation_identifier = OperationIdentifier(
-            operation_id=operation_id, parent_id=self._parent_id, name=name
+            operation_id=operation_id, parent_id=self._non_virtual_parent_id, name=name
         )
 
         def parallel_in_child_context() -> BatchResult[T]:
@@ -515,7 +524,9 @@ class DurableContext(DurableContextProtocol):
             func=callable_with_child_context,
             state=self.state,
             operation_identifier=OperationIdentifier(
-                operation_id=operation_id, parent_id=self._parent_id, name=step_name
+                operation_id=operation_id,
+                parent_id=self._non_virtual_parent_id,
+                name=step_name,
             ),
             config=config,
         )
@@ -539,7 +550,7 @@ class DurableContext(DurableContextProtocol):
             state=self.state,
             operation_identifier=OperationIdentifier(
                 operation_id=operation_id,
-                parent_id=self._parent_id,
+                parent_id=self._non_virtual_parent_id,
                 name=step_name,
             ),
             context_logger=self.logger,
@@ -566,7 +577,7 @@ class DurableContext(DurableContextProtocol):
             state=self.state,
             operation_identifier=OperationIdentifier(
                 operation_id=operation_id,
-                parent_id=self._parent_id,
+                parent_id=self._non_virtual_parent_id,
                 name=name,
             ),
         )
@@ -621,7 +632,7 @@ class DurableContext(DurableContextProtocol):
                 state=self.state,
                 operation_identifier=OperationIdentifier(
                     operation_id=operation_id,
-                    parent_id=self._parent_id,
+                    parent_id=self._non_virtual_parent_id,
                     name=name,
                 ),
                 context_logger=self.logger,

--- a/src/aws_durable_execution_sdk_python/operation/child.py
+++ b/src/aws_durable_execution_sdk_python/operation/child.py
@@ -118,7 +118,7 @@ class ChildOperationExecutor(OperationExecutor[T]):
             checkpointed_result.raise_callable_error()
 
         # Create START checkpoint if not exists
-        if not checkpointed_result.is_existent():
+        if not checkpointed_result.is_existent() and not self.config.is_virtual:
             start_operation: OperationUpdate = OperationUpdate.create_context_start(
                 identifier=self.operation_identifier,
                 sub_type=self.sub_type,
@@ -156,6 +156,14 @@ class ChildOperationExecutor(OperationExecutor[T]):
 
         try:
             raw_result: T = self.func()
+
+            if self.config.is_virtual:
+                logger.debug(
+                    "Virtual context: Exiting child context without creating another checkpoint. id: %s, name: %s",
+                    self.operation_identifier.operation_id,
+                    self.operation_identifier.name,
+                )
+                return raw_result
 
             # If in replay_children mode, return without checkpointing
             if checkpointed_result.is_replay_children():
@@ -270,8 +278,7 @@ def child_handler(
     Raises:
         May raise operation-specific errors during execution
     """
-    if not config:
-        config = ChildConfig()
-
-    executor = ChildOperationExecutor(func, state, operation_identifier, config)
+    executor = ChildOperationExecutor(
+        func, state, operation_identifier, config or ChildConfig()
+    )
     return executor.process()

--- a/src/aws_durable_execution_sdk_python/operation/map.py
+++ b/src/aws_durable_execution_sdk_python/operation/map.py
@@ -12,7 +12,7 @@ from aws_durable_execution_sdk_python.concurrency.models import (
     BatchResult,
     Executable,
 )
-from aws_durable_execution_sdk_python.config import MapConfig
+from aws_durable_execution_sdk_python.config import MapConfig, NestingType
 from aws_durable_execution_sdk_python.lambda_service import OperationSubType
 
 if TYPE_CHECKING:
@@ -36,6 +36,7 @@ R = TypeVar("R")
 class MapExecutor(Generic[T, R], ConcurrentExecutor[Callable, R]):  # noqa: PYI059
     def __init__(
         self,
+        operation_identifier: OperationIdentifier,
         executables: list[Executable[Callable]],
         items: Sequence[T],
         max_concurrency: int | None,
@@ -46,8 +47,10 @@ class MapExecutor(Generic[T, R], ConcurrentExecutor[Callable, R]):  # noqa: PYI0
         serdes: SerDes | None,
         summary_generator: SummaryGenerator | None = None,
         item_serdes: SerDes | None = None,
+        nesting_type: NestingType = NestingType.NESTED,
     ):
         super().__init__(
+            operation_identifier=operation_identifier,
             executables=executables,
             max_concurrency=max_concurrency,
             completion_config=completion_config,
@@ -57,12 +60,14 @@ class MapExecutor(Generic[T, R], ConcurrentExecutor[Callable, R]):  # noqa: PYI0
             serdes=serdes,
             summary_generator=summary_generator,
             item_serdes=item_serdes,
+            nesting_type=nesting_type,
         )
         self.items = items
 
     @classmethod
     def from_items(
         cls,
+        operation_identifier: OperationIdentifier,
         items: Sequence[T],
         func: Callable,
         config: MapConfig,
@@ -73,6 +78,7 @@ class MapExecutor(Generic[T, R], ConcurrentExecutor[Callable, R]):  # noqa: PYI0
         ]
 
         return cls(
+            operation_identifier=operation_identifier,
             executables=executables,
             items=items,
             max_concurrency=config.max_concurrency,
@@ -83,6 +89,7 @@ class MapExecutor(Generic[T, R], ConcurrentExecutor[Callable, R]):  # noqa: PYI0
             serdes=config.serdes,
             summary_generator=config.summary_generator,
             item_serdes=config.item_serdes,
+            nesting_type=config.nesting_type,
         )
 
     def execute_item(self, child_context, executable: Executable[Callable]) -> R:
@@ -109,6 +116,7 @@ def map_handler(
     # See TypeScript reference: aws-durable-execution-sdk-js/src/handlers/map-handler/map-handler.ts (~line 79)
 
     executor: MapExecutor[T, R] = MapExecutor.from_items(
+        operation_identifier=operation_identifier,
         items=items,
         func=func,
         config=config or MapConfig(summary_generator=MapSummaryGenerator()),

--- a/src/aws_durable_execution_sdk_python/operation/parallel.py
+++ b/src/aws_durable_execution_sdk_python/operation/parallel.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, TypeVar
 
 from aws_durable_execution_sdk_python.concurrency.executor import ConcurrentExecutor
 from aws_durable_execution_sdk_python.concurrency.models import Executable
-from aws_durable_execution_sdk_python.config import ParallelConfig
+from aws_durable_execution_sdk_python.config import ParallelConfig, NestingType
 from aws_durable_execution_sdk_python.lambda_service import OperationSubType
 
 if TYPE_CHECKING:
@@ -29,6 +29,7 @@ R = TypeVar("R")
 class ParallelExecutor(ConcurrentExecutor[Callable, R]):
     def __init__(
         self,
+        operation_identifier: OperationIdentifier,
         executables: list[Executable[Callable]],
         max_concurrency: int | None,
         completion_config,
@@ -38,8 +39,10 @@ class ParallelExecutor(ConcurrentExecutor[Callable, R]):
         serdes: SerDes | None,
         summary_generator: SummaryGenerator | None = None,
         item_serdes: SerDes | None = None,
+        nesting_type: NestingType = NestingType.NESTED,
     ):
         super().__init__(
+            operation_identifier=operation_identifier,
             executables=executables,
             max_concurrency=max_concurrency,
             completion_config=completion_config,
@@ -49,11 +52,13 @@ class ParallelExecutor(ConcurrentExecutor[Callable, R]):
             serdes=serdes,
             summary_generator=summary_generator,
             item_serdes=item_serdes,
+            nesting_type=nesting_type,
         )
 
     @classmethod
     def from_callables(
         cls,
+        operation_identifier: OperationIdentifier,
         callables: Sequence[Callable],
         config: ParallelConfig,
     ) -> ParallelExecutor:
@@ -62,6 +67,7 @@ class ParallelExecutor(ConcurrentExecutor[Callable, R]):
             Executable(index=i, func=func) for i, func in enumerate(callables)
         ]
         return cls(
+            operation_identifier=operation_identifier,
             executables=executables,
             max_concurrency=config.max_concurrency,
             completion_config=config.completion_config,
@@ -71,6 +77,7 @@ class ParallelExecutor(ConcurrentExecutor[Callable, R]):
             serdes=config.serdes,
             summary_generator=config.summary_generator,
             item_serdes=config.item_serdes,
+            nesting_type=config.nesting_type,
         )
 
     def execute_item(self, child_context, executable: Executable[Callable]) -> R:  # noqa: PLR6301
@@ -95,6 +102,7 @@ def parallel_handler(
     # See TypeScript reference: aws-durable-execution-sdk-js/src/handlers/parallel-handler/parallel-handler.ts (~line 112)
 
     executor = ParallelExecutor.from_callables(
+        operation_identifier,
         callables,
         config or ParallelConfig(summary_generator=ParallelSummaryGenerator()),
     )

--- a/tests/concurrency_test.py
+++ b/tests/concurrency_test.py
@@ -25,15 +25,22 @@ from aws_durable_execution_sdk_python.concurrency.models import (
     ExecutableWithState,
     ExecutionCounters,
 )
-from aws_durable_execution_sdk_python.config import CompletionConfig, MapConfig
+from aws_durable_execution_sdk_python.config import (
+    CompletionConfig,
+    MapConfig,
+    NestingType,
+    ChildConfig,
+)
 from aws_durable_execution_sdk_python.exceptions import (
     CallableRuntimeError,
     InvalidStateError,
     SuspendExecution,
     TimedSuspendExecution,
 )
+from aws_durable_execution_sdk_python.identifier import OperationIdentifier
 from aws_durable_execution_sdk_python.lambda_service import (
     ErrorObject,
+    OperationSubType,
 )
 from aws_durable_execution_sdk_python.operation.map import MapExecutor
 
@@ -853,36 +860,66 @@ def test_batch_result_failed_with_none_error():
     assert failed[0].error is not None
 
 
-def test_concurrent_executor_properties():
-    """Test ConcurrentExecutor basic properties."""
+def test_concurrent_executor_nesting_type_parameter():
+    """Test ConcurrentExecutor nesting_type parameter."""
 
     class TestExecutor(ConcurrentExecutor):
         def execute_item(self, child_context, executable):
             return f"result_{executable.index}"
 
-    executables = [Executable(0, lambda: "test"), Executable(1, lambda: "test2")]
-    completion_config = CompletionConfig(
-        min_successful=1,
-        tolerated_failure_count=None,
-        tolerated_failure_percentage=None,
-    )
-    executor = TestExecutor(
+    executables = [Executable(0, lambda: "test")]
+    completion_config = CompletionConfig(min_successful=1)
+
+    # Test with NESTED (default)
+    executor_nested = TestExecutor(
+        operation_identifier=OperationIdentifier("op-1", "parent-1", "name-1"),
         executables=executables,
-        max_concurrency=2,
+        max_concurrency=1,
+        completion_config=completion_config,
+        sub_type_top="TOP",
+        sub_type_iteration="ITER",
+        name_prefix="test_",
+        serdes=None,
+        nesting_type=NestingType.NESTED,
+    )
+    assert executor_nested.nesting_type is NestingType.NESTED
+
+    # Test with FLAT
+    executor_flat = TestExecutor(
+        operation_identifier=OperationIdentifier("op-1", "parent-1", "name-1"),
+        executables=executables,
+        max_concurrency=1,
+        completion_config=completion_config,
+        sub_type_top="TOP",
+        sub_type_iteration="ITER",
+        name_prefix="test_",
+        serdes=None,
+        nesting_type=NestingType.FLAT,
+    )
+    assert executor_flat.nesting_type is NestingType.FLAT
+
+
+def test_concurrent_executor_default_nesting_type():
+    """Test ConcurrentExecutor uses NESTED as default nesting_type."""
+
+    class TestExecutor(ConcurrentExecutor):
+        def execute_item(self, child_context, executable):
+            return f"result_{executable.index}"
+
+    executables = [Executable(0, lambda: "test")]
+    completion_config = CompletionConfig(min_successful=1)
+
+    executor = TestExecutor(
+        operation_identifier=OperationIdentifier("op-1", "parent-1", "name-1"),
+        executables=executables,
+        max_concurrency=1,
         completion_config=completion_config,
         sub_type_top="TOP",
         sub_type_iteration="ITER",
         name_prefix="test_",
         serdes=None,
     )
-
-    # Test basic properties
-    assert executor.executables == executables
-    assert executor.max_concurrency == 2
-    assert executor.completion_config == completion_config
-    assert executor.sub_type_top == "TOP"
-    assert executor.sub_type_iteration == "ITER"
-    assert executor.name_prefix == "test_"
+    assert executor.nesting_type is NestingType.NESTED
 
 
 def test_concurrent_executor_full_execution_path():
@@ -899,6 +936,7 @@ def test_concurrent_executor_full_execution_path():
         tolerated_failure_percentage=None,
     )
     executor = TestExecutor(
+        operation_identifier=OperationIdentifier("op-1", "parent-1", "name-1"),
         executables=executables,
         max_concurrency=2,
         completion_config=completion_config,
@@ -960,6 +998,7 @@ def test_concurrent_executor_on_task_complete_timed_suspend():
     )
 
     executor = TestExecutor(
+        operation_identifier=OperationIdentifier("op-1", "parent-1", "name-1"),
         executables=executables,
         max_concurrency=1,
         completion_config=completion_config,
@@ -998,6 +1037,7 @@ def test_concurrent_executor_on_task_complete_suspend():
     )
 
     executor = TestExecutor(
+        operation_identifier=OperationIdentifier("op-1", "parent-1", "name-1"),
         executables=executables,
         max_concurrency=1,
         completion_config=completion_config,
@@ -1033,6 +1073,7 @@ def test_concurrent_executor_on_task_complete_exception():
     )
 
     executor = TestExecutor(
+        operation_identifier=OperationIdentifier("op-1", "parent-1", "name-1"),
         executables=executables,
         max_concurrency=1,
         completion_config=completion_config,
@@ -1082,6 +1123,7 @@ def test_concurrent_executor_create_result_with_early_exit():
     )
 
     executor = TestExecutor(
+        operation_identifier=OperationIdentifier("op-1", "parent-1", "name-1"),
         executables=executables,
         max_concurrency=2,
         completion_config=completion_config,
@@ -1123,6 +1165,7 @@ def test_concurrent_executor_execute_item_in_child_context():
     )
 
     executor = TestExecutor(
+        operation_identifier=OperationIdentifier("op-1", "parent-1", "name-1"),
         executables=executables,
         max_concurrency=1,
         completion_config=completion_config,
@@ -1173,6 +1216,7 @@ def test_concurrent_executor_create_result_failure_tolerance_exceeded():
     )
 
     executor = TestExecutor(
+        operation_identifier=OperationIdentifier("op-1", "parent-1", "name-1"),
         executables=executables,
         max_concurrency=1,
         completion_config=completion_config,
@@ -1210,6 +1254,7 @@ def test_single_task_suspend_bubbles_up():
     )
 
     executor = TestExecutor(
+        operation_identifier=OperationIdentifier("op-1", "parent-1", "name-1"),
         executables=executables,
         max_concurrency=1,
         completion_config=completion_config,
@@ -1256,6 +1301,7 @@ def test_multiple_tasks_one_suspends_execution_continues():
     completion_config = CompletionConfig.all_completed()
 
     executor = TestExecutor(
+        operation_identifier=OperationIdentifier("op-1", "parent-1", "name-1"),
         executables=executables,
         max_concurrency=2,
         completion_config=completion_config,
@@ -1301,6 +1347,7 @@ def test_concurrent_executor_with_single_task_resubmit():
     )
 
     executor = TestExecutor(
+        operation_identifier=OperationIdentifier("op-1", "parent-1", "name-1"),
         executables=executables,
         max_concurrency=1,
         completion_config=completion_config,
@@ -1374,6 +1421,7 @@ def test_concurrent_executor_with_timed_resubmit_while_other_task_running():
     )
 
     executor = TestExecutor(
+        operation_identifier=OperationIdentifier("op-1", "parent-1", "name-1"),
         executables=executables,
         max_concurrency=2,
         completion_config=completion_config,
@@ -1438,6 +1486,7 @@ def test_concurrent_executor_should_execution_suspend_with_timeout():
     )
 
     executor = TestExecutor(
+        operation_identifier=OperationIdentifier("op-1", "parent-1", "name-1"),
         executables=executables,
         max_concurrency=1,
         completion_config=completion_config,
@@ -1476,6 +1525,7 @@ def test_concurrent_executor_should_execution_suspend_indefinite():
     )
 
     executor = TestExecutor(
+        operation_identifier=OperationIdentifier("op-1", "parent-1", "name-1"),
         executables=executables,
         max_concurrency=1,
         completion_config=completion_config,
@@ -1517,6 +1567,7 @@ def test_concurrent_executor_create_result_with_failed_status():
     )
 
     executor = TestExecutor(
+        operation_identifier=OperationIdentifier("op-1", "parent-1", "name-1"),
         executables=executables,
         max_concurrency=1,
         completion_config=completion_config,
@@ -1577,6 +1628,7 @@ def test_concurrent_executor_mixed_suspend_states():
     )
 
     executor = TestExecutor(
+        operation_identifier=OperationIdentifier("op-1", "parent-1", "name-1"),
         executables=executables,
         max_concurrency=2,
         completion_config=completion_config,
@@ -1618,6 +1670,7 @@ def test_concurrent_executor_multiple_timed_suspends():
     )
 
     executor = TestExecutor(
+        operation_identifier=OperationIdentifier("op-1", "parent-1", "name-1"),
         executables=executables,
         max_concurrency=2,
         completion_config=completion_config,
@@ -1694,6 +1747,7 @@ def test_should_execution_suspend_earliest_timestamp_comparison():
     )
 
     executor = TestExecutor(
+        operation_identifier=OperationIdentifier("op-1", "parent-1", "name-1"),
         executables=executables,
         max_concurrency=3,
         completion_config=completion_config,
@@ -1742,6 +1796,7 @@ def test_concurrent_executor_execute_with_failing_task():
     )
 
     executor = TestExecutor(
+        operation_identifier=OperationIdentifier("op-1", "parent-1", "name-1"),
         executables=executables,
         max_concurrency=1,
         completion_config=completion_config,
@@ -1804,6 +1859,7 @@ def test_create_result_no_failed_executables():
     )
 
     executor = TestExecutor(
+        operation_identifier=OperationIdentifier("op-1", "parent-1", "name-1"),
         executables=executables,
         max_concurrency=1,
         completion_config=completion_config,
@@ -1846,6 +1902,7 @@ def test_create_result_with_suspended_executable():
     )
 
     executor = TestExecutor(
+        operation_identifier=OperationIdentifier("op-1", "parent-1", "name-1"),
         executables=executables,
         max_concurrency=1,
         completion_config=completion_config,
@@ -1879,6 +1936,7 @@ def test_create_result_completed_branch():
     completion_config = CompletionConfig(min_successful=1)
 
     executor = TestExecutor(
+        operation_identifier=OperationIdentifier("op-1", "parent-1", "name-1"),
         executables=executables,
         max_concurrency=1,
         completion_config=completion_config,
@@ -1913,6 +1971,7 @@ def test_create_result_failed_branch():
     completion_config = CompletionConfig(min_successful=1)
 
     executor = TestExecutor(
+        operation_identifier=OperationIdentifier("op-1", "parent-1", "name-1"),
         executables=executables,
         max_concurrency=1,
         completion_config=completion_config,
@@ -1950,6 +2009,7 @@ def test_create_result_pending_branch():
     completion_config = CompletionConfig(min_successful=1)
 
     executor = TestExecutor(
+        operation_identifier=OperationIdentifier("op-1", "parent-1", "name-1"),
         executables=executables,
         max_concurrency=1,
         completion_config=completion_config,
@@ -1987,6 +2047,7 @@ def test_create_result_running_branch():
     completion_config = CompletionConfig(min_successful=1)
 
     executor = TestExecutor(
+        operation_identifier=OperationIdentifier("op-1", "parent-1", "name-1"),
         executables=executables,
         max_concurrency=1,
         completion_config=completion_config,
@@ -2024,6 +2085,7 @@ def test_create_result_suspended_branch():
     completion_config = CompletionConfig(min_successful=1)
 
     executor = TestExecutor(
+        operation_identifier=OperationIdentifier("op-1", "parent-1", "name-1"),
         executables=executables,
         max_concurrency=1,
         completion_config=completion_config,
@@ -2060,6 +2122,7 @@ def test_create_result_suspended_with_timeout_branch():
     completion_config = CompletionConfig(min_successful=1)
 
     executor = TestExecutor(
+        operation_identifier=OperationIdentifier("op-1", "parent-1", "name-1"),
         executables=executables,
         max_concurrency=1,
         completion_config=completion_config,
@@ -2104,6 +2167,7 @@ def test_create_result_mixed_statuses():
     completion_config = CompletionConfig(min_successful=1)
 
     executor = TestExecutor(
+        operation_identifier=OperationIdentifier("op-1", "parent-1", "name-1"),
         executables=executables,
         max_concurrency=6,
         completion_config=completion_config,
@@ -2190,6 +2254,7 @@ def test_create_result_multiple_completed():
     completion_config = CompletionConfig(min_successful=3)
 
     executor = TestExecutor(
+        operation_identifier=OperationIdentifier("op-1", "parent-1", "name-1"),
         executables=executables,
         max_concurrency=3,
         completion_config=completion_config,
@@ -2232,6 +2297,7 @@ def test_create_result_multiple_failed():
     completion_config = CompletionConfig(min_successful=1)
 
     executor = TestExecutor(
+        operation_identifier=OperationIdentifier("op-1", "parent-1", "name-1"),
         executables=executables,
         max_concurrency=3,
         completion_config=completion_config,
@@ -2275,6 +2341,7 @@ def test_create_result_multiple_started_states():
     completion_config = CompletionConfig(min_successful=1)
 
     executor = TestExecutor(
+        operation_identifier=OperationIdentifier("op-1", "parent-1", "name-1"),
         executables=executables,
         max_concurrency=4,
         completion_config=completion_config,
@@ -2322,6 +2389,7 @@ def test_create_result_empty_executables():
     completion_config = CompletionConfig(min_successful=0)
 
     executor = TestExecutor(
+        operation_identifier=OperationIdentifier("op-1", "parent-1", "name-1"),
         executables=executables,
         max_concurrency=1,
         completion_config=completion_config,
@@ -2474,8 +2542,12 @@ def test_operation_id_determinism_across_shuffles():
     # Track operation_id -> result associations
     captured_associations = []
 
-    def patched_child_handler(func, execution_state, operation_identifier, config):
+    def patched_child_handler(
+        func, execution_state, operation_identifier, config: ChildConfig
+    ):
         """Patched child handler that captures operation_id -> result mapping."""
+        assert config.is_virtual
+        assert config.sub_type == "TEST_ITER"
         result = func()  # Execute the function
         captured_associations.append((operation_identifier.operation_id, result))
         return result
@@ -2497,6 +2569,7 @@ def test_operation_id_determinism_across_shuffles():
         random.shuffle(executables)
 
         executor = TestExecutor(
+            operation_identifier=OperationIdentifier("op-1", "parent-1", "name-1"),
             executables=executables,
             max_concurrency=2,
             completion_config=completion_config,
@@ -2504,6 +2577,7 @@ def test_operation_id_determinism_across_shuffles():
             sub_type_iteration="TEST_ITER",
             name_prefix="test_",
             serdes=None,
+            nesting_type=NestingType.FLAT,
         )
 
         # Create executor context mock
@@ -2515,7 +2589,7 @@ def test_operation_id_determinism_across_shuffles():
 
         executor_context._create_step_id_for_logical_step = create_step_id  # noqa SLF001
 
-        def create_child_context(operation_id):
+        def create_child_context(operation_id, non_virtual_parent_id):
             child_ctx = Mock()
             child_ctx.state = execution_state
             return child_ctx
@@ -2551,6 +2625,7 @@ def test_concurrent_executor_replay_with_succeeded_operations():
     config = MapConfig()
 
     executor = MapExecutor.from_items(
+        operation_identifier=OperationIdentifier("op-1", "parent-1", "name-1"),
         items=items,
         func=func1,
         config=config,
@@ -2609,6 +2684,7 @@ def test_concurrent_executor_replay_with_failed_operations():
     config = MapConfig()
 
     executor = MapExecutor.from_items(
+        operation_identifier=OperationIdentifier("op-1", "parent-1", "name-1"),
         items=items,
         func=func1,
         config=config,
@@ -2648,6 +2724,7 @@ def test_concurrent_executor_replay_with_replay_children():
     config = MapConfig()
 
     executor = MapExecutor.from_items(
+        operation_identifier=OperationIdentifier("op-1", "parent-1", "name-1"),
         items=items,
         func=func1,
         config=config,
@@ -2779,6 +2856,7 @@ def test_executor_does_not_deadlock_when_all_tasks_terminal_but_completion_confi
     )
 
     executor = TestExecutor(
+        operation_identifier=OperationIdentifier("op-1", "parent-1", "name-1"),
         executables=executables,
         max_concurrency=2,
         completion_config=completion_config,
@@ -2820,7 +2898,12 @@ def test_executor_terminates_quickly_when_impossible_to_succeed():
         ),
     )
 
-    executor = MapExecutor.from_items(items=items, func=task_func, config=config)
+    executor = MapExecutor.from_items(
+        operation_identifier=OperationIdentifier("op-1", "parent-1", "name-1"),
+        items=items,
+        func=task_func,
+        config=config,
+    )
 
     execution_state = Mock()
     execution_state.create_checkpoint = Mock()
@@ -2869,6 +2952,7 @@ def test_executor_exits_early_with_min_successful():
     completion_config = CompletionConfig(min_successful=1)
 
     executor = TestExecutor(
+        operation_identifier=OperationIdentifier("op-1", "parent-1", "name-1"),
         executables=executables,
         max_concurrency=2,
         completion_config=completion_config,
@@ -2884,7 +2968,7 @@ def test_executor_exits_early_with_min_successful():
     executor_context._create_step_id_for_logical_step = lambda idx: f"step_{idx}"  # noqa: SLF001
     executor_context._parent_id = "parent"  # noqa: SLF001
 
-    def create_child_context(op_id):
+    def create_child_context(op_id, non_virtual_parent_id):
         child = Mock()
         child.state = execution_state
         return child
@@ -2942,6 +3026,7 @@ def test_executor_returns_with_incomplete_branches():
     completion_config = CompletionConfig(min_successful=1)
 
     executor = TestExecutor(
+        operation_identifier=OperationIdentifier("op-1", "parent-1", "name-1"),
         executables=executables,
         max_concurrency=2,
         completion_config=completion_config,
@@ -2956,7 +3041,9 @@ def test_executor_returns_with_incomplete_branches():
     executor_context = Mock()
     executor_context._create_step_id_for_logical_step = lambda idx: f"step_{idx}"  # noqa: SLF001
     executor_context._parent_id = "parent"  # noqa: SLF001
-    executor_context.create_child_context = lambda op_id: Mock(state=execution_state)
+    executor_context.create_child_context = lambda op_id, non_virtual_parent_id: Mock(
+        state=execution_state
+    )
 
     result = executor.execute(execution_state, executor_context)
 
@@ -3000,6 +3087,7 @@ def test_executor_returns_before_slow_branch_completes():
     completion_config = CompletionConfig(min_successful=1)
 
     executor = TestExecutor(
+        operation_identifier=OperationIdentifier("op-1", "parent-1", "name-1"),
         executables=executables,
         max_concurrency=2,
         completion_config=completion_config,
@@ -3014,7 +3102,9 @@ def test_executor_returns_before_slow_branch_completes():
     executor_context = Mock()
     executor_context._create_step_id_for_logical_step = lambda idx: f"step_{idx}"  # noqa: SLF001
     executor_context._parent_id = "parent"  # noqa: SLF001
-    executor_context.create_child_context = lambda op_id: Mock(state=execution_state)
+    executor_context.create_child_context = lambda op_id, non_virtual_parent_id: Mock(
+        state=execution_state
+    )
 
     result = executor.execute(execution_state, executor_context)
 

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -6,7 +6,6 @@ from unittest.mock import Mock
 from aws_durable_execution_sdk_python.config import (
     BatchedInput,
     CallbackConfig,
-    CheckpointMode,
     ChildConfig,
     CompletionConfig,
     Duration,
@@ -143,16 +142,6 @@ def test_step_config_with_values():
     assert config.retry_strategy is retry_strategy
     assert config.step_semantics == StepSemantics.AT_MOST_ONCE_PER_RETRY
     assert config.serdes is serdes
-
-
-def test_checkpoint_mode_enum():
-    """Test CheckpointMode enum."""
-    assert CheckpointMode.NO_CHECKPOINT.value == ("NO_CHECKPOINT",)
-    assert CheckpointMode.CHECKPOINT_AT_FINISH.value == ("CHECKPOINT_AT_FINISH",)
-    assert (
-        CheckpointMode.CHECKPOINT_AT_START_AND_FINISH.value
-        == "CHECKPOINT_AT_START_AND_FINISH"
-    )
 
 
 def test_child_config_defaults():

--- a/tests/operation/child_test.py
+++ b/tests/operation/child_test.py
@@ -644,12 +644,13 @@ def test_small_payload_with_summary_generator():
     assert success_operation.payload == '"small_payload"'  # JSON serialized
 
 
-def test_small_payload_without_summary_generator():
-    """Test: Small payload without summary_generator -> replay_children = False
+def test_child_handler_is_virtual_no_start():
+    """Test child_handler with is_virtual skips START checkpoint.
 
     Verifies:
-    - Small payload does NOT trigger replay_children
-    - get_checkpoint_result called once
+    - NO_CHECKPOINT mode: no START checkpoint created when operation not started
+    - Only SUCCEED checkpoint created
+    - Function executes normally
     """
     mock_state = Mock(spec=ExecutionState)
     mock_state.durable_execution_arn = "test_arn"
@@ -660,27 +661,198 @@ def test_small_payload_without_summary_generator():
     mock_result.is_replay_children.return_value = False
     mock_result.is_existent.return_value = False
     mock_state.get_checkpoint_result.return_value = mock_result
+    mock_callable = Mock(return_value="no_checkpoint_result")
 
-    # Small payload (< 256KB)
-    small_result = "small_payload"
-    mock_callable = Mock(return_value=small_result)
+    config = ChildConfig(is_virtual=True)
 
-    child_config = ChildConfig[str]()  # No summary_generator
-
-    actual_result = child_handler(
-        mock_callable,
-        mock_state,
-        OperationIdentifier("op2", None, "test_name"),
-        child_config,
+    result = child_handler(
+        mock_callable, mock_state, OperationIdentifier("op1", None, "test_name"), config
     )
 
-    assert actual_result == small_result
+    assert result == "no_checkpoint_result"
+
     # Verify get_checkpoint_result called once
     assert mock_state.get_checkpoint_result.call_count == 1
+
+    # Verify only SUCCEED checkpoint created (no START)
+    assert mock_state.create_checkpoint.call_count == 0
+
+    mock_callable.assert_called_once()
+
+
+def test_child_handler_is_virtual_no_succeed():
+    """Test child_handler with is_virtual skips SUCCEED checkpoint.
+
+    Verifies:
+    - NO_CHECKPOINT mode: no SUCCEED checkpoint created
+    - Function executes and returns result
+    - No checkpoints created at all
+    """
+    mock_state = Mock(spec=ExecutionState)
+    mock_state.durable_execution_arn = "test_arn"
+    mock_result = Mock()
+    mock_result.is_succeeded.return_value = False
+    mock_result.is_failed.return_value = False
+    mock_result.is_started.return_value = False
+    mock_result.is_replay_children.return_value = False
+    mock_result.is_existent.return_value = False
+    mock_state.get_checkpoint_result.return_value = mock_result
+    mock_callable = Mock(return_value="no_checkpoint_result")
+
+    config = ChildConfig(is_virtual=True)
+
+    result = child_handler(
+        mock_callable, mock_state, OperationIdentifier("op2", None, "test_name"), config
+    )
+
+    assert result == "no_checkpoint_result"
+
+    # Verify no checkpoints created
+    mock_state.create_checkpoint.assert_not_called()
+
+    mock_callable.assert_called_once()
+
+
+def test_child_handler_not_is_virtual_finish_mode():
+    """Test child_handler with is_virtual=False creates both checkpoints.
+
+    Verifies:
+    - CHECKPOINT_AT_START_AND_FINISH mode: both START and SUCCEED checkpoints created
+    - Function executes normally
+    """
+    mock_state = Mock(spec=ExecutionState)
+    mock_state.durable_execution_arn = "test_arn"
+    mock_result = Mock()
+    mock_result.is_succeeded.return_value = False
+    mock_result.is_failed.return_value = False
+    mock_result.is_started.return_value = False
+    mock_result.is_replay_children.return_value = False
+    mock_result.is_existent.return_value = False
+    mock_state.get_checkpoint_result.return_value = mock_result
+    mock_callable = Mock(return_value="checkpoint_result")
+
+    config = ChildConfig(is_virtual=False)
+
+    result = child_handler(
+        mock_callable, mock_state, OperationIdentifier("op3", None, "test_name"), config
+    )
+
+    assert result == "checkpoint_result"
+
+    # Verify both START and SUCCEED checkpoints created
+    assert mock_state.create_checkpoint.call_count == 2
+
+    # Verify START checkpoint
+    start_call = mock_state.create_checkpoint.call_args_list[0]
+    start_operation = start_call[1]["operation_update"]
+    assert start_operation.action.value == "START"
+    assert start_call[1]["is_sync"] is False
+
+    # Verify SUCCEED checkpoint
     success_call = mock_state.create_checkpoint.call_args_list[1]
     success_operation = success_call[1]["operation_update"]
+    assert success_operation.action.value == "SUCCEED"
 
-    # Small payload should NOT trigger replay_children
-    assert not success_operation.context_options.replay_children
-    # Should checkpoint the actual result
-    assert success_operation.payload == '"small_payload"'  # JSON serialized
+    mock_callable.assert_called_once()
+
+
+def test_child_handler_is_virtual_with_exception():
+    """Test child_handler with is_virtual still checkpoints failures.
+
+    Verifies:
+    - NO_CHECKPOINT mode: FAIL checkpoint still created for exceptions
+    - Exception is properly raised
+    """
+    mock_state = Mock(spec=ExecutionState)
+    mock_state.durable_execution_arn = "test_arn"
+    mock_result = Mock()
+    mock_result.is_succeeded.return_value = False
+    mock_result.is_failed.return_value = False
+    mock_result.is_started.return_value = False
+    mock_result.is_replay_children.return_value = False
+    mock_result.is_existent.return_value = False
+    mock_state.get_checkpoint_result.return_value = mock_result
+    mock_callable = Mock(side_effect=ValueError("Test error"))
+
+    config = ChildConfig(is_virtual=True)
+
+    with pytest.raises(CallableRuntimeError):
+        child_handler(
+            mock_callable,
+            mock_state,
+            OperationIdentifier("op4", None, "test_name"),
+            config,
+        )
+
+    # Verify FAIL checkpoint created (failures are always checkpointed)
+    assert mock_state.create_checkpoint.call_count == 1
+    fail_call = mock_state.create_checkpoint.call_args_list[0]
+    fail_operation = fail_call[1]["operation_update"]
+    assert fail_operation.action.value == "FAIL"
+
+    mock_callable.assert_called_once()
+
+
+def test_child_config_is_virtual():
+    """Test ChildConfig is_virtual works with other parameters."""
+
+    config = ChildConfig(
+        is_virtual=True,
+        sub_type=OperationSubType.STEP,
+        serdes=None,
+    )
+
+    assert config.is_virtual
+    assert config.sub_type == OperationSubType.STEP
+    assert config.serdes is None
+
+
+def test_child_handler_is_virtual_comparison():
+    """Test comparing behavior between different is_virtual
+
+    Verifies:
+    - CHECKPOINT_AT_START_AND_FINISH: creates 2 checkpoints (START + SUCCEED)
+    - NO_CHECKPOINT: creates 0 checkpoints for success case
+    """
+
+    # Setup common mocks
+    def setup_mocks():
+        mock_state = Mock(spec=ExecutionState)
+        mock_state.durable_execution_arn = "test_arn"
+        mock_result = Mock()
+        mock_result.is_succeeded.return_value = False
+        mock_result.is_failed.return_value = False
+        mock_result.is_started.return_value = False
+        mock_result.is_replay_children.return_value = False
+        mock_result.is_existent.return_value = False
+        mock_state.get_checkpoint_result.return_value = mock_result
+        mock_callable = Mock(return_value="test_result")
+        return mock_state, mock_callable
+
+    # Test CHECKPOINT_AT_START_AND_FINISH mode
+    mock_state1, mock_callable1 = setup_mocks()
+    config1 = ChildConfig(is_virtual=False)
+
+    result1 = child_handler(
+        mock_callable1,
+        mock_state1,
+        OperationIdentifier("op1", None, "test_name"),
+        config1,
+    )
+
+    assert result1 == "test_result"
+    assert mock_state1.create_checkpoint.call_count == 2  # START + SUCCEED
+
+    # Test NO_CHECKPOINT mode
+    mock_state2, mock_callable2 = setup_mocks()
+    config2 = ChildConfig(is_virtual=True)
+
+    result2 = child_handler(
+        mock_callable2,
+        mock_state2,
+        OperationIdentifier("op2", None, "test_name"),
+        config2,
+    )
+
+    assert result2 == "test_result"
+    assert mock_state2.create_checkpoint.call_count == 0  # No checkpoints

--- a/tests/operation/map_test.py
+++ b/tests/operation/map_test.py
@@ -18,6 +18,7 @@ from aws_durable_execution_sdk_python.config import (
     CompletionConfig,
     ItemBatcher,
     MapConfig,
+    NestingType,
 )
 from aws_durable_execution_sdk_python.context import DurableContext, ExecutionContext
 from aws_durable_execution_sdk_python.identifier import OperationIdentifier
@@ -53,6 +54,7 @@ def test_map_executor_init():
     items = ["item1"]
 
     executor = MapExecutor(
+        operation_identifier=OperationIdentifier("id-1", "parent-1", "name-1"),
         executables=executables,
         items=items,
         max_concurrency=2,
@@ -61,10 +63,12 @@ def test_map_executor_init():
         iteration_sub_type=OperationSubType.MAP_ITERATION,
         name_prefix="test-",
         serdes=None,
+        nesting_type=NestingType.FLAT,
     )
 
     assert executor.items == items
     assert executor.executables == executables
+    assert executor.nesting_type is NestingType.FLAT
 
 
 def test_map_executor_from_items():
@@ -74,14 +78,17 @@ def test_map_executor_from_items():
     def callable_func(ctx, item, idx, items):
         return item.upper()
 
-    config = MapConfig(max_concurrency=3)
+    config = MapConfig(max_concurrency=3, nesting_type=NestingType.FLAT)
 
-    executor = MapExecutor.from_items(items, callable_func, config)
+    executor = MapExecutor.from_items(
+        OperationIdentifier("id-1", "parent-1", "name-1"), items, callable_func, config
+    )
 
     assert len(executor.executables) == 3
     assert executor.items == items
     assert all(exe.func == callable_func for exe in executor.executables)
     assert [exe.index for exe in executor.executables] == [0, 1, 2]
+    assert executor.nesting_type is NestingType.FLAT
 
 
 def test_map_executor_from_items_default_config():
@@ -91,10 +98,16 @@ def test_map_executor_from_items_default_config():
     def callable_func(ctx, item, idx, items):
         return item
 
-    executor = MapExecutor.from_items(items, callable_func, MapConfig())
+    executor = MapExecutor.from_items(
+        OperationIdentifier("id-1", "parent-1", "name-1"),
+        items,
+        callable_func,
+        MapConfig(),
+    )
 
     assert len(executor.executables) == 1
     assert executor.items == items
+    assert executor.nesting_type is NestingType.NESTED
 
 
 @patch("aws_durable_execution_sdk_python.operation.map.logger")
@@ -105,7 +118,12 @@ def test_map_executor_execute_item(mock_logger):
     def callable_func(ctx, item, idx, items):
         return f"{item}_{idx}"
 
-    executor = MapExecutor.from_items(items, callable_func, MapConfig())
+    executor = MapExecutor.from_items(
+        OperationIdentifier("id-1", "parent-1", "name-1"),
+        items,
+        callable_func,
+        MapConfig(),
+    )
     executable = executor.executables[0]
 
     result = executor.execute_item(None, executable)
@@ -123,7 +141,12 @@ def test_map_executor_execute_item_with_context():
     def callable_func(ctx, item, idx, items):
         return item * 2 + idx
 
-    executor = MapExecutor.from_items(items, callable_func, MapConfig())
+    executor = MapExecutor.from_items(
+        OperationIdentifier("id-1", "parent-1", "name-1"),
+        items,
+        callable_func,
+        MapConfig(),
+    )
     executable = executor.executables[1]
 
     result = executor.execute_item("mock_context", executable)
@@ -210,7 +233,12 @@ def test_map_executor_execute_item_accesses_all_parameters():
         assert items_list == items
         return f"{item}_{idx}_{len(items_list)}"
 
-    executor = MapExecutor.from_items(items, callable_func, MapConfig())
+    executor = MapExecutor.from_items(
+        OperationIdentifier("id-1", "parent-1", "name-1"),
+        items,
+        callable_func,
+        MapConfig(),
+    )
     executable = executor.executables[2]
 
     result = executor.execute_item("test_context", executable)
@@ -225,7 +253,12 @@ def test_map_executor_from_items_empty_list():
     def callable_func(ctx, item, idx, items):
         return item
 
-    executor = MapExecutor.from_items(items, callable_func, MapConfig())
+    executor = MapExecutor.from_items(
+        OperationIdentifier("id-1", "parent-1", "name-1"),
+        items,
+        callable_func,
+        MapConfig(),
+    )
 
     assert len(executor.executables) == 0
     assert executor.items == []
@@ -238,7 +271,12 @@ def test_map_executor_from_items_single_item():
     def callable_func(ctx, item, idx, items):
         return f"processed_{item}"
 
-    executor = MapExecutor.from_items(items, callable_func, MapConfig())
+    executor = MapExecutor.from_items(
+        OperationIdentifier("id-1", "parent-1", "name-1"),
+        items,
+        callable_func,
+        MapConfig(),
+    )
 
     assert len(executor.executables) == 1
     assert executor.executables[0].index == 0
@@ -252,7 +290,12 @@ def test_map_executor_inheritance():
     def callable_func(ctx, item, idx, items):
         return item
 
-    executor = MapExecutor.from_items(items, callable_func, MapConfig())
+    executor = MapExecutor.from_items(
+        OperationIdentifier("id-1", "parent-1", "name-1"),
+        items,
+        callable_func,
+        MapConfig(),
+    )
 
     # Verify it has inherited attributes from ConcurrentExecutor
     assert hasattr(executor, "executables")
@@ -453,7 +496,9 @@ def test_map_executor_from_items_with_summary_generator():
 
     config = MapConfig(summary_generator=mock_summary_generator)
 
-    executor = MapExecutor.from_items(items, callable_func, config)
+    executor = MapExecutor.from_items(
+        OperationIdentifier("id-1", "parent-1", "name-1"), items, callable_func, config
+    )
 
     # Verify that the summary_generator is preserved in the executor
     assert executor.summary_generator is mock_summary_generator
@@ -505,6 +550,7 @@ def test_map_executor_init_with_summary_generator():
         return f"Summary: {result}"
 
     executor = MapExecutor(
+        operation_identifier=OperationIdentifier("id-1", "parent-1", "name-1"),
         executables=executables,
         items=items,
         max_concurrency=2,

--- a/tests/operation/parallel_test.py
+++ b/tests/operation/parallel_test.py
@@ -16,7 +16,11 @@ from aws_durable_execution_sdk_python.concurrency.models import (
     CompletionReason,
     Executable,
 )
-from aws_durable_execution_sdk_python.config import CompletionConfig, ParallelConfig
+from aws_durable_execution_sdk_python.config import (
+    CompletionConfig,
+    ParallelConfig,
+    NestingType,
+)
 from aws_durable_execution_sdk_python.context import DurableContext, ExecutionContext
 from aws_durable_execution_sdk_python.identifier import OperationIdentifier
 from aws_durable_execution_sdk_python.lambda_service import OperationSubType
@@ -54,6 +58,7 @@ def test_parallel_executor_init():
     completion_config = CompletionConfig.all_successful()
 
     executor = ParallelExecutor(
+        operation_identifier=OperationIdentifier("test_op", "parent", "test_parallel"),
         executables=executables,
         max_concurrency=2,
         completion_config=completion_config,
@@ -61,6 +66,7 @@ def test_parallel_executor_init():
         iteration_sub_type=OperationSubType.PARALLEL_BRANCH,
         name_prefix="test-",
         serdes=None,
+        nesting_type=NestingType.FLAT,
     )
 
     assert executor.executables == executables
@@ -69,6 +75,7 @@ def test_parallel_executor_init():
     assert executor.sub_type_top == OperationSubType.PARALLEL
     assert executor.sub_type_iteration == OperationSubType.PARALLEL_BRANCH
     assert executor.name_prefix == "test-"
+    assert executor.nesting_type is NestingType.FLAT
 
 
 def test_parallel_executor_from_callables():
@@ -81,9 +88,11 @@ def test_parallel_executor_from_callables():
         return "result2"
 
     callables = [func1, func2]
-    config = ParallelConfig(max_concurrency=3)
+    config = ParallelConfig(max_concurrency=3, nesting_type=NestingType.FLAT)
 
-    executor = ParallelExecutor.from_callables(callables, config)
+    executor = ParallelExecutor.from_callables(
+        OperationIdentifier("test_op", "parent", "test_parallel"), callables, config
+    )
 
     assert len(executor.executables) == 2
     assert executor.executables[0].index == 0
@@ -94,6 +103,7 @@ def test_parallel_executor_from_callables():
     assert executor.sub_type_top == OperationSubType.PARALLEL
     assert executor.sub_type_iteration == OperationSubType.PARALLEL_BRANCH
     assert executor.name_prefix == "parallel-branch-"
+    assert executor.nesting_type is NestingType.FLAT
 
 
 def test_parallel_executor_from_callables_default_config():
@@ -105,11 +115,14 @@ def test_parallel_executor_from_callables_default_config():
     callables = [func1]
     config = ParallelConfig()
 
-    executor = ParallelExecutor.from_callables(callables, config)
+    executor = ParallelExecutor.from_callables(
+        OperationIdentifier("test_op", "parent", "test_parallel"), callables, config
+    )
 
     assert len(executor.executables) == 1
     assert executor.max_concurrency is None
     assert executor.completion_config == CompletionConfig.all_successful()
+    assert executor.nesting_type is NestingType.NESTED
 
 
 def test_parallel_executor_execute_item():
@@ -120,6 +133,7 @@ def test_parallel_executor_execute_item():
 
     executable = Executable(index=0, func=test_func)
     executor = ParallelExecutor(
+        operation_identifier=OperationIdentifier("test_op", "parent", "test_parallel"),
         executables=[executable],
         max_concurrency=None,
         completion_config=CompletionConfig.all_successful(),
@@ -144,6 +158,7 @@ def test_parallel_executor_execute_item_with_exception():
 
     executable = Executable(index=0, func=failing_func)
     executor = ParallelExecutor(
+        operation_identifier=OperationIdentifier("test_op", "parent", "test_parallel"),
         executables=[executable],
         max_concurrency=None,
         completion_config=CompletionConfig.all_successful(),
@@ -270,7 +285,9 @@ def test_parallel_handler_creates_executor_with_correct_config():
             callables, config, execution_state, executor_context, operation_identifier
         )
 
-        mock_from_callables.assert_called_once_with(callables, config)
+        mock_from_callables.assert_called_once_with(
+            operation_identifier, callables, config
+        )
         mock_executor.execute.assert_called_once_with(
             execution_state, executor_context=executor_context
         )
@@ -311,16 +328,18 @@ def test_parallel_handler_creates_executor_with_default_config_when_none():
         assert result == mock_batch_result
         # Verify that a default ParallelConfig was created
         args, _ = mock_from_callables.call_args
-        assert args[0] == callables
-        assert isinstance(args[1], ParallelConfig)
-        assert args[1].max_concurrency is None
-        assert args[1].completion_config == CompletionConfig.all_successful()
+        assert args[0] == operation_identifier
+        assert args[1] == callables
+        assert isinstance(args[2], ParallelConfig)
+        assert args[2].max_concurrency is None
+        assert args[2].completion_config == CompletionConfig.all_successful()
 
 
 def test_parallel_executor_inheritance():
     """Test that ParallelExecutor properly inherits from ConcurrentExecutor."""
     executables = [Executable(index=0, func=lambda x: x)]
     executor = ParallelExecutor(
+        operation_identifier=OperationIdentifier("test_op", "parent", "test_parallel"),
         executables=executables,
         max_concurrency=None,
         completion_config=CompletionConfig.all_successful(),
@@ -338,7 +357,9 @@ def test_parallel_executor_from_callables_empty_list():
     callables = []
     config = ParallelConfig()
 
-    executor = ParallelExecutor.from_callables(callables, config)
+    executor = ParallelExecutor.from_callables(
+        OperationIdentifier("test_op", "parent", "test_parallel"), callables, config
+    )
 
     assert len(executor.executables) == 0
     assert executor.max_concurrency is None
@@ -357,6 +378,7 @@ def test_parallel_executor_execute_item_return_type():
         return {"key": "value"}
 
     executor = ParallelExecutor(
+        operation_identifier=OperationIdentifier("test_op", "parent", "test_parallel"),
         executables=[],
         max_concurrency=None,
         completion_config=CompletionConfig.all_successful(),
@@ -457,7 +479,9 @@ def test_parallel_executor_from_callables_with_summary_generator():
     callables = [func1]
     config = ParallelConfig(summary_generator=mock_summary_generator)
 
-    executor = ParallelExecutor.from_callables(callables, config)
+    executor = ParallelExecutor.from_callables(
+        OperationIdentifier("test_op", "parent", "test_parallel"), callables, config
+    )
 
     # Verify that the summary_generator is preserved in the executor
     assert executor.summary_generator is mock_summary_generator


### PR DESCRIPTION
*Issue #, if available:*

- fixes: https://github.com/aws/aws-durable-execution-sdk-python/issues/350

*Description of changes:*

- added a new nesting mode parameter to map and parallel operation
- added a new checkpoint mode parameter to child context operation

```
============================= test session starts ==============================
collecting ... collected 1 item

examples/test/map/test_map_operations_flat.py::test_map_operations 

========================= 1 passed, 1 warning in 0.55s =========================
PASSED [100%]

============================= test session starts ==============================
collecting ... collected 1 item

examples/test/parallel/test_parallel_flat.py::test_parallel_flat 

======================== 1 passed, 3 warnings in 1.55s =========================
PASSED  [100%]
```

TESTING_SDK_BRANCH=nest_type

Fixed integration workflow.

```
examples/test/parallel/test_parallel_flat.py::test_parallel_flat PASSED  [ 97%]
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
