### PR TITLE
fix: change format of user agent header

### DIFF
--- a/src/aws_durable_execution_sdk_python/lambda_service.py
+++ b/src/aws_durable_execution_sdk_python/lambda_service.py
@@ -18,6 +18,7 @@ from aws_durable_execution_sdk_python.exceptions import (
     GetExecutionStateError,
 )
 
+
 if TYPE_CHECKING:
     from mypy_boto3_lambda import LambdaClient as Boto3LambdaClient
     from mypy_boto3_lambda.type_defs import (
@@ -1060,7 +1061,7 @@ class LambdaClient(DurableServiceClient):
                 config=Config(
                     connect_timeout=5,
                     read_timeout=50,
-                    user_agent_extra=f"@aws/durable-execution-sdk-python/{__version__}",
+                    user_agent_extra=f"aws-durable-execution-sdk-python/{__version__}",
                 ),
             )
         return cls(client=cls._cached_boto_client)

--- a/tests/lambda_service_test.py
+++ b/tests/lambda_service_test.py
@@ -40,6 +40,7 @@ from aws_durable_execution_sdk_python.lambda_service import (
     WaitOptions,
 )
 
+
 # =============================================================================
 # Fixtures
 # =============================================================================
@@ -1941,7 +1942,7 @@ def test_lambda_client_initialize_client_default(
     config = call_args[1]["config"]
     assert config.connect_timeout == 5
     assert config.read_timeout == 50
-    assert config.user_agent_extra == f"@aws/durable-execution-sdk-python/{__version__}"
+    assert config.user_agent_extra == f"aws-durable-execution-sdk-python/{__version__}"
     assert isinstance(client, LambdaClient)
 
 
@@ -1965,7 +1966,7 @@ def test_lambda_client_initialize_client_with_endpoint(
     config = call_args[1]["config"]
     assert config.connect_timeout == 5
     assert config.read_timeout == 50
-    assert config.user_agent_extra == f"@aws/durable-execution-sdk-python/{__version__}"
+    assert config.user_agent_extra == f"aws-durable-execution-sdk-python/{__version__}"
     assert isinstance(client, LambdaClient)
 
 
@@ -2042,7 +2043,7 @@ def test_lambda_client_initialize_client_no_endpoint(
     assert call_args[0] == ("lambda",)
     assert "config" in call_args[1]
     config = call_args[1]["config"]
-    assert config.user_agent_extra == f"@aws/durable-execution-sdk-python/{__version__}"
+    assert config.user_agent_extra == f"aws-durable-execution-sdk-python/{__version__}"
     assert isinstance(client, LambdaClient)
 
 


### PR DESCRIPTION
- Update the UserAgent string format to be consistent with the format used in other language SDKs.

*Issue #, if available:*

N/A

*Description of changes:*

- Updated the format of the `user_agent_extra` to match the new format being used in the other language SDKs.
- The new format is `aws-durable-execution-sdk-python/{version}`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
