### PR TITLE
[refactor]: use an executor class instead of closure

### DIFF
--- a/src/aws_durable_execution_sdk_python/execution.py
+++ b/src/aws_durable_execution_sdk_python/execution.py
@@ -7,14 +7,13 @@ import logging
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast, Callable
 
 from aws_durable_execution_sdk_python.context import DurableContext
 from aws_durable_execution_sdk_python.exceptions import (
     BackgroundThreadError,
     BotoClientError,
     CheckpointError,
-    DurableExecutionsError,
     ExecutionError,
     InvocationError,
     SuspendExecution,
@@ -24,13 +23,12 @@ from aws_durable_execution_sdk_python.lambda_service import (
     ErrorObject,
     LambdaClient,
     Operation,
-    OperationType,
     OperationUpdate,
 )
 from aws_durable_execution_sdk_python.state import ExecutionState, ReplayStatus
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, MutableMapping
+    from collections.abc import MutableMapping
 
     from mypy_boto3_lambda import LambdaClient as Boto3LambdaClient
 
@@ -51,9 +49,9 @@ class InitialExecutionState:
 
     @staticmethod
     def from_dict(input_dict: MutableMapping[str, Any]) -> InitialExecutionState:
-        operations = []
-        if input_operations := input_dict.get("Operations"):
-            operations = [Operation.from_dict(op) for op in input_operations]
+        operations = [
+            Operation.from_dict(op) for op in input_dict.get("Operations", [])
+        ]
         return InitialExecutionState(
             operations=operations,
             next_marker=input_dict.get("NextMarker", ""),
@@ -61,9 +59,9 @@ class InitialExecutionState:
 
     @staticmethod
     def from_json_dict(input_dict: MutableMapping[str, Any]) -> InitialExecutionState:
-        operations = []
-        if input_operations := input_dict.get("Operations"):
-            operations = [Operation.from_json_dict(op) for op in input_operations]
+        operations = [
+            Operation.from_json_dict(op) for op in input_dict.get("Operations", [])
+        ]
         return InitialExecutionState(
             operations=operations,
             next_marker=input_dict.get("NextMarker", ""),
@@ -199,11 +197,6 @@ class DurableExecutionInvocationOutput:
 
         return result
 
-    @classmethod
-    def create_succeeded(cls, result: str) -> DurableExecutionInvocationOutput:
-        """Create a succeeded invocation output."""
-        return cls(status=InvocationStatus.SUCCEEDED, result=result)
-
 
 # endregion Invocation models
 
@@ -217,54 +210,89 @@ def durable_execution(
     if func is None:
         logger.debug("Decorator called with parameters")
         return functools.partial(durable_execution, boto3_client=boto3_client)
+    else:
+        logger.debug("Starting durable execution handler...")
 
-    logger.debug("Starting durable execution handler...")
+        def wrapper(event: Any, context: LambdaContext) -> MutableMapping[str, Any]:
+            executor = DurableExecutionExecutor(
+                cast(Callable[[Any, DurableContext], Any], func),
+                boto3_client,
+                event,
+                context,
+            )
+            return executor.execute()
 
-    def wrapper(event: Any, context: LambdaContext) -> MutableMapping[str, Any]:
-        invocation_input: DurableExecutionInvocationInput
-        service_client: DurableServiceClient
+        return wrapper
 
+
+class DurableExecutionExecutor:
+    def __init__(
+        self,
+        func: Callable[[Any, DurableContext], Any],
+        boto3_client: Boto3LambdaClient | None,
+        event: Any,
+        context: LambdaContext,
+    ):
+        self.func = func
+        self.boto3_client = boto3_client
+        self.event = event
+        self.context = context
+        self.invocation_input = self._parse_invocation_input(event)
+        self.service_client = self._parse_service_client(event, boto3_client)
+
+    def _parse_invocation_input(self, event: Any) -> DurableExecutionInvocationInput:
         # event likely only to be DurableExecutionInvocationInputWithClient when directly injected by test framework
+        invocation_input: (
+            DurableExecutionInvocationInputWithClient | DurableExecutionInvocationInput
+        )
         if isinstance(event, DurableExecutionInvocationInputWithClient):
-            logger.debug("durableExecutionArn: %s", event.durable_execution_arn)
             invocation_input = event
-            service_client = invocation_input.service_client
         else:
             try:
-                logger.debug(
-                    "durableExecutionArn: %s", event.get("DurableExecutionArn")
-                )
                 invocation_input = DurableExecutionInvocationInput.from_json_dict(event)
-            except (KeyError, TypeError, AttributeError) as e:
+            except (KeyError, TypeError, AttributeError):
                 msg = (
                     "Unexpected payload provided to start the durable execution. "
                     "Check your resource configurations to confirm the durability is set."
                 )
-                raise ExecutionError(msg) from e
+                # throws ExecutionError to terminate the invocation
+                self._handle_execution_output(
+                    exception=ExecutionError(msg), retryable=True
+                )
+                # add a redundant raise to make type checker happy
+                raise ExecutionError(msg)
 
+        logger.debug("durableExecutionArn: %s", invocation_input.durable_execution_arn)
+        return invocation_input
+
+    @staticmethod
+    def _parse_service_client(event, boto3_client):
+        if isinstance(event, DurableExecutionInvocationInputWithClient):
+            return event.service_client
+        elif boto3_client:
+            return LambdaClient(boto3_client)
+        else:
             # Use custom client if provided, otherwise initialize from environment
-            service_client = (
-                LambdaClient(client=boto3_client)
-                if boto3_client is not None
-                else LambdaClient.initialize_client()
-            )
+            return LambdaClient.initialize_client()
 
+    def execute(self):
         execution_state: ExecutionState = ExecutionState(
-            durable_execution_arn=invocation_input.durable_execution_arn,
-            initial_checkpoint_token=invocation_input.checkpoint_token,
+            durable_execution_arn=self.invocation_input.durable_execution_arn,
+            initial_checkpoint_token=self.invocation_input.checkpoint_token,
             operations={},
-            service_client=service_client,
+            service_client=self.service_client,
             # If there are operations other than the initial EXECUTION one, current state is in replay mode
+            # todo: replay status will be wrong if initial_execution_state contains only one operation and more in next pages
             replay_status=ReplayStatus.REPLAY
-            if len(invocation_input.initial_execution_state.operations) > 1
+            if len(self.invocation_input.initial_execution_state.operations) > 1
             else ReplayStatus.NEW,
         )
 
         try:
             execution_state.fetch_paginated_operations(
-                invocation_input.initial_execution_state.operations,
-                invocation_input.checkpoint_token,
-                invocation_input.initial_execution_state.next_marker,
+                self.invocation_input.initial_execution_state.operations,
+                self.invocation_input.checkpoint_token,
+                self.invocation_input.initial_execution_state.next_marker,
             )
         except BotoClientError as e:
             # Non-retryable Durable API errors (e.g., customer configuration issues,
@@ -275,11 +303,9 @@ def durable_execution(
                     "without retry.",
                     extra=e.build_logger_extras(),
                 )
-                return DurableExecutionInvocationOutput(
-                    status=InvocationStatus.FAILED,
-                    error=ErrorObject.from_exception(e),
-                ).to_dict()
-            raise
+            return self._handle_execution_output(
+                exception=e, retryable=e.is_retryable()
+            )
 
         raw_input_payload: str | None = execution_state.get_input_payload()
 
@@ -289,15 +315,15 @@ def durable_execution(
         if raw_input_payload and raw_input_payload.strip():
             try:
                 input_event = json.loads(raw_input_payload)
-            except json.JSONDecodeError:
+            except json.JSONDecodeError as e:
                 logger.exception(
                     "Failed to parse input payload as JSON: payload: %r",
                     raw_input_payload,
                 )
-                raise
+                self._handle_execution_output(exception=e, retryable=True)
 
         durable_context: DurableContext = DurableContext.from_lambda_context(
-            state=execution_state, lambda_context=context
+            state=execution_state, lambda_context=self.context
         )
 
         # Use ThreadPoolExecutor for concurrent execution of user code and background checkpoint processing
@@ -312,13 +338,13 @@ def durable_execution(
 
             # Thread 2: Execute user function
             logger.debug(
-                "%s entering user-space...", invocation_input.durable_execution_arn
+                "%s entering user-space...", self.invocation_input.durable_execution_arn
             )
-            user_future = executor.submit(func, input_event, durable_context)
+            user_future = executor.submit(self.func, input_event, durable_context)
 
             logger.debug(
                 "%s waiting for user code completion...",
-                invocation_input.durable_execution_arn,
+                self.invocation_input.durable_execution_arn,
             )
 
             try:
@@ -328,71 +354,44 @@ def durable_execution(
                 # done with userland
                 logger.debug(
                     "%s exiting user-space...",
-                    invocation_input.durable_execution_arn,
+                    self.invocation_input.durable_execution_arn,
                 )
-                serialized_result = json.dumps(result)
-                # large response handling here. Remember if checkpointing to complete, NOT to include
-                # payload in response
-                if (
-                    serialized_result
-                    and len(serialized_result) > LAMBDA_RESPONSE_SIZE_LIMIT
-                ):
-                    logger.debug(
-                        "Response size (%s bytes) exceeds Lambda limit (%s) bytes). Checkpointing result.",
-                        len(serialized_result),
-                        LAMBDA_RESPONSE_SIZE_LIMIT,
-                    )
-                    success_operation = OperationUpdate.create_execution_succeed(
-                        payload=serialized_result
-                    )
-                    # Checkpoint large result with blocking (is_sync=True, default).
-                    # Must ensure the result is persisted before returning to Lambda.
-                    # Large results exceed Lambda response limits and must be stored durably
-                    # before the execution completes.
-                    try:
-                        execution_state.create_checkpoint(
-                            success_operation, is_sync=True
-                        )
-                    except CheckpointError as e:
-                        return handle_checkpoint_error(e).to_dict()
-                    return DurableExecutionInvocationOutput.create_succeeded(
-                        result=""
-                    ).to_dict()
+                serialized_result = self._handle_large_result(execution_state, result)
 
-                return DurableExecutionInvocationOutput.create_succeeded(
-                    result=serialized_result
-                ).to_dict()
+                return self._handle_execution_output(result=serialized_result)
 
             except BackgroundThreadError as bg_error:
                 # Background checkpoint system failed - propagated through CompletionEvent
                 # Do not attempt to checkpoint anything, just terminate immediately
-                if isinstance(bg_error.source_exception, BotoClientError):
+                cause = bg_error.source_exception
+
+                if isinstance(cause, BotoClientError):
                     logger.exception(
                         "Checkpoint processing failed",
-                        extra=bg_error.source_exception.build_logger_extras(),
+                        extra=cause.build_logger_extras(),
                     )
                     # Non-retryable Durable API errors (e.g., customer configuration issues,
                     # 4xx client errors) will never succeed on retry — fail the execution immediately.
-                    if not bg_error.source_exception.is_retryable():
+                    if not cause.is_retryable():
                         logger.exception(
                             "Non-retryable Durable API error from background thread. Must fail execution "
                             "without retry.",
-                            extra=bg_error.source_exception.build_logger_extras(),
+                            extra=cause.build_logger_extras(),
                         )
-                        return DurableExecutionInvocationOutput(
-                            status=InvocationStatus.FAILED,
-                            error=ErrorObject.from_exception(bg_error.source_exception),
-                        ).to_dict()
                 else:
                     logger.exception("Checkpoint processing failed")
-                raise bg_error.source_exception from bg_error
+
+                retryable = (
+                    not isinstance(cause, BotoClientError) or cause.is_retryable()
+                )
+                return self._handle_execution_output(
+                    exception=cause, retryable=retryable
+                )
 
             except SuspendExecution:
                 # User code suspended - stop background checkpointing thread
                 logger.debug("Suspending execution...")
-                return DurableExecutionInvocationOutput(
-                    status=InvocationStatus.PENDING
-                ).to_dict()
+                return self._handle_execution_output(status=InvocationStatus.PENDING)
 
             except CheckpointError as e:
                 # Checkpoint system is broken - stop background thread and exit immediately
@@ -400,71 +399,120 @@ def durable_execution(
                     "Checkpoint system failed",
                     extra=e.build_logger_extras(),
                 )
-                return handle_checkpoint_error(e).to_dict()
+                # Terminate Lambda invocation immediately and have it be retried if retryable
+                return self._handle_execution_output(
+                    exception=e, retryable=e.is_retryable()
+                )
             except InvocationError as e:
-                # Non-retryable Durable API errors (e.g., customer configuration issues,
-                # 4xx client errors) will never succeed on retry — fail the execution immediately.
-                if not e.is_retryable():
+                if e.is_retryable():
+                    logger.exception("Invocation error. Must terminate.")
+                else:
+                    # Non-retryable Durable API errors (e.g., customer configuration issues,
+                    # 4xx client errors) will never succeed on retry — fail the execution immediately.
                     logger.exception(
                         "Non-retryable Durable API error. Must fail execution without retry.",
                         extra=e.build_logger_extras(),  # type: ignore[attr-defined]
                     )
-                    return DurableExecutionInvocationOutput(
-                        status=InvocationStatus.FAILED,
-                        error=ErrorObject.from_exception(e),
-                    ).to_dict()
-                logger.exception("Invocation error. Must terminate.")
-                # Throw the error to trigger Lambda retry
-                raise
+                return self._handle_execution_output(
+                    exception=e, retryable=e.is_retryable()
+                )
             except ExecutionError as e:
                 logger.exception("Execution error. Must fail execution without retry.")
-                return DurableExecutionInvocationOutput(
-                    status=InvocationStatus.FAILED,
-                    error=ErrorObject.from_exception(e),
-                ).to_dict()
+                return self._handle_execution_output(exception=e)
             except Exception as e:
                 # all user-space errors go here
                 logger.exception("Execution failed")
 
-                result = DurableExecutionInvocationOutput(
-                    status=InvocationStatus.FAILED, error=ErrorObject.from_exception(e)
-                ).to_dict()
-
-                serialized_result = json.dumps(result)
-
-                if (
-                    serialized_result
-                    and len(serialized_result) > LAMBDA_RESPONSE_SIZE_LIMIT
-                ):
-                    logger.debug(
-                        "Response size (%s bytes) exceeds Lambda limit (%s) bytes). Checkpointing result.",
-                        len(serialized_result),
-                        LAMBDA_RESPONSE_SIZE_LIMIT,
-                    )
-                    failed_operation = OperationUpdate.create_execution_fail(
-                        error=ErrorObject.from_exception(e)
+                try:
+                    error = self._handle_large_error(execution_state, exception=e)
+                except CheckpointError as e:
+                    # Terminate Lambda invocation immediately and have it be retried if retryable
+                    return self._handle_execution_output(
+                        exception=e, retryable=e.is_retryable()
                     )
 
-                    # Checkpoint large result with blocking (is_sync=True, default).
-                    # Must ensure the result is persisted before returning to Lambda.
-                    # Large results exceed Lambda response limits and must be stored durably
-                    # before the execution completes.
-                    try:
-                        execution_state.create_checkpoint_sync(failed_operation)
-                    except CheckpointError as e:
-                        return handle_checkpoint_error(e).to_dict()
-                    return DurableExecutionInvocationOutput(
-                        status=InvocationStatus.FAILED
-                    ).to_dict()
+                # fail without an ErrorObject
+                return self._handle_execution_output(
+                    status=InvocationStatus.FAILED, error=error
+                )
 
-                return result
+    @staticmethod
+    def _handle_large_result(execution_state: ExecutionState, result: Any) -> str:
+        # large response handling here. Remember if checkpointing to complete, NOT to include
+        # payload in response
+        serialized_result = json.dumps(result)
+        if serialized_result and len(serialized_result) > LAMBDA_RESPONSE_SIZE_LIMIT:
+            logger.debug(
+                "Response size (%s bytes) exceeds Lambda limit (%s) bytes). Checkpointing result.",
+                len(serialized_result),
+                LAMBDA_RESPONSE_SIZE_LIMIT,
+            )
+            success_operation = OperationUpdate.create_execution_succeed(
+                payload=serialized_result
+            )
+            # Checkpoint large result with blocking (is_sync=True, default).
+            # Must ensure the result is persisted before returning to Lambda.
+            # Large results exceed Lambda response limits and must be stored durably
+            # before the execution completes.
+            execution_state.create_checkpoint(success_operation, is_sync=True)
+            return ""
 
-    return wrapper
+        return serialized_result
 
+    @staticmethod
+    def _handle_large_error(
+        execution_state: ExecutionState, exception: Exception
+    ) -> ErrorObject | None:
+        # large response handling here. Remember if checkpointing to complete, NOT to include
+        # payload in response
+        error = ErrorObject.from_exception(exception)
+        serialized_error = json.dumps(error.to_dict())
+        if serialized_error and len(serialized_error) > LAMBDA_RESPONSE_SIZE_LIMIT:
+            logger.debug(
+                "Response size (%s bytes) exceeds Lambda limit (%s) bytes). Checkpointing result.",
+                len(serialized_error),
+                LAMBDA_RESPONSE_SIZE_LIMIT,
+            )
+            failed_operation = OperationUpdate.create_execution_fail(error=error)
+            # Checkpoint large result with blocking (is_sync=True, default).
+            # Must ensure the result is persisted before returning to Lambda.
+            # Large results exceed Lambda response limits and must be stored durably
+            # before the execution completes.
+            execution_state.create_checkpoint_sync(failed_operation)
 
-def handle_checkpoint_error(error: CheckpointError) -> DurableExecutionInvocationOutput:
-    if error.is_retryable():
-        raise error from None  # Terminate Lambda immediately and have it be retried
-    return DurableExecutionInvocationOutput(
-        status=InvocationStatus.FAILED, error=ErrorObject.from_exception(error)
-    )
+            # return fail without an ErrorObject
+            return None
+
+        return error
+
+    def _handle_execution_output(
+        self,
+        result: str | None = None,
+        error: ErrorObject | None = None,
+        exception: Exception | None = None,
+        retryable: bool = False,
+        status: InvocationStatus | None = None,
+    ) -> MutableMapping[str, Any]:
+        if exception:
+            if retryable:
+                # Throw the error to trigger Lambda retry
+                raise exception
+            else:
+                return self._handle_execution_output(
+                    result=result,
+                    error=ErrorObject.from_exception(exception),
+                )
+
+        if error:
+            output = DurableExecutionInvocationOutput(
+                status=InvocationStatus.FAILED, result=result, error=error
+            )
+        elif result is not None:
+            output = DurableExecutionInvocationOutput(
+                status=InvocationStatus.SUCCEEDED, result=result
+            )
+        elif status:
+            output = DurableExecutionInvocationOutput(status=status)
+        else:
+            raise ValueError("Unexpected durable execution output")
+        return output.to_dict()

--- a/src/aws_durable_execution_sdk_python/execution.py
+++ b/src/aws_durable_execution_sdk_python/execution.py
@@ -501,6 +501,7 @@ class DurableExecutionExecutor:
                 return self._handle_execution_output(
                     result=result,
                     error=ErrorObject.from_exception(exception),
+                    status=status,
                 )
 
         if error:


### PR DESCRIPTION
*Issue #, if available:*

Useful for #370 

*Description of changes:*

Added `DurableExecutionExecutor` class to wrap the required fields that were previously shared via closure. 
- This would make it easier to add more fields later like plugins.
- This would make it easier to split the big method into smaller pieces

plugins and more fields will be added to this new class to be shared across methods.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
