### PR TITLE
fix: replay status after paginated state

### DIFF
--- a/src/aws_durable_execution_sdk_python/execution.py
+++ b/src/aws_durable_execution_sdk_python/execution.py
@@ -254,10 +254,7 @@ def durable_execution(
             initial_checkpoint_token=invocation_input.checkpoint_token,
             operations={},
             service_client=service_client,
-            # If there are operations other than the initial EXECUTION one, current state is in replay mode
-            replay_status=ReplayStatus.REPLAY
-            if len(invocation_input.initial_execution_state.operations) > 1
-            else ReplayStatus.NEW,
+            replay_status=ReplayStatus.NEW,
         )
 
         try:
@@ -280,6 +277,9 @@ def durable_execution(
                     error=ErrorObject.from_exception(e),
                 ).to_dict()
             raise
+
+        if len(execution_state.operations) > 1:
+            execution_state.mark_replaying()
 
         raw_input_payload: str | None = execution_state.get_input_payload()
 

--- a/src/aws_durable_execution_sdk_python/execution.py
+++ b/src/aws_durable_execution_sdk_python/execution.py
@@ -278,8 +278,7 @@ def durable_execution(
                 ).to_dict()
             raise
 
-        if len(execution_state.operations) > 1:
-            execution_state.mark_replaying()
+        execution_state.mark_replaying_if_prior_operations_exist()
 
         raw_input_payload: str | None = execution_state.get_input_payload()
 

--- a/src/aws_durable_execution_sdk_python/state.py
+++ b/src/aws_durable_execution_sdk_python/state.py
@@ -379,10 +379,17 @@ class ExecutionState:
         with self._replay_status_lock:
             return self._replay_status is ReplayStatus.REPLAY
 
-    def mark_replaying(self) -> None:
-        """Mark execution state as replaying."""
-        with self._replay_status_lock:
-            self._replay_status = ReplayStatus.REPLAY
+    def mark_replaying_if_prior_operations_exist(self) -> None:
+        """Mark execution state as replaying when non-execution operations exist."""
+        with self._operations_lock:
+            has_prior_operations: bool = any(
+                op.operation_type is not OperationType.EXECUTION
+                for op in self.operations.values()
+            )
+
+        if has_prior_operations:
+            with self._replay_status_lock:
+                self._replay_status = ReplayStatus.REPLAY
 
     def get_checkpoint_result(self, checkpoint_id: str) -> CheckpointedResult:
         """Get checkpoint result.

--- a/src/aws_durable_execution_sdk_python/state.py
+++ b/src/aws_durable_execution_sdk_python/state.py
@@ -379,6 +379,11 @@ class ExecutionState:
         with self._replay_status_lock:
             return self._replay_status is ReplayStatus.REPLAY
 
+    def mark_replaying(self) -> None:
+        """Mark execution state as replaying."""
+        with self._replay_status_lock:
+            self._replay_status = ReplayStatus.REPLAY
+
     def get_checkpoint_result(self, checkpoint_id: str) -> CheckpointedResult:
         """Get checkpoint result.
 

--- a/tests/execution_test.py
+++ b/tests/execution_test.py
@@ -43,6 +43,7 @@ from aws_durable_execution_sdk_python.lambda_service import (
     OperationStatus,
     OperationType,
     OperationUpdate,
+    StateOutput,
     StepDetails,
     WaitDetails,
 )
@@ -2684,6 +2685,36 @@ def _make_lambda_context():
     ctx.invoked_function_arn = None
     ctx.tenant_id = None
     return ctx
+
+
+def test_durable_execution_replays_when_paginated_state_has_prior_operations():
+    """Test paginated execution state starts in replay mode when prior operations exist."""
+    mock_client = Mock(spec=DurableServiceClient)
+    step_operation = Operation(
+        operation_id="step1",
+        operation_type=OperationType.STEP,
+        status=OperationStatus.SUCCEEDED,
+    )
+    mock_client.get_execution_state.return_value = StateOutput(
+        operations=[step_operation],
+        next_marker=None,
+    )
+
+    invocation_input = _make_invocation_input(mock_client, next_marker="page2")
+
+    @durable_execution
+    def test_handler(event: Any, context: DurableContext) -> dict:
+        return {"is_replaying": context.state.is_replaying()}
+
+    result = test_handler(invocation_input, _make_lambda_context())
+
+    assert result["Status"] == InvocationStatus.SUCCEEDED.value
+    assert json.loads(result["Result"]) == {"is_replaying": True}
+    mock_client.get_execution_state.assert_called_once_with(
+        durable_execution_arn="arn:test:execution",
+        checkpoint_token="token123",
+        next_marker="page2",
+    )
 
 
 def test_durable_execution_non_retryable_invocation_error_returns_failed():


### PR DESCRIPTION
*Issue #, if available:*

Fixes #376

*Description of changes:*

This updates durable execution initialization so replay status is determined after paginated execution state has been fetched.

Previously, replay status was based only on the first page of `initial_execution_state.operations`. If that first page contained only the execution operation and prior operations were returned on later pages, the invocation could incorrectly start in `NEW` mode.

Changes:
- Initialize execution state as `NEW`
- Fetch paginated operations before deciding replay mode
- Mark execution state as replaying when fetched state contains prior operations
- Add a regression test for paginated initial state with prior operations

Tests:
- `hatch test tests/execution_test.py::test_durable_execution_replays_when_paginated_state_has_prior_operations`
- `hatch test tests/execution_test.py`
- `hatch run types:check`
- `hatch fmt --check`
- `.github/scripts/ci-checks.sh`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.