### PR TITLE
refactor: move replay status init into ExecutionState

### DIFF
--- a/src/aws_durable_execution_sdk_python/context.py
+++ b/src/aws_durable_execution_sdk_python/context.py
@@ -42,7 +42,6 @@ from aws_durable_execution_sdk_python.serdes import (
     SerDes,
     deserialize,
 )
-from aws_durable_execution_sdk_python.state import ExecutionState  # noqa: TCH001
 from aws_durable_execution_sdk_python.threading import OrderedCounter
 from aws_durable_execution_sdk_python.types import Callback as CallbackProtocol
 from aws_durable_execution_sdk_python.types import (
@@ -58,6 +57,7 @@ from aws_durable_execution_sdk_python.types import (
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
 
+    from aws_durable_execution_sdk_python.state import ExecutionState  # noqa: TCH001
     from aws_durable_execution_sdk_python.concurrency.models import BatchResult
     from aws_durable_execution_sdk_python.state import CheckpointedResult
     from aws_durable_execution_sdk_python.types import LambdaContext

--- a/src/aws_durable_execution_sdk_python/execution.py
+++ b/src/aws_durable_execution_sdk_python/execution.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import contextlib
 import functools
 import json
 import logging
@@ -25,7 +24,7 @@ from aws_durable_execution_sdk_python.lambda_service import (
     Operation,
     OperationUpdate,
 )
-from aws_durable_execution_sdk_python.state import ExecutionState, ReplayStatus
+from aws_durable_execution_sdk_python.state import ExecutionState
 
 if TYPE_CHECKING:
     from collections.abc import MutableMapping
@@ -234,11 +233,11 @@ class DurableExecutionExecutor:
         context: LambdaContext,
     ):
         self.func = func
-        self.boto3_client = boto3_client
-        self.event = event
         self.context = context
         self.invocation_input = self._parse_invocation_input(event)
         self.service_client = self._parse_service_client(event, boto3_client)
+        self.durable_execution_arn = self.invocation_input.durable_execution_arn
+        logger.debug("durableExecutionArn: %s", self.durable_execution_arn)
 
     def _parse_invocation_input(self, event: Any) -> DurableExecutionInvocationInput:
         # event likely only to be DurableExecutionInvocationInputWithClient when directly injected by test framework
@@ -262,7 +261,6 @@ class DurableExecutionExecutor:
                 # add a redundant raise to make type checker happy
                 raise ExecutionError(msg)
 
-        logger.debug("durableExecutionArn: %s", invocation_input.durable_execution_arn)
         return invocation_input
 
     @staticmethod
@@ -275,20 +273,11 @@ class DurableExecutionExecutor:
             # Use custom client if provided, otherwise initialize from environment
             return LambdaClient.initialize_client()
 
-    def execute(self):
-        execution_state: ExecutionState = ExecutionState(
-            durable_execution_arn=self.invocation_input.durable_execution_arn,
-            initial_checkpoint_token=self.invocation_input.checkpoint_token,
-            operations={},
-            service_client=self.service_client,
-            replay_status=ReplayStatus.NEW,
-        )
-
+    def execute(self) -> MutableMapping[str, Any]:
         try:
-            execution_state.fetch_paginated_operations(
-                self.invocation_input.initial_execution_state.operations,
-                self.invocation_input.checkpoint_token,
-                self.invocation_input.initial_execution_state.next_marker,
+            execution_state: ExecutionState = ExecutionState(
+                invocation_input=self.invocation_input,
+                service_client=self.service_client,
             )
         except BotoClientError as e:
             # Non-retryable Durable API errors (e.g., customer configuration issues,
@@ -303,22 +292,12 @@ class DurableExecutionExecutor:
                 exception=e, retryable=e.is_retryable()
             )
 
-        execution_state.mark_replaying_if_prior_operations_exist()
-
-        raw_input_payload: str | None = execution_state.get_input_payload()
-
-        # Python RIC LambdaMarshaller just uses standard json deserialization for event
-        # https://github.com/aws/aws-lambda-python-runtime-interface-client/blob/main/awslambdaric/lambda_runtime_marshaller.py#L46
-        input_event: MutableMapping[str, Any] = {}
-        if raw_input_payload and raw_input_payload.strip():
-            try:
-                input_event = json.loads(raw_input_payload)
-            except json.JSONDecodeError as e:
-                logger.exception(
-                    "Failed to parse input payload as JSON: payload: %r",
-                    raw_input_payload,
-                )
-                self._handle_execution_output(exception=e, retryable=True)
+        try:
+            input_event: Any = execution_state.get_input_event()
+        except json.JSONDecodeError as e:
+            self._handle_execution_output(exception=e, retryable=True)
+            # add a redundant raise to make type checker happy
+            raise e
 
         durable_context: DurableContext = DurableContext.from_lambda_context(
             state=execution_state, lambda_context=self.context
@@ -329,110 +308,101 @@ class DurableExecutionExecutor:
             ThreadPoolExecutor(
                 max_workers=2, thread_name_prefix="dex-handler"
             ) as executor,
-            contextlib.closing(execution_state) as execution_state,
         ):
             # Thread 1: Run background checkpoint processing
-            executor.submit(execution_state.checkpoint_batches_forever)
+            with execution_state.start_checkpointing(executor):
+                # Thread 2: Execute user function
+                logger.debug("%s entering user-space...", self.durable_execution_arn)
+                user_future = executor.submit(self.func, input_event, durable_context)
 
-            # Thread 2: Execute user function
-            logger.debug(
-                "%s entering user-space...", self.invocation_input.durable_execution_arn
-            )
-            user_future = executor.submit(self.func, input_event, durable_context)
+                return self._handle_user_future_result(execution_state, user_future)
 
-            logger.debug(
-                "%s waiting for user code completion...",
-                self.invocation_input.durable_execution_arn,
-            )
+    def _handle_user_future_result(self, execution_state, user_future):
+        logger.debug(
+            "%s waiting for user code completion...", self.durable_execution_arn
+        )
 
-            try:
-                # Background checkpointing errors will propagate through CompletionEvent.wait() as BackgroundThreadError
-                result = user_future.result()
+        try:
+            # Background checkpointing errors will propagate through CompletionEvent.wait() as BackgroundThreadError
+            result = user_future.result()
 
-                # done with userland
-                logger.debug(
-                    "%s exiting user-space...",
-                    self.invocation_input.durable_execution_arn,
+            # done with userland
+            logger.debug("%s exiting user-space...", self.durable_execution_arn)
+            serialized_result = self._handle_large_result(execution_state, result)
+
+            return self._handle_execution_output(result=serialized_result)
+
+        except BackgroundThreadError as bg_error:
+            # Background checkpoint system failed - propagated through CompletionEvent
+            # Do not attempt to checkpoint anything, just terminate immediately
+            cause = bg_error.source_exception
+
+            if isinstance(cause, BotoClientError):
+                logger.exception(
+                    "Checkpoint processing failed",
+                    extra=cause.build_logger_extras(),
                 )
-                serialized_result = self._handle_large_result(execution_state, result)
-
-                return self._handle_execution_output(result=serialized_result)
-
-            except BackgroundThreadError as bg_error:
-                # Background checkpoint system failed - propagated through CompletionEvent
-                # Do not attempt to checkpoint anything, just terminate immediately
-                cause = bg_error.source_exception
-
-                if isinstance(cause, BotoClientError):
+                # Non-retryable Durable API errors (e.g., customer configuration issues,
+                # 4xx client errors) will never succeed on retry — fail the execution immediately.
+                if not cause.is_retryable():
                     logger.exception(
-                        "Checkpoint processing failed",
+                        "Non-retryable Durable API error from background thread. Must fail execution "
+                        "without retry.",
                         extra=cause.build_logger_extras(),
                     )
-                    # Non-retryable Durable API errors (e.g., customer configuration issues,
-                    # 4xx client errors) will never succeed on retry — fail the execution immediately.
-                    if not cause.is_retryable():
-                        logger.exception(
-                            "Non-retryable Durable API error from background thread. Must fail execution "
-                            "without retry.",
-                            extra=cause.build_logger_extras(),
-                        )
-                else:
-                    logger.exception("Checkpoint processing failed")
+            else:
+                logger.exception("Checkpoint processing failed")
 
-                retryable = (
-                    not isinstance(cause, BotoClientError) or cause.is_retryable()
-                )
-                return self._handle_execution_output(
-                    exception=cause, retryable=retryable
-                )
+            retryable = not isinstance(cause, BotoClientError) or cause.is_retryable()
+            return self._handle_execution_output(exception=cause, retryable=retryable)
 
-            except SuspendExecution:
-                # User code suspended - stop background checkpointing thread
-                logger.debug("Suspending execution...")
-                return self._handle_execution_output(status=InvocationStatus.PENDING)
+        except SuspendExecution:
+            # User code suspended - stop background checkpointing thread
+            logger.debug("Suspending execution...")
+            return self._handle_execution_output(status=InvocationStatus.PENDING)
 
-            except CheckpointError as e:
-                # Checkpoint system is broken - stop background thread and exit immediately
+        except CheckpointError as e:
+            # Checkpoint system is broken - stop background thread and exit immediately
+            logger.exception(
+                "Checkpoint system failed",
+                extra=e.build_logger_extras(),
+            )
+            # Terminate Lambda invocation immediately and have it be retried if retryable
+            return self._handle_execution_output(
+                exception=e, retryable=e.is_retryable()
+            )
+        except InvocationError as e:
+            if e.is_retryable():
+                logger.exception("Invocation error. Must terminate.")
+            else:
+                # Non-retryable Durable API errors (e.g., customer configuration issues,
+                # 4xx client errors) will never succeed on retry — fail the execution immediately.
                 logger.exception(
-                    "Checkpoint system failed",
-                    extra=e.build_logger_extras(),
+                    "Non-retryable Durable API error. Must fail execution without retry.",
+                    extra=e.build_logger_extras(),  # type: ignore[attr-defined]
                 )
+            return self._handle_execution_output(
+                exception=e, retryable=e.is_retryable()
+            )
+        except ExecutionError as e:
+            logger.exception("Execution error. Must fail execution without retry.")
+            return self._handle_execution_output(exception=e)
+        except Exception as e:
+            # all user-space errors go here
+            logger.exception("Execution failed")
+
+            try:
+                error = self._handle_large_error(execution_state, exception=e)
+            except CheckpointError as e:
                 # Terminate Lambda invocation immediately and have it be retried if retryable
                 return self._handle_execution_output(
                     exception=e, retryable=e.is_retryable()
                 )
-            except InvocationError as e:
-                if e.is_retryable():
-                    logger.exception("Invocation error. Must terminate.")
-                else:
-                    # Non-retryable Durable API errors (e.g., customer configuration issues,
-                    # 4xx client errors) will never succeed on retry — fail the execution immediately.
-                    logger.exception(
-                        "Non-retryable Durable API error. Must fail execution without retry.",
-                        extra=e.build_logger_extras(),  # type: ignore[attr-defined]
-                    )
-                return self._handle_execution_output(
-                    exception=e, retryable=e.is_retryable()
-                )
-            except ExecutionError as e:
-                logger.exception("Execution error. Must fail execution without retry.")
-                return self._handle_execution_output(exception=e)
-            except Exception as e:
-                # all user-space errors go here
-                logger.exception("Execution failed")
 
-                try:
-                    error = self._handle_large_error(execution_state, exception=e)
-                except CheckpointError as e:
-                    # Terminate Lambda invocation immediately and have it be retried if retryable
-                    return self._handle_execution_output(
-                        exception=e, retryable=e.is_retryable()
-                    )
-
-                # fail without an ErrorObject
-                return self._handle_execution_output(
-                    status=InvocationStatus.FAILED, error=error
-                )
+            # fail with user's error
+            return self._handle_execution_output(
+                status=InvocationStatus.FAILED, error=error
+            )
 
     @staticmethod
     def _handle_large_result(execution_state: ExecutionState, result: Any) -> str:

--- a/src/aws_durable_execution_sdk_python/state.py
+++ b/src/aws_durable_execution_sdk_python/state.py
@@ -7,10 +7,12 @@ import logging
 import queue
 import threading
 import time
+from concurrent.futures import Executor
+from contextlib import contextmanager
 from dataclasses import dataclass
 from enum import Enum
 from threading import Lock
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from aws_durable_execution_sdk_python.exceptions import (
     BackgroundThreadError,
@@ -29,12 +31,18 @@ from aws_durable_execution_sdk_python.lambda_service import (
     OperationType,
     OperationUpdate,
     StateOutput,
+    CheckpointUpdatedExecutionState,
 )
 from aws_durable_execution_sdk_python.threading import CompletionEvent, OrderedLock
 
 if TYPE_CHECKING:
     import datetime
     from collections.abc import MutableMapping
+
+    from aws_durable_execution_sdk_python.execution import (
+        InitialExecutionState,
+        DurableExecutionInvocationInput,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -225,16 +233,13 @@ class ExecutionState:
 
     def __init__(
         self,
-        durable_execution_arn: str,
-        initial_checkpoint_token: str,
-        operations: MutableMapping[str, Operation],
+        invocation_input: DurableExecutionInvocationInput,
         service_client: DurableServiceClient,
         batcher_config: CheckpointBatcherConfig | None = None,
-        replay_status: ReplayStatus = ReplayStatus.NEW,
     ):
-        self.durable_execution_arn: str = durable_execution_arn
-        self._current_checkpoint_token: str = initial_checkpoint_token
-        self.operations: MutableMapping[str, Operation] = operations
+        self.durable_execution_arn: str = invocation_input.durable_execution_arn
+        self._current_checkpoint_token: str = invocation_input.checkpoint_token
+        self.operations: MutableMapping[str, Operation] = {}
         self._service_client: DurableServiceClient = service_client
         self._ordered_checkpoint_lock: OrderedLock = OrderedLock()
         self._operations_lock: Lock = Lock()
@@ -258,24 +263,25 @@ class ExecutionState:
 
         # Protects parent_to_children and parent_done
         self._parent_done_lock: Lock = Lock()
-        self._replay_status: ReplayStatus = replay_status
         self._replay_status_lock: Lock = Lock()
         self._visited_operations: set[str] = set()
 
+        # fetch initial operations
+        self.fetch_paginated_operations(invocation_input.initial_execution_state)
+        self._replay_status: ReplayStatus = (
+            ReplayStatus.REPLAY if len(self.operations) > 1 else ReplayStatus.NEW
+        )
+
     def fetch_paginated_operations(
         self,
-        initial_operations: list[Operation],
-        checkpoint_token: str,
-        next_marker: str | None,
+        execution_state: InitialExecutionState | CheckpointUpdatedExecutionState,
     ) -> None:
         """Add initial operations and fetch all paginated operations from the Durable Functions API. This method is thread_safe.
 
         The checkpoint_token is passed explicitly as a parameter rather than using the instance variable to ensure thread safety.
 
         Args:
-            initial_operations: initial operations to be added to ExecutionState
-            checkpoint_token: checkpoint token used to call Durable Functions API.
-            next_marker: a marker indicates that there are paginated operations.
+            execution_state: InitialExecutionState | CheckpointUpdatedExecutionState - the initial execution state or the execution state returned from checkpoint API
 
         Raises:
             GetExecutionStateError: If the API call fails. The error is logged
@@ -284,13 +290,14 @@ class ExecutionState:
                 based on is_retryable().
         """
         all_operations: list[Operation] = (
-            initial_operations.copy() if initial_operations else []
+            execution_state.operations.copy() if execution_state.operations else []
         )
+        next_marker = execution_state.next_marker
         try:
             while next_marker:
                 output: StateOutput = self._service_client.get_execution_state(
                     durable_execution_arn=self.durable_execution_arn,
-                    checkpoint_token=checkpoint_token,
+                    checkpoint_token=self._current_checkpoint_token,
                     next_marker=next_marker,
                 )
                 all_operations.extend(output.operations)
@@ -308,6 +315,23 @@ class ExecutionState:
                     self.operations.update(
                         {op.operation_id: op for op in all_operations}
                     )
+
+    def get_input_event(self) -> Any:
+        """Get the input event from the execution operation."""
+        # Python RIC LambdaMarshaller just uses standard json deserialization for event
+        # https://github.com/aws/aws-lambda-python-runtime-interface-client/blob/main/awslambdaric/lambda_runtime_marshaller.py#L46
+        raw_input_payload = self.get_input_payload()
+        if raw_input_payload and raw_input_payload.strip():
+            try:
+                return json.loads(raw_input_payload)
+            except json.JSONDecodeError:
+                logger.exception(
+                    "Failed to parse input payload as JSON: payload: %r",
+                    raw_input_payload,
+                )
+                raise
+
+        return {}
 
     def get_input_payload(self) -> str | None:
         # It is possible that backend will not provide an execution operation
@@ -378,18 +402,6 @@ class ExecutionState:
         """
         with self._replay_status_lock:
             return self._replay_status is ReplayStatus.REPLAY
-
-    def mark_replaying_if_prior_operations_exist(self) -> None:
-        """Mark execution state as replaying when non-execution operations exist."""
-        with self._operations_lock:
-            has_prior_operations: bool = any(
-                op.operation_type is not OperationType.EXECUTION
-                for op in self.operations.values()
-            )
-
-        if has_prior_operations:
-            with self._replay_status_lock:
-                self._replay_status = ReplayStatus.REPLAY
 
     def get_checkpoint_result(self, checkpoint_id: str) -> CheckpointedResult:
         """Get checkpoint result.
@@ -682,11 +694,7 @@ class ExecutionState:
                     current_checkpoint_token = output.checkpoint_token
 
                     # Fetch new operations from the API before unblocking sync waiters
-                    self.fetch_paginated_operations(
-                        output.new_execution_state.operations,
-                        output.checkpoint_token,
-                        output.new_execution_state.next_marker,
-                    )
+                    self.fetch_paginated_operations(output.new_execution_state)
 
                     # Signal completion for any synchronous operations
                     for queued_op in batch:
@@ -894,5 +902,12 @@ class ExecutionState:
         serialized = json.dumps(queued_op.operation_update.to_dict()).encode("utf-8")
         return len(serialized)
 
-    def close(self):
-        self.stop_checkpointing()
+    @contextmanager
+    def start_checkpointing(self, executor: Executor):
+        # start checkpointing
+        executor.submit(self.checkpoint_batches_forever)
+        try:
+            yield self
+        finally:
+            # stop checkpointing
+            self.stop_checkpointing()

--- a/tests/e2e/map_with_concurrent_waits_int_test.py
+++ b/tests/e2e/map_with_concurrent_waits_int_test.py
@@ -33,7 +33,10 @@ from __future__ import annotations
 import threading
 from concurrent.futures import ThreadPoolExecutor
 
-
+from aws_durable_execution_sdk_python.execution import (
+    DurableExecutionInvocationInput,
+    InitialExecutionState,
+)
 from aws_durable_execution_sdk_python.lambda_service import (
     CheckpointOutput,
     CheckpointUpdatedExecutionState,
@@ -63,9 +66,11 @@ def _make_state(
         max_batch_operations=max_ops,
     )
     return ExecutionState(
-        durable_execution_arn="test-arn",
-        initial_checkpoint_token="token-0",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test-arn",
+            checkpoint_token="token-0",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_client,
         batcher_config=config,
     )

--- a/tests/logger_test.py
+++ b/tests/logger_test.py
@@ -4,6 +4,10 @@ import logging
 from collections.abc import Mapping
 from unittest.mock import Mock
 
+from aws_durable_execution_sdk_python.execution import (
+    DurableExecutionInvocationInput,
+    InitialExecutionState,
+)
 from aws_durable_execution_sdk_python.identifier import OperationIdentifier
 from aws_durable_execution_sdk_python.lambda_service import (
     Operation,
@@ -79,9 +83,11 @@ class PowertoolsLoggerStub:
 
 
 EXECUTION_STATE = ExecutionState(
-    durable_execution_arn="arn:aws:test",
-    initial_checkpoint_token="test_token",  # noqa: S106
-    operations={},
+    invocation_input=DurableExecutionInvocationInput(
+        checkpoint_token="test_token",  # noqa: S106
+        durable_execution_arn="arn:aws:test",
+        initial_execution_state=InitialExecutionState([], ""),
+    ),
     service_client=Mock(),
 )
 
@@ -223,9 +229,11 @@ def test_logger_with_log_info():
     logger = Logger.from_log_info(mock_logger, original_info)
 
     execution_state_new = ExecutionState(
-        durable_execution_arn="arn:aws:new",
-        initial_checkpoint_token="test_token",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="arn:aws:new",
+            checkpoint_token="test_token",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=Mock(),
     )
     new_info = LogInfo(execution_state_new, "parent2", "op123", "new_name")
@@ -366,17 +374,23 @@ def test_logger_without_mocked_logger():
 
 
 def test_logger_replay_no_logging():
+    execution = Operation(
+        operation_id="test",
+        operation_type=OperationType.EXECUTION,
+        status=OperationStatus.STARTED,
+    )
     operation = Operation(
         operation_id="op1",
         operation_type=OperationType.STEP,
         status=OperationStatus.SUCCEEDED,
     )
     replay_execution_state = ExecutionState(
-        durable_execution_arn="arn:aws:test",
-        initial_checkpoint_token="test_token",  # noqa: S106
-        operations={"op1": operation},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="arn:aws:new/test",
+            checkpoint_token="test_token",  # noqa: S106
+            initial_execution_state=InitialExecutionState([execution, operation], ""),
+        ),
         service_client=Mock(),
-        replay_status=ReplayStatus.REPLAY,
     )
     log_info = LogInfo(replay_execution_state, "parent123", "test_name", 5)
     mock_logger = Mock()
@@ -399,11 +413,12 @@ def test_logger_replay_then_new_logging():
         status=OperationStatus.SUCCEEDED,
     )
     execution_state = ExecutionState(
-        durable_execution_arn="arn:aws:test",
-        initial_checkpoint_token="test_token",  # noqa: S106
-        operations={"op1": operation1, "op2": operation2},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="arn:aws:new",
+            checkpoint_token="test_token",  # noqa: S106
+            initial_execution_state=InitialExecutionState([operation1, operation2], ""),
+        ),
         service_client=Mock(),
-        replay_status=ReplayStatus.REPLAY,
     )
     log_info = LogInfo(execution_state, "parent123", "test_name", 5)
     mock_logger = Mock()

--- a/tests/state_test.py
+++ b/tests/state_test.py
@@ -20,6 +20,10 @@ from aws_durable_execution_sdk_python.exceptions import (
     GetExecutionStateError,
     OrphanedChildException,
 )
+from aws_durable_execution_sdk_python.execution import (
+    DurableExecutionInvocationInput,
+    InitialExecutionState,
+)
 from aws_durable_execution_sdk_python.identifier import OperationIdentifier
 from aws_durable_execution_sdk_python.lambda_service import (
     CallbackDetails,
@@ -36,6 +40,7 @@ from aws_durable_execution_sdk_python.lambda_service import (
     OperationUpdate,
     StateOutput,
     StepDetails,
+    ExecutionDetails,
 )
 from aws_durable_execution_sdk_python.state import (
     CheckpointBatcherConfig,
@@ -386,9 +391,11 @@ def test_execution_state_creation():
     """Test ExecutionState creation."""
     mock_lambda_client = Mock(spec=LambdaClient)
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="test_token",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="test_token",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
     )
     assert state.durable_execution_arn == "test_arn"
@@ -406,9 +413,11 @@ def test_get_checkpoint_result_success_with_result():
         step_details=step_details,
     )
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={"op1": operation},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([operation], ""),
+        ),
         service_client=mock_lambda_client,
     )
 
@@ -427,9 +436,11 @@ def test_get_checkpoint_result_success_without_step_details():
         status=OperationStatus.SUCCEEDED,
     )
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={"op1": operation},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([operation], ""),
+        ),
         service_client=mock_lambda_client,
     )
 
@@ -448,9 +459,11 @@ def test_get_checkpoint_result_operation_not_succeeded():
         status=OperationStatus.FAILED,
     )
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={"op1": operation},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([operation], ""),
+        ),
         service_client=mock_lambda_client,
     )
 
@@ -464,9 +477,11 @@ def test_get_checkpoint_result_operation_not_found():
     """Test get_checkpoint_result with nonexistent operation."""
     mock_lambda_client = Mock(spec=LambdaClient)
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
     )
 
@@ -481,9 +496,11 @@ def test_create_checkpoint():
     mock_lambda_client = Mock(spec=LambdaClient)
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
     )
 
@@ -511,9 +528,11 @@ def test_create_checkpoint_with_none():
     mock_lambda_client = Mock(spec=LambdaClient)
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
     )
 
@@ -535,9 +554,11 @@ def test_create_checkpoint_with_no_args():
     mock_lambda_client = Mock(spec=LambdaClient)
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
     )
 
@@ -563,9 +584,11 @@ def test_get_checkpoint_result_started():
         status=OperationStatus.STARTED,
     )
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={"op1": operation},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([operation], ""),
+        ),
         service_client=mock_lambda_client,
     )
 
@@ -656,22 +679,21 @@ def test_fetch_paginated_operations_with_marker():
     mock_lambda_client.get_execution_state.side_effect = mock_get_execution_state
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="test_token",  # noqa: S106
+            initial_execution_state=InitialExecutionState(
+                [
+                    Operation(
+                        operation_id="0",
+                        operation_type=OperationType.STEP,
+                        status=OperationStatus.STARTED,
+                    )
+                ],
+                "marker1",
+            ),
+        ),
         service_client=mock_lambda_client,
-    )
-
-    state.fetch_paginated_operations(
-        initial_operations=[
-            Operation(
-                operation_id="0",
-                operation_type=OperationType.STEP,
-                status=OperationStatus.STARTED,
-            )
-        ],
-        checkpoint_token="test_token",  # noqa: S106
-        next_marker="marker1",
     )
 
     assert mock_lambda_client.get_execution_state.call_count == 3
@@ -753,30 +775,29 @@ def test_fetch_paginated_operations_stores_partial_results_on_error():
 
     mock_lambda_client.get_execution_state.side_effect = mock_get_execution_state
 
-    state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
-        service_client=mock_lambda_client,
-    )
-
     with pytest.raises(GetExecutionStateError):
-        state.fetch_paginated_operations(
-            initial_operations=[
-                Operation(
-                    operation_id="0",
-                    operation_type=OperationType.STEP,
-                    status=OperationStatus.STARTED,
-                )
-            ],
-            checkpoint_token="test_token",  # noqa: S106
-            next_marker="marker1",
+        state = ExecutionState(
+            DurableExecutionInvocationInput(
+                durable_execution_arn="test_arn",
+                checkpoint_token="test_token",  # noqa: S106
+                initial_execution_state=InitialExecutionState(
+                    [
+                        Operation(
+                            operation_id="0",
+                            operation_type=OperationType.STEP,
+                            status=OperationStatus.STARTED,
+                        )
+                    ],
+                    "marker1",
+                ),
+            ),
+            service_client=mock_lambda_client,
         )
 
-    # Initial operation + page 1 should be stored despite page 2 failing
-    assert "0" in state.operations
-    assert "1" in state.operations
-    assert len(state.operations) == 2
+        # Initial operation + page 1 should be stored despite page 2 failing
+        assert "0" in state.operations
+        assert "1" in state.operations
+        assert len(state.operations) == 2
 
 
 def test_fetch_paginated_operations_logs_error(caplog):
@@ -791,21 +812,17 @@ def test_fetch_paginated_operations_logs_error(caplog):
     )
     mock_lambda_client.get_execution_state.side_effect = error
 
-    state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
-        service_client=mock_lambda_client,
-    )
-
     with pytest.raises(GetExecutionStateError):
-        state.fetch_paginated_operations(
-            initial_operations=[],
-            checkpoint_token="test_token",  # noqa: S106
-            next_marker="marker1",
+        state = ExecutionState(
+            DurableExecutionInvocationInput(
+                durable_execution_arn="test_arn",
+                checkpoint_token="test_token",  # noqa: S106
+                initial_execution_state=InitialExecutionState([], "marker1"),
+            ),
+            service_client=mock_lambda_client,
         )
 
-    assert "Durable API error during state fetch." in caplog.text
+        assert "Durable API error during state fetch." in caplog.text
 
 
 # ============================================================================
@@ -901,9 +918,11 @@ def test_checkpoint_batch_respects_default_max_items_limit():
     )
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
         batcher_config=config,
     )
@@ -969,9 +988,11 @@ def test_collect_checkpoint_batch_respects_size_limit():
     )
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
         batcher_config=config,
     )
@@ -1002,9 +1023,11 @@ def test_collect_checkpoint_batch_uses_overflow_queue():
     mock_lambda_client = Mock(spec=LambdaClient)
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
     )
 
@@ -1053,9 +1076,11 @@ def test_collect_checkpoint_batch_handles_empty_checkpoint():
     mock_lambda_client = Mock(spec=LambdaClient)
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
     )
 
@@ -1088,9 +1113,11 @@ def test_collect_checkpoint_batch_returns_empty_when_stopped():
     mock_lambda_client = Mock(spec=LambdaClient)
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
     )
 
@@ -1109,9 +1136,11 @@ def test_parent_child_relationship_building():
     mock_lambda_client = Mock(spec=LambdaClient)
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
     )
 
@@ -1150,9 +1179,11 @@ def test_descendant_cancellation_when_parent_completes():
     mock_lambda_client = Mock(spec=LambdaClient)
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
     )
 
@@ -1189,9 +1220,11 @@ def test_rejection_of_operations_from_completed_parents():
     mock_lambda_client = Mock(spec=LambdaClient)
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
     )
 
@@ -1238,9 +1271,11 @@ def test_nested_parallel_operations_deep_hierarchy():
     mock_lambda_client = Mock(spec=LambdaClient)
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
     )
 
@@ -1294,9 +1329,11 @@ def test_synchronous_checkpoint_blocks_until_complete():
     )
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
     )
 
@@ -1342,9 +1379,11 @@ def test_concurrent_access_to_operations_dictionary():
     mock_lambda_client = Mock(spec=LambdaClient)
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
     )
 
@@ -1411,9 +1450,11 @@ def test_stop_checkpointing_signals_background_thread():
     mock_lambda_client = Mock(spec=LambdaClient)
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
     )
 
@@ -1504,9 +1545,11 @@ def test_create_checkpoint_sync_with_parent_id():
     mock_lambda_client = Mock(spec=LambdaClient)
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
     )
 
@@ -1555,9 +1598,11 @@ def test_create_checkpoint_sync_rejects_orphaned_operation():
     mock_lambda_client = Mock(spec=LambdaClient)
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
     )
 
@@ -1619,9 +1664,11 @@ def test_mark_orphans_handles_cycles():
     mock_lambda_client = Mock(spec=LambdaClient)
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
     )
 
@@ -1649,9 +1696,11 @@ def test_checkpoint_batches_forever_exception_handling():
     mock_lambda_client.checkpoint.side_effect = RuntimeError("API error")
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
     )
 
@@ -1696,9 +1745,11 @@ def test_collect_checkpoint_batch_shutdown_path():
     mock_lambda_client = Mock(spec=LambdaClient)
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
     )
 
@@ -1725,9 +1776,11 @@ def test_collect_checkpoint_batch_shutdown_empty_queue():
     mock_lambda_client = Mock(spec=LambdaClient)
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
     )
 
@@ -1752,9 +1805,11 @@ def test_collect_checkpoint_batch_overflow_put_back():
     )
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
         batcher_config=config,
     )
@@ -1797,9 +1852,11 @@ def test_create_checkpoint_sync_with_none_operation_update():
     mock_lambda_client = Mock(spec=LambdaClient)
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
     )
 
@@ -1829,9 +1886,11 @@ def test_checkpoint_batches_forever_exception_with_no_sync_operations():
     mock_lambda_client.checkpoint.side_effect = RuntimeError("API error")
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
     )
 
@@ -1868,9 +1927,11 @@ def test_collect_checkpoint_batch_size_limit_during_time_window():
     )
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
         batcher_config=config,
     )
@@ -1921,9 +1982,11 @@ def test_collect_checkpoint_batch_respects_max_operations_limit():
     )
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
         batcher_config=config,
     )
@@ -1964,9 +2027,11 @@ def test_collect_checkpoint_batch_time_window_expires():
     )
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
         batcher_config=config,
     )
@@ -2011,9 +2076,11 @@ def test_collect_checkpoint_batch_empty_overflow_queue_path():
     mock_lambda_client = Mock(spec=LambdaClient)
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
     )
 
@@ -2048,9 +2115,11 @@ def test_collect_checkpoint_batch_overflow_queue_hits_operation_limit():
     )
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
         batcher_config=config,
     )
@@ -2087,9 +2156,11 @@ def test_collect_checkpoint_batch_overflow_queue_size_limit():
     )
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
         batcher_config=config,
     )
@@ -2136,9 +2207,11 @@ def test_checkpoint_error_signals_completion_events_with_error():
     mock_lambda_client.checkpoint.side_effect = RuntimeError("Checkpoint API error")
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
     )
 
@@ -2192,9 +2265,11 @@ def test_synchronous_caller_receives_error_on_background_thread_failure():
     mock_lambda_client.checkpoint.side_effect = RuntimeError("Background thread error")
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
     )
 
@@ -2269,9 +2344,11 @@ def test_exception_propagates_through_threadpoolexecutor():
     mock_lambda_client.checkpoint.side_effect = RuntimeError("Checkpoint API failure")
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
     )
 
@@ -2302,9 +2379,11 @@ def test_multiple_sync_operations_all_remain_blocked_on_error():
     mock_lambda_client.checkpoint.side_effect = RuntimeError("Batch processing error")
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
     )
 
@@ -2353,9 +2432,11 @@ def test_async_operations_not_affected_by_error_handling():
     mock_lambda_client.checkpoint.side_effect = RuntimeError("API error")
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
     )
 
@@ -2390,9 +2471,11 @@ def test_mixed_sync_async_operations_only_sync_blocked_on_error():
     mock_lambda_client.checkpoint.side_effect = RuntimeError("Mixed batch error")
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
     )
 
@@ -2450,9 +2533,11 @@ def test_create_checkpoint_accepts_is_sync_parameter():
     mock_lambda_client = Mock(spec=LambdaClient)
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
     )
 
@@ -2484,9 +2569,11 @@ def test_create_checkpoint_default_is_sync_true():
     mock_lambda_client = Mock(spec=LambdaClient)
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
     )
 
@@ -2530,9 +2617,11 @@ def test_create_checkpoint_explicit_is_sync_true():
     mock_lambda_client = Mock(spec=LambdaClient)
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
     )
 
@@ -2571,9 +2660,11 @@ def test_create_checkpoint_is_sync_false_no_completion_event():
     mock_lambda_client = Mock(spec=LambdaClient)
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
     )
 
@@ -2601,9 +2692,11 @@ def test_create_checkpoint_is_sync_false_returns_immediately():
     mock_lambda_client = Mock(spec=LambdaClient)
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
     )
 
@@ -2639,9 +2732,11 @@ def test_create_checkpoint_with_none_defaults_to_sync():
     mock_lambda_client = Mock(spec=LambdaClient)
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
     )
 
@@ -2675,9 +2770,11 @@ def test_create_checkpoint_no_args_defaults_to_sync():
     mock_lambda_client = Mock(spec=LambdaClient)
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
     )
 
@@ -2714,9 +2811,11 @@ def test_collect_checkpoint_batch_overflow_queue_size_limit_final():
     )
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
         batcher_config=config,
     )
@@ -2769,9 +2868,11 @@ def test_create_checkpoint_blocks_until_completion_default():
     )
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
     )
 
@@ -2840,9 +2941,11 @@ def test_create_checkpoint_blocks_until_completion_explicit_true():
     )
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
     )
 
@@ -2911,9 +3014,11 @@ def test_create_checkpoint_completion_event_created_and_signaled():
     )
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
     )
 
@@ -2975,9 +3080,11 @@ def test_create_checkpoint_completion_event_not_signaled_on_failure():
     mock_lambda_client.checkpoint.side_effect = RuntimeError("Checkpoint failed")
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
     )
 
@@ -3061,9 +3168,11 @@ def test_create_checkpoint_caller_remains_blocked_on_background_failure():
     mock_lambda_client.checkpoint.side_effect = RuntimeError("Background failure")
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
     )
 
@@ -3143,9 +3252,11 @@ def test_create_checkpoint_multiple_sync_calls_all_block():
     )
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
     )
 
@@ -3219,9 +3330,11 @@ def test_create_checkpoint_sync_with_empty_checkpoint():
     )
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
     )
 
@@ -3277,9 +3390,11 @@ def test_create_checkpoint_sync_success():
     )
 
     state = ExecutionState(
-        durable_execution_arn="test-arn",
-        initial_checkpoint_token="initial-token",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test-arn",
+            checkpoint_token="initial-token",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_client,
     )
 
@@ -3311,9 +3426,11 @@ def test_create_checkpoint_sync_unwraps_background_thread_error():
     mock_client.checkpoint.side_effect = original_error
 
     state = ExecutionState(
-        durable_execution_arn="test-arn",
-        initial_checkpoint_token="initial-token",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test-arn",
+            checkpoint_token="initial-token",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_client,
     )
 
@@ -3344,9 +3461,11 @@ def test_create_checkpoint_sync_always_synchronous():
     )
 
     state = ExecutionState(
-        durable_execution_arn="test-arn",
-        initial_checkpoint_token="initial-token",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test-arn",
+            checkpoint_token="initial-token",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_client,
     )
 
@@ -3381,11 +3500,12 @@ def test_state_replay_mode():
         status=OperationStatus.SUCCEEDED,
     )
     execution_state = ExecutionState(
-        durable_execution_arn="arn:aws:test",
-        initial_checkpoint_token="test_token",  # noqa: S106
-        operations={"op1": operation1, "op2": operation2},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="arn:aws:test",
+            checkpoint_token="test_token",  # noqa: S106
+            initial_execution_state=InitialExecutionState([operation1, operation2], ""),
+        ),
         service_client=Mock(),
-        replay_status=ReplayStatus.REPLAY,
     )
     assert execution_state.is_replaying() is True
     execution_state.track_replay(operation_id="op1")
@@ -3414,11 +3534,12 @@ def test_state_replay_mode_with_timed_out():
         status=OperationStatus.SUCCEEDED,
     )
     execution_state = ExecutionState(
-        durable_execution_arn="arn:aws:test",
-        initial_checkpoint_token="test_token",  # noqa: S106
-        operations={"op1": operation1, "op2": operation2},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="arn:aws:test",
+            checkpoint_token="test_token",  # noqa: S106
+            initial_execution_state=InitialExecutionState([operation1, operation2], ""),
+        ),
         service_client=Mock(),
-        replay_status=ReplayStatus.REPLAY,
     )
     assert execution_state.is_replaying() is True
     execution_state.track_replay(operation_id="op1")
@@ -3445,9 +3566,11 @@ def test_collect_checkpoint_batch_coalesces_many_empty_checkpoints():
     )
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
         batcher_config=config,
     )
@@ -3478,9 +3601,11 @@ def test_collect_checkpoint_batch_empty_checkpoints_with_real_ops_respects_limit
     )
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
         batcher_config=config,
     )
@@ -3517,9 +3642,11 @@ def test_collect_checkpoint_batch_overflow_coalesces_empty_checkpoints():
     )
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
         batcher_config=config,
     )
@@ -3557,9 +3684,11 @@ def test_checkpoint_batches_forever_single_api_call_for_many_empty_checkpoints()
     )
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
         batcher_config=config,
     )
@@ -3605,9 +3734,11 @@ def test_collect_checkpoint_batch_first_empty_counts_toward_limit():
     )
 
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
         batcher_config=config,
     )
@@ -3657,9 +3788,11 @@ def test_execution_state_get_execution_operation_no_operations():
         max_batch_operations=2,
     )
     state = ExecutionState(
-        durable_execution_arn="test_arn",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn",
+            checkpoint_token="token123",  # noqa: S106
+            initial_execution_state=InitialExecutionState([], ""),
+        ),
         service_client=mock_lambda_client,
         batcher_config=config,
     )
@@ -3688,9 +3821,11 @@ def test_initial_execution_state_get_execution_operation_wrong_type():
         max_batch_operations=2,
     )
     state = ExecutionState(
-        durable_execution_arn="test_arn/step1",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={"step1": operation},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="test_arn/step1",
+            checkpoint_token="test_token",  # noqa: S106
+            initial_execution_state=InitialExecutionState([operation], ""),
+        ),
         service_client=mock_lambda_client,
         batcher_config=config,
     )
@@ -3711,10 +3846,35 @@ def test_initial_execution_state_get_input_payload_none():
         execution_details=None,
     )
 
+    mock_lambda_client = Mock(spec=LambdaClient)
+    config = CheckpointBatcherConfig(
+        max_batch_size_bytes=10 * 1024 * 1024,
+        max_batch_time_seconds=10.0,
+        max_batch_operations=2,
+    )
+    state = ExecutionState(
+        DurableExecutionInvocationInput(
+            durable_execution_arn="arn:aws:test/exec1",
+            checkpoint_token="test_token",  # noqa: S106
+            initial_execution_state=InitialExecutionState([operation], ""),
+        ),
+        service_client=mock_lambda_client,
+        batcher_config=config,
+    )
+
+    result = state.get_input_payload()
+    assert result is None
+
+
+def test_initial_execution_state_get_input_payload():
+    """Test get_input_payload returns None when execution_details is None."""
+    event = {"name": "world"}
+    event_str = json.dumps(event)
     operation = Operation(
-        operation_id="step1",
-        operation_type=OperationType.STEP,
+        operation_id="exec1",
+        operation_type=OperationType.EXECUTION,
         status=OperationStatus.STARTED,
+        execution_details=ExecutionDetails(input_payload=event_str),
     )
 
     mock_lambda_client = Mock(spec=LambdaClient)
@@ -3724,12 +3884,48 @@ def test_initial_execution_state_get_input_payload_none():
         max_batch_operations=2,
     )
     state = ExecutionState(
-        durable_execution_arn="test_arn/exec1",
-        initial_checkpoint_token="token123",  # noqa: S106
-        operations={"step1": operation},
+        DurableExecutionInvocationInput(
+            durable_execution_arn="arn:aws:test/exec1",
+            checkpoint_token="test_token",  # noqa: S106
+            initial_execution_state=InitialExecutionState([operation], ""),
+        ),
         service_client=mock_lambda_client,
         batcher_config=config,
     )
 
     result = state.get_input_payload()
-    assert result is None
+    assert result == event_str
+
+    assert state.get_input_event() == event
+
+
+def test_initial_execution_state_get_input_invalid_payload():
+    """Test get_input_payload returns None when execution_details is None."""
+    operation = Operation(
+        operation_id="exec1",
+        operation_type=OperationType.EXECUTION,
+        status=OperationStatus.STARTED,
+        execution_details=ExecutionDetails(input_payload="invalid"),
+    )
+
+    mock_lambda_client = Mock(spec=LambdaClient)
+    config = CheckpointBatcherConfig(
+        max_batch_size_bytes=10 * 1024 * 1024,
+        max_batch_time_seconds=10.0,
+        max_batch_operations=2,
+    )
+    state = ExecutionState(
+        DurableExecutionInvocationInput(
+            durable_execution_arn="arn:aws:test/exec1",
+            checkpoint_token="test_token",  # noqa: S106
+            initial_execution_state=InitialExecutionState([operation], ""),
+        ),
+        service_client=mock_lambda_client,
+        batcher_config=config,
+    )
+
+    result = state.get_input_payload()
+    assert result == "invalid"
+
+    with pytest.raises(json.JSONDecodeError):
+        state.get_input_event()


### PR DESCRIPTION
*Issue #, if available:*

- refactoring for #376 
- follow-up of #377 

*Description of changes:*

- Move replay status initialization into ExecutionState
- Move input parsing into ExecutionState
- Split giant `execute()` into smaller pieces

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
