### PR TITLE
Add Lambda bundled runtime useragent header

### DIFF
--- a/src/aws_durable_execution_sdk_python/lambda_service.py
+++ b/src/aws_durable_execution_sdk_python/lambda_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import datetime
 import logging
+import os
 from collections.abc import MutableMapping
 from dataclasses import dataclass, field
 from enum import Enum
@@ -32,6 +33,8 @@ if TYPE_CHECKING:
 ReplayChildren: TypeAlias = bool
 OperationPayload: TypeAlias = str
 TimeoutSeconds: TypeAlias = int
+
+_IS_RUNTIME_BUNDLED: bool = os.path.dirname(__file__).startswith("/var/lang")
 
 logger = logging.getLogger(__name__)
 
@@ -1061,7 +1064,7 @@ class LambdaClient(DurableServiceClient):
                 config=Config(
                     connect_timeout=5,
                     read_timeout=50,
-                    user_agent_extra=f"aws-durable-execution-sdk-python/{__version__}",
+                    user_agent_extra=f"aws-durable-execution-sdk-python/{__version__}{'-bundled' if _IS_RUNTIME_BUNDLED else ''}",
                 ),
             )
         return cls(client=cls._cached_boto_client)

--- a/src/aws_durable_execution_sdk_python/lambda_service.py
+++ b/src/aws_durable_execution_sdk_python/lambda_service.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import copy
 import datetime
 import logging
-import os
 from collections.abc import MutableMapping
 from dataclasses import dataclass, field
 from enum import Enum
@@ -34,9 +33,16 @@ ReplayChildren: TypeAlias = bool
 OperationPayload: TypeAlias = str
 TimeoutSeconds: TypeAlias = int
 
-_IS_RUNTIME_BUNDLED: bool = os.path.dirname(__file__).startswith("/var/lang")
-
 logger = logging.getLogger(__name__)
+
+
+def _is_in_var_dir(module_file: str = __file__) -> bool:
+    """Return True if this SDK is installed under /var/lang/.
+
+    Lambda bundled Python runtimes install packages at
+    /var/lang/lib/pythonX.Y/site-packages/.
+    """
+    return module_file.startswith("/var/lang/")
 
 
 # region model
@@ -1064,7 +1070,7 @@ class LambdaClient(DurableServiceClient):
                 config=Config(
                     connect_timeout=5,
                     read_timeout=50,
-                    user_agent_extra=f"aws-durable-execution-sdk-python/{__version__}{'-bundled' if _IS_RUNTIME_BUNDLED else ''}",
+                    user_agent_extra=f"aws-durable-execution-sdk-python/{__version__}{'-bundled' if _is_in_var_dir() else ''}",
                 ),
             )
         return cls(client=cls._cached_boto_client)

--- a/tests/lambda_service_test.py
+++ b/tests/lambda_service_test.py
@@ -38,6 +38,7 @@ from aws_durable_execution_sdk_python.lambda_service import (
     TimestampConverter,
     WaitDetails,
     WaitOptions,
+    _is_in_var_dir,
 )
 
 
@@ -2047,13 +2048,15 @@ def test_lambda_client_initialize_client_no_endpoint(
     assert isinstance(client, LambdaClient)
 
 
-@patch("aws_durable_execution_sdk_python.lambda_service._IS_RUNTIME_BUNDLED", True)
-@patch.dict("os.environ", {}, clear=True)
+@patch(
+    "aws_durable_execution_sdk_python.lambda_service._is_in_var_dir",
+    return_value=True,
+)
 @patch("boto3.client")
 def test_lambda_client_user_agent_runtime_bundled(
-    mock_boto_client, reset_lambda_client_cache
+    mock_boto_client, _mock_is_in_var_dir, reset_lambda_client_cache
 ):
-    """Test user agent includes -bundled when SDK is installed in Lambda runtime path."""
+    """user_agent_extra includes -bundled when SDK is in /var/lang/."""
     mock_client = Mock()
     mock_boto_client.return_value = mock_client
 
@@ -2068,13 +2071,15 @@ def test_lambda_client_user_agent_runtime_bundled(
     assert isinstance(client, LambdaClient)
 
 
-@patch("aws_durable_execution_sdk_python.lambda_service._IS_RUNTIME_BUNDLED", False)
-@patch.dict("os.environ", {}, clear=True)
+@patch(
+    "aws_durable_execution_sdk_python.lambda_service._is_in_var_dir",
+    return_value=False,
+)
 @patch("boto3.client")
 def test_lambda_client_user_agent_not_runtime_bundled(
-    mock_boto_client, reset_lambda_client_cache
+    mock_boto_client, _mock_is_in_var_dir, reset_lambda_client_cache
 ):
-    """Test user agent does not include -bundled when SDK is customer-installed."""
+    """user_agent_extra omits -bundled when SDK is not in /var/lang."""
     mock_client = Mock()
     mock_boto_client.return_value = mock_client
 
@@ -2084,6 +2089,33 @@ def test_lambda_client_user_agent_not_runtime_bundled(
     config = call_args[1]["config"]
     assert config.user_agent_extra == f"aws-durable-execution-sdk-python/{__version__}"
     assert isinstance(client, LambdaClient)
+
+
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        # Lambda bundled runtime site-packages
+        (
+            "/var/lang/lib/python3.13/site-packages/aws_durable_execution_sdk_python/lambda_service.py",
+            True,
+        ),
+        (
+            "/var/lang/lib/python3.12/site-packages/aws_durable_execution_sdk_python/lambda_service.py",
+            True,
+        ),
+        # Customer deployment package
+        ("/var/task/aws_durable_execution_sdk_python/lambda_service.py", False),
+        # Lambda Layer
+        ("/opt/python/aws_durable_execution_sdk_python/lambda_service.py", False),
+        # Trailing-slash guard: /var/langsurprise must not match
+        ("/var/langsurprise/lib/python3.13/site-packages/x.py", False),
+        # Local dev
+        ("/Users/me/project/.venv/lib/python3.12/site-packages/x.py", False),
+        ("", False),
+    ],
+)
+def test_is_in_var_dir(path, expected):
+    assert _is_in_var_dir(path) is expected
 
 
 def test_lambda_client_checkpoint_with_non_none_client_token():

--- a/tests/lambda_service_test.py
+++ b/tests/lambda_service_test.py
@@ -2047,6 +2047,45 @@ def test_lambda_client_initialize_client_no_endpoint(
     assert isinstance(client, LambdaClient)
 
 
+@patch("aws_durable_execution_sdk_python.lambda_service._IS_RUNTIME_BUNDLED", True)
+@patch.dict("os.environ", {}, clear=True)
+@patch("boto3.client")
+def test_lambda_client_user_agent_runtime_bundled(
+    mock_boto_client, reset_lambda_client_cache
+):
+    """Test user agent includes -bundled when SDK is installed in Lambda runtime path."""
+    mock_client = Mock()
+    mock_boto_client.return_value = mock_client
+
+    client = LambdaClient.initialize_client()
+
+    call_args = mock_boto_client.call_args
+    config = call_args[1]["config"]
+    assert (
+        config.user_agent_extra
+        == f"aws-durable-execution-sdk-python/{__version__}-bundled"
+    )
+    assert isinstance(client, LambdaClient)
+
+
+@patch("aws_durable_execution_sdk_python.lambda_service._IS_RUNTIME_BUNDLED", False)
+@patch.dict("os.environ", {}, clear=True)
+@patch("boto3.client")
+def test_lambda_client_user_agent_not_runtime_bundled(
+    mock_boto_client, reset_lambda_client_cache
+):
+    """Test user agent does not include -bundled when SDK is customer-installed."""
+    mock_client = Mock()
+    mock_boto_client.return_value = mock_client
+
+    client = LambdaClient.initialize_client()
+
+    call_args = mock_boto_client.call_args
+    config = call_args[1]["config"]
+    assert config.user_agent_extra == f"aws-durable-execution-sdk-python/{__version__}"
+    assert isinstance(client, LambdaClient)
+
+
 def test_lambda_client_checkpoint_with_non_none_client_token():
     """Test LambdaClient.checkpoint with non-None client_token."""
     mock_client = Mock()


### PR DESCRIPTION
- Add boolean that checks if the SDK is running in a path that matches the path used within the Lambda bundled runtime.
- Update the useragent header string to include "-bundledruntime" if the above boolean is true.

*Issue #, if available:*

N/A

*Description of changes:*

**Note:** we are waiting to confirm the Lambda bundled runtime SDK path. Do NOT merge this PR until we get confirmation.

Updating the UserAgent header string to indicate whether the SDK is being run within the Lambda bundled runtime.

- A new boolean checks if the SDK's current path matches the path where it would be installed in the Lambda bundled runtime.
- If the above boolean is true, the string inserted into the UserAgent header will include "-bundled". Example:
`aws-durable-execution-sdk-python/{version}-bundled`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
