### PR TITLE
fix: remove lowercase requirement from linter

### DIFF
--- a/.github/scripts/lintcommit.py
+++ b/.github/scripts/lintcommit.py
@@ -81,9 +81,6 @@ def validate_subject(subject_line: str) -> str | None:
     if subject.endswith("."):
         return "subject must not end with a period"
 
-    if subject != subject.lower():
-        return "subject must be lowercase"
-
     return None
 
 

--- a/.github/scripts/tests/test_lintcommit.py
+++ b/.github/scripts/tests/test_lintcommit.py
@@ -116,10 +116,6 @@ def test_subject_uppercase() -> None:
     assert validate_subject("feat: Add new feature") == "subject must be lowercase"
 
 
-def test_subject_uppercase_acronym_rejected() -> None:
-    assert validate_subject("ci: configure CI/CD") == "subject must be lowercase"
-
-
 # region validate_message
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Remove the requirement of lowercase in commit subject

Examples of valid commit subjects:

```
refactor: move replay status init into ExecutionState
fix: checkpoint START when retry a failed step
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
