### PR TITLE
ci: Skip commit lint for Dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   lint-commits:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2


### PR DESCRIPTION
*Issue #, if available:* Fixing https://github.com/aws/aws-durable-execution-sdk-python/pull/398 

*Description of changes:*
Skip the `lint-commits` CI job for Dependabot PRs since its auto-generated commit messages don't conform to conventional commit format, causing unnecessary failures on dependency update PRs.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
