### PR TITLE
chore: fast follow up on nits from monorepo pr

### DIFF
--- a/.github/scripts/ci-checks.sh
+++ b/.github/scripts/ci-checks.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -e
 

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ dist/
 
 .kiro/
 
-*/build/*
-*/*.zip
+**/build/
+**/*.zip
 
 .env

--- a/packages/aws-durable-execution-sdk-python-otel/README.md
+++ b/packages/aws-durable-execution-sdk-python-otel/README.md
@@ -2,9 +2,11 @@
 
 OpenTelemetry instrumentation for the [AWS Durable Execution SDK for Python](https://github.com/aws/aws-durable-execution-sdk-python).
 
+> **Note:** v0.1.0 reserves the package name. Instrumentation lands in v0.2.0.
+
 ## Overview
 
-This package provides automatic OpenTelemetry tracing for durable execution workflows, giving you visibility into step execution, waits, retries, and overall workflow performance.
+This package will provide automatic OpenTelemetry tracing for durable execution workflows, giving you visibility into step execution, waits, retries, and overall workflow performance.
 
 ## Installation
 
@@ -15,20 +17,12 @@ pip install aws-durable-execution-sdk-python-otel
 ## Quick Start
 
 ```python
-from aws_durable_execution_sdk_python import DurableContext, durable_execution
-from aws_durable_execution_sdk_python_otel import instrument_durable_execution
+from aws_durable_execution_sdk_python_otel import __version__
 
-# Instrument the SDK (call once at module load)
-instrument_durable_execution()
-
-@durable_execution
-def handler(event: dict, context: DurableContext) -> dict:
-    # Steps, waits, and invokes are automatically traced
-    result = context.step(lambda _: do_work(), name="my-step")
-    return {"result": result}
+print(__version__)
 ```
 
-## Features
+## Planned Features (v0.2.0)
 
 - Automatic span creation for steps, waits, invokes, and child contexts
 - Replay-aware tracing (distinguishes fresh executions from replays)

--- a/packages/aws-durable-execution-sdk-python/tests/operation/map_test.py
+++ b/packages/aws-durable-execution-sdk-python/tests/operation/map_test.py
@@ -1162,9 +1162,9 @@ def test_map_custom_serdes_serializes_batch_result():
             parent_call = mock_serialize.call_args_list[2]
             assert parent_call[1]["serdes"] is custom_serdes
             assert isinstance(parent_call[1]["value"], BatchResult)
+            assert parent_call[1]["value"] is result
     finally:
         importlib.reload(child)
-        assert parent_call[1]["value"] is result
 
 
 def test_map_with_empty_list_should_exit_early():


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1. .gitignore — Changed */build/* → **/build/ and */*.zip → **/*.zip so patterns correctly match nested paths like packages/<pkg>/build/.
2. map_test.py — Moved assert parent_call[1]["value"] is result from the finally: clause into the try block (before importlib.reload), matching the pattern in parallel_test.py.
3. README.md
 — Added a note that v0.1.0 reserves the package name, moved unimplemented features to a "Planned Features (v0.2.0)" section, and replaced the non-existent instrument_durable_execution quick start with a simple version import.
4. ci-checks.sh — Changed shebang from `#!/bin/sh` to `#!/usr/bin/env` bash since the script uses bash array syntax.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
