### PR TITLE
ci: centralize pytest configuration in root

### DIFF
--- a/packages/aws-durable-execution-sdk-python-examples/pyproject.toml
+++ b/packages/aws-durable-execution-sdk-python-examples/pyproject.toml
@@ -15,15 +15,6 @@ dependencies = [
 [tool.hatch.build.targets.wheel]
 packages = ["src"]
 
-[tool.pytest.ini_options]
-testpaths = ["test"]
-addopts = "-v --strict-markers"
-pythonpath = ["."]
-markers = [
-  "example: marks tests as example tests (deselect with '-m \"not example\"')",
-  "durable_execution: marks tests that use the durable_runner fixture (not used for test selection)",
-]
-
 [tool.hatch.envs.examples.scripts]
 cli = "python cli.py {args}"
 bootstrap = "python cli.py bootstrap"

--- a/packages/aws-durable-execution-sdk-python-otel/pyproject.toml
+++ b/packages/aws-durable-execution-sdk-python-otel/pyproject.toml
@@ -80,7 +80,3 @@ lines-after-imports = 2
   "SIM117",
   "TRY301",
 ]
-
-[tool.pytest.ini_options]
-testpaths = ["tests"]
-addopts = "-v --strict-markers"

--- a/packages/aws-durable-execution-sdk-python/pyproject.toml
+++ b/packages/aws-durable-execution-sdk-python/pyproject.toml
@@ -73,16 +73,3 @@ lines-after-imports = 2
   "SIM117",
   "TRY301",
 ]
-
-[tool.pytest.ini_options]
-# Declare custom markers to avoid warnings with --strict-markers
-markers = [
-  # Used for test selection with -m example
-  "example: marks tests as example tests (deselect with '-m \"not example\"')",
-  # Used for configuration - passes handler and lambda_function_name to durable_runner fixture
-  "durable_execution: marks tests that use the durable_runner fixture (not used for test selection)",
-]
-# Default test discovery paths
-testpaths = ["tests"]
-# Default options for all test runs
-addopts = "-v --strict-markers"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,13 +22,19 @@ cov = "pytest --cov-report=term-missing --cov {args}"
 examples-integration = "pytest --runner-mode=cloud -m example packages/aws-durable-execution-sdk-python-examples/test/ -v {args}"
 
 [tool.pytest.ini_options]
-addopts = "--import-mode=importlib"
+# Declare custom markers to avoid warnings with --strict-markers
+addopts = "-v --strict-markers --import-mode=importlib"
 testpaths = [
     "packages/aws-durable-execution-sdk-python/tests",
     "packages/aws-durable-execution-sdk-python-otel/tests",
     "packages/aws-durable-execution-sdk-python-examples/test",
 ]
-
+markers = [
+  # Used for test selection with -m example
+  "example: marks tests as example tests (deselect with '-m \"not example\"')",
+  # Used for configuration - passes handler and lambda_function_name to durable_runner fixture
+  "durable_execution: marks tests that use the durable_runner fixture (not used for test selection)",
+]
 
 [tool.hatch.envs.types]
 workspace.members = ["packages/*"]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* We are getting new warnings for unknown pytest mark when running integration tests.

> There are some warnings in the newest integration test CI workflow
packages/aws-durable-execution-sdk-python-examples/test/step/test_step.py:10
/home/runner/work/aws-durable-execution-sdk-python/aws-durable-execution-sdk-python/language-sdk/packages/aws-durable-execution-sdk-python-examples/test/step/test_step.py:10: PytestUnknownMarkWarning: Unknown pytest.mark.example - is this a typo? You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
@pytest.mark.example Is this something caused by the mono repo change? There was no warning before (e.g. test run history) - @wangyb-A

For this PR, I'm moving duplicated `[tool.pytest.ini_options]` sections from sub-package `pyproject.toml` files to the root `pyproject.toml`. All pytest runs happen from the repo root, so markers, testpaths, and addopts only need to live in the root config.

Issue accidentally introduced in https://github.com/aws/aws-durable-execution-sdk-python/pull/397/changes#r3327105014

*Testing*: I ran the `hatch run test:cov` from the project root and there are no more warnings.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
