### PR TITLE
fix(examples):parallel_first_successful update to match sdk

### DIFF
--- a/packages/aws-durable-execution-sdk-python-examples/src/parallel/parallel_first_successful.py
+++ b/packages/aws-durable-execution-sdk-python-examples/src/parallel/parallel_first_successful.py
@@ -21,7 +21,6 @@ def handler(_event: Any, context: DurableContext) -> str:
     )
 
     # Extract the first successful result
-    first_result = (
-        results.successful_results[0] if results.successful_results else "None"
-    )
+    successful = results.get_results()
+    first_result = successful[0] if successful else "None"
     return f"First successful result: {first_result}"

--- a/packages/aws-durable-execution-sdk-python-examples/test/parallel/test_parallel_first_successful.py
+++ b/packages/aws-durable-execution-sdk-python-examples/test/parallel/test_parallel_first_successful.py
@@ -1,0 +1,46 @@
+"""Tests for parallel first successful example."""
+
+import pytest
+from aws_durable_execution_sdk_python.execution import InvocationStatus
+from aws_durable_execution_sdk_python.lambda_service import OperationStatus
+from src.parallel import parallel_first_successful
+from test.conftest import deserialize_operation_payload
+
+
+@pytest.mark.example
+@pytest.mark.durable_execution(
+    handler=parallel_first_successful.handler,
+    lambda_function_name="Parallel First Successful",
+)
+def test_parallel_first_successful(durable_runner):
+    """Test parallel with first_successful completion strategy."""
+    with durable_runner:
+        result = durable_runner.run(input="test", timeout=10)
+
+    assert result.status is InvocationStatus.SUCCEEDED
+
+    result_data = deserialize_operation_payload(result.result)
+    # The handler returns a string like "First successful result: Task 1"
+    assert result_data.startswith("First successful result: ")
+    # The first successful result should be one of the tasks
+    assert result_data in [
+        "First successful result: Task 1",
+        "First successful result: Task 2",
+        "First successful result: Task 3",
+    ]
+
+    # Get the parallel operation
+    parallel_op = result.get_context("first_successful_parallel")
+    assert parallel_op is not None
+    assert parallel_op.status is OperationStatus.SUCCEEDED
+
+    # Verify child operations exist (3 branches)
+    assert len(parallel_op.child_operations) == 3
+
+    # At least one child should have succeeded
+    succeeded = [
+        op
+        for op in parallel_op.child_operations
+        if op.status is OperationStatus.SUCCEEDED
+    ]
+    assert len(succeeded) >= 1


### PR DESCRIPTION
*Issue #, if available:* #400

*Description of changes:*

`successful_results` was never formally introduced in the SDK but the example was not updated to reflect this. Using existing get_results() to fetch successful results from branches.

Added a new test to our integration tests. See successful run [here](https://github.com/aws/aws-durable-execution-sdk-python/actions/runs/26851761724/job/79185322768?pr=413#step:6:1261).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
