### PR TITLE
feat: example scripts moved to root

### DIFF
--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -58,14 +58,12 @@ jobs:
     - name: Install Hatch
       run: pip install hatch
     - name: Build examples
-      working-directory: ./packages/aws-durable-execution-sdk-python-examples
       run: |
-        hatch run -- examples:pip install -e ../aws-durable-execution-sdk-python
+        hatch run -- examples:pip install -e packages/aws-durable-execution-sdk-python
         hatch run examples:build
 
     - name: Deploy Lambda function - ${{ matrix.example.name }}
       id: deploy
-      working-directory: ./packages/aws-durable-execution-sdk-python-examples
       env:
         AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
         LAMBDA_ENDPOINT: "https://lambda.us-west-2.amazonaws.com"

--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -59,7 +59,7 @@ jobs:
       run: pip install hatch
     - name: Build examples
       run: |
-        hatch run -- examples:pip install -e packages/aws-durable-execution-sdk-python
+        hatch run -- examples:pip install -e packages/aws-durable-execution-sdk-python packages/aws-durable-execution-sdk-python-otel
         hatch run examples:build
 
     - name: Deploy Lambda function - ${{ matrix.example.name }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -97,7 +97,7 @@ jobs:
         rm -rf /tmp/aws/
 
     - name: Deploy and test examples
-      working-directory: language-sdk/packages/aws-durable-execution-sdk-python-examples
+      working-directory: language-sdk
       env:
         AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
         LAMBDA_ENDPOINT: "https://lambda.us-west-2.amazonaws.com"
@@ -105,7 +105,7 @@ jobs:
         KMS_KEY_ARN: ${{ secrets.KMS_KEY_ARN }}
       run: |
         echo "Building examples..."
-        hatch run -- examples:pip install -e ../testing-sdk
+        hatch run -- examples:pip install -e packages/testing-sdk
         hatch run examples:build
 
         # Get first integration example for testing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,8 +92,7 @@ hatch fmt
 # Build distribution
 hatch build
 
-# Examples deployment (from examples package)
-cd ../aws-durable-execution-sdk-python-examples
+# Examples deployment (from repo root)
 hatch run examples:build
 hatch run examples:deploy "Hello World"
 ```
@@ -309,7 +308,7 @@ tests/mypackage/mymodule_test.py
 ## Examples and Deployment
 
 The project includes a unified CLI tool for managing examples, deployment, and AWS account setup.
-Run these commands from the examples package directory (`packages/aws-durable-execution-sdk-python-examples`).
+Run these commands from the **repository root**.
 
 To run examples tests from the repo root:
 ```bash

--- a/packages/aws-durable-execution-sdk-python-examples/pyproject.toml
+++ b/packages/aws-durable-execution-sdk-python-examples/pyproject.toml
@@ -10,23 +10,11 @@ requires-python = ">=3.11"
 dependencies = [
   "aws-durable-execution-sdk-python",
   "aws-durable-execution-sdk-python-testing",
+  "aws-durable-execution-sdk-python-otel"
 ]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src"]
-
-[tool.hatch.envs.examples.scripts]
-cli = "python cli.py {args}"
-bootstrap = "python cli.py bootstrap"
-generate-sam-template = "python scripts/generate_sam_template.py"
-build = "python cli.py build"
-deploy = "python cli.py deploy {args}"
-invoke = "python cli.py invoke {args}"
-get = "python cli.py get {args}"
-history = "python cli.py history {args}"
-policy = "python cli.py policy {args}"
-list = "python cli.py list"
-clean = "rm -rf build .aws-sam *.zip"
 
 [tool.ruff]
 line-length = 88

--- a/packages/aws-durable-execution-sdk-python-examples/test/README.md
+++ b/packages/aws-durable-execution-sdk-python-examples/test/README.md
@@ -12,14 +12,14 @@ Tests run against the in-memory `DurableFunctionTestRunner`:
 - ✅ Validates local runner behavior
 
 ```bash
-# Run all example tests locally (default)
-hatch run test:examples
+# Run all example tests locally (default, from repo root)
+hatch run dev-examples:test
 
 # Run with explicit mode flag
-pytest --runner-mode=local -m example examples/test/
+pytest --runner-mode=local -m example packages/aws-durable-execution-sdk-python-examples/test/
 
 # Run specific test
-pytest --runner-mode=local -k test_hello_world examples/test/
+pytest --runner-mode=local -k test_hello_world packages/aws-durable-execution-sdk-python-examples/test/
 ```
 
 ### Cloud Mode (Integration)
@@ -30,7 +30,7 @@ Tests run against actual AWS Lambda functions using `DurableFunctionCloudTestRun
 - ⚠️ Requires deployed functions
 
 ```bash
-# Deploy function first
+# Deploy function first (from repo root)
 hatch run examples:deploy "hello world" --function-name HelloWorld-Test
 
 # Set environment variables for cloud testing
@@ -39,10 +39,10 @@ export LAMBDA_ENDPOINT=https://lambda.us-west-2.amazonaws.com
 export QUALIFIED_FUNCTION_NAME="HelloWorld-Test:\$LATEST"
 export LAMBDA_FUNCTION_TEST_NAME="hello world"
 
-# Run tests
-pytest --runner-mode=cloud -k test_hello_world examples/test/
+# Run tests (from repo root)
+pytest --runner-mode=cloud -k test_hello_world packages/aws-durable-execution-sdk-python-examples/test/
 
-# Or using hatch
+# Or using hatch (from repo root)
 hatch run test:examples-integration -k test_hello_world
 ```
 
@@ -116,4 +116,4 @@ result = runner.run(input="test", timeout=120)  # Increase to 120s
 
 **Solution**: Install dependencies:
 ```bash
-hatch run test:examples  # Installs dependencies automatically
+hatch run dev-examples:test  # Installs dependencies automatically

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ typecheck = "mypy --install-types --non-interactive packages/aws-durable-executi
 workspace.members = [
   "packages/aws-durable-execution-sdk-python",
   "packages/aws-durable-execution-sdk-python-examples",
+  "packages/aws-durable-execution-sdk-python-otel",
 ]
 dependencies = [
   "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,26 @@ pre-install-commands = [
 [tool.hatch.envs.test-pypi-examples.scripts]
 test = "pytest packages/aws-durable-execution-sdk-python-examples/test {args}"
 
+[tool.hatch.envs.examples]
+workspace.members = [
+  "packages/aws-durable-execution-sdk-python",
+  "packages/aws-durable-execution-sdk-python-examples",
+  "packages/aws-durable-execution-sdk-python-otel",
+]
+
+[tool.hatch.envs.examples.scripts]
+cli = "python packages/aws-durable-execution-sdk-python-examples/cli.py {args}"
+bootstrap = "python packages/aws-durable-execution-sdk-python-examples/cli.py bootstrap"
+generate-sam-template = "python packages/aws-durable-execution-sdk-python-examples/scripts/generate_sam_template.py"
+build = "python packages/aws-durable-execution-sdk-python-examples/cli.py build"
+deploy = "python packages/aws-durable-execution-sdk-python-examples/cli.py deploy {args}"
+invoke = "python packages/aws-durable-execution-sdk-python-examples/cli.py invoke {args}"
+get = "python packages/aws-durable-execution-sdk-python-examples/cli.py get {args}"
+history = "python packages/aws-durable-execution-sdk-python-examples/cli.py history {args}"
+policy = "python packages/aws-durable-execution-sdk-python-examples/cli.py policy {args}"
+list = "python packages/aws-durable-execution-sdk-python-examples/cli.py list"
+clean = "rm -rf packages/aws-durable-execution-sdk-python-examples/build packages/aws-durable-execution-sdk-python-examples/.aws-sam packages/aws-durable-execution-sdk-python-examples/*.zip"
+
 [tool.ruff]
 line-length = 88
 target-version = "py311"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Moving the scripts defined in the `aws-durable-execution-sdk-python-examples/pyproject.toml` to the root `pyproject.toml` for consistency.

Also fixing a ci bug from this [PR](https://github.com/aws/aws-durable-execution-sdk-python/actions/runs/26921643616/workflow?pr=417#L63). Frank is adding dependency on otel package to examples but our ci only installs the sdk locally. Added otel package as part of install.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
