### PR TITLE
feat: add otel layers for otel examples

### DIFF
--- a/packages/aws-durable-execution-sdk-python-examples/cli.py
+++ b/packages/aws-durable-execution-sdk-python-examples/cli.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 
 try:
     import boto3
+
     from aws_durable_execution_sdk_python.lambda_service import LambdaClient
 except ImportError:
     sys.exit(1)
@@ -326,6 +327,9 @@ def deploy_function(example_name: str, function_name: str | None = None):
         f"arn:aws:iam::{config['account_id']}:role/DurableFunctionsIntegrationTestRole"
     )
 
+    env_vars = {"AWS_ENDPOINT_URL_LAMBDA": config["lambda_endpoint"]}
+    env_vars.update(example_config.get("environment", {}))
+
     function_config = {
         "FunctionName": function_name,
         "Runtime": "python3.13",
@@ -334,12 +338,16 @@ def deploy_function(example_name: str, function_name: str | None = None):
         "Description": example_config["description"],
         "Timeout": 60,
         "MemorySize": 128,
-        "Environment": {
-            "Variables": {"AWS_ENDPOINT_URL_LAMBDA": config["lambda_endpoint"]}
-        },
+        "Environment": {"Variables": env_vars},
         "DurableConfig": example_config["durableConfig"],
         "LoggingConfig": example_config.get("loggingConfig", {}),
     }
+
+    if "layers" in example_config:
+        function_config["Layers"] = example_config["layers"]
+
+    if "tracing" in example_config:
+        function_config["TracingConfig"] = {"Mode": example_config["tracing"]}
 
     if config["kms_key_arn"]:
         function_config["KMSKeyArn"] = config["kms_key_arn"]

--- a/packages/aws-durable-execution-sdk-python-examples/examples-catalog.json
+++ b/packages/aws-durable-execution-sdk-python-examples/examples-catalog.json
@@ -634,6 +634,13 @@
         "RetentionPeriodInDays": 7,
         "ExecutionTimeout": 300
       },
+      "tracing": "Active",
+      "layers": [
+        "arn:aws:lambda:us-west-2:615299751070:layer:AWSOpenTelemetryDistroPython:32"
+      ],
+      "environment": {
+        "AWS_LAMBDA_EXEC_WRAPPER": "/opt/otel-instrument"
+      },
       "path": "./src/plugin/execution_with_otel.py"
     },
     {
@@ -648,6 +655,14 @@
       "loggingConfig": {
         "ApplicationLogLevel": "INFO",
         "LogFormat": "JSON"
+      },
+      "tracing": "Active",
+      "layers": [
+        "arn:aws:lambda:us-west-2:615299751070:layer:AWSOpenTelemetryDistroPython:32"
+      ],
+      "environment": {
+        "AWS_LAMBDA_EXEC_WRAPPER": "/opt/otel-instrument",
+        "OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED": "true"
       },
       "path": "./src/otel/otel_logger_example.py"
     }

--- a/packages/aws-durable-execution-sdk-python-examples/scripts/generate_sam_template.py
+++ b/packages/aws-durable-execution-sdk-python-examples/scripts/generate_sam_template.py
@@ -3,8 +3,6 @@
 import json
 from pathlib import Path
 
-import json
-
 
 def load_catalog():
     """Load examples catalog."""
@@ -94,6 +92,21 @@ def generate_sam_template():
             template["Resources"][function_name]["Properties"]["DurableConfig"] = (
                 example["durableConfig"]
             )
+
+        if "layers" in example:
+            template["Resources"][function_name]["Properties"]["Layers"] = example[
+                "layers"
+            ]
+
+        if "tracing" in example:
+            template["Resources"][function_name]["Properties"]["Tracing"] = example[
+                "tracing"
+            ]
+
+        if "environment" in example:
+            template["Resources"][function_name]["Properties"]["Environment"] = {
+                "Variables": example["environment"]
+            }
 
     template_path = Path(__file__).parent.parent / "template.yaml"
     with open(template_path, "w") as f:

--- a/packages/aws-durable-execution-sdk-python-examples/src/otel/otel_logger_example.py
+++ b/packages/aws-durable-execution-sdk-python-examples/src/otel/otel_logger_example.py
@@ -28,11 +28,7 @@ from aws_durable_execution_sdk_python.context import (
 from aws_durable_execution_sdk_python.execution import durable_execution
 
 
-tracer_provider = TracerProvider()
-trace.set_tracer_provider(tracer_provider)
-
-# enrich_logger defaults to True, so the execution logger is wrapped with OTel
-# trace context injection (otel.trace_id, otel.span_id, otel.trace_sampled).
+tracer_provider = trace.get_tracer_provider()
 otel = DurableExecutionOtelPlugin(tracer_provider)
 
 

--- a/packages/aws-durable-execution-sdk-python-examples/template.yaml
+++ b/packages/aws-durable-execution-sdk-python-examples/template.yaml
@@ -38,7 +38,8 @@
           ]
         },
         "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          "arn:aws:iam::aws:policy/CloudWatchLambdaApplicationSignalsExecutionRolePolicy"
         ],
         "Policies": [
           {
@@ -1043,6 +1044,16 @@
             "DurableFunctionRole",
             "Arn"
           ]
+        },
+        "Tracing": "Active",
+        "Layers": [
+          "arn:aws:lambda:us-west-2:615299751070:layer:AWSOpenTelemetryDistroPython:32" # from https://aws-otel.github.io/docs/getting-started/lambda#adot-lambda-layer-arns
+        ],
+        "Environment": {
+          "Variables": {
+            "AWS_LAMBDA_EXEC_WRAPPER": "/opt/otel-instrument",
+            "OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED": "true"
+          }
         },
         "DurableConfig": {
           "RetentionPeriodInDays": 7,

--- a/packages/aws-durable-execution-sdk-python-examples/template.yaml
+++ b/packages/aws-durable-execution-sdk-python-examples/template.yaml
@@ -38,8 +38,7 @@
           ]
         },
         "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-          "arn:aws:iam::aws:policy/CloudWatchLambdaApplicationSignalsExecutionRolePolicy"
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
         ],
         "Policies": [
           {
@@ -1030,6 +1029,15 @@
         "DurableConfig": {
           "RetentionPeriodInDays": 7,
           "ExecutionTimeout": 300
+        },
+        "Layers": [
+          "arn:aws:lambda:us-west-2:615299751070:layer:AWSOpenTelemetryDistroPython:32"
+        ],
+        "Tracing": "Active",
+        "Environment": {
+          "Variables": {
+            "AWS_LAMBDA_EXEC_WRAPPER": "/opt/otel-instrument"
+          }
         }
       }
     },
@@ -1045,19 +1053,19 @@
             "Arn"
           ]
         },
-        "Tracing": "Active",
+        "DurableConfig": {
+          "RetentionPeriodInDays": 7,
+          "ExecutionTimeout": 300
+        },
         "Layers": [
-          "arn:aws:lambda:us-west-2:615299751070:layer:AWSOpenTelemetryDistroPython:32" # from https://aws-otel.github.io/docs/getting-started/lambda#adot-lambda-layer-arns
+          "arn:aws:lambda:us-west-2:615299751070:layer:AWSOpenTelemetryDistroPython:32"
         ],
+        "Tracing": "Active",
         "Environment": {
           "Variables": {
             "AWS_LAMBDA_EXEC_WRAPPER": "/opt/otel-instrument",
             "OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED": "true"
           }
-        },
-        "DurableConfig": {
-          "RetentionPeriodInDays": 7,
-          "ExecutionTimeout": 300
         }
       }
     }


### PR DESCRIPTION
*Issue #, if available:* close #421

*Description of changes:*
- Add otel (tracing) template parameter to template and deployment script
- The hardcoded layer arn is from: https://aws-otel.github.io/docs/getting-started/lambda#aws-lambda-layer-for-opentelemetry-arns
- Fix the otel example:

<img width="1129" height="1803" alt="iShot_2026-06-16_14 17 56" src="https://github.com/user-attachments/assets/09269fce-ca97-4df7-8533-c133e2ac32f3" />
<img width="1141" height="914" alt="iShot_2026-06-16_14 18 12" src="https://github.com/user-attachments/assets/492e907b-2a6f-4ab6-a901-679ce85ed626" />

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
