### PR TITLE
fix(sdk): serialize context Error and ReplayChildren

### DIFF
--- a/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/lambda_service.py
+++ b/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/lambda_service.py
@@ -914,7 +914,14 @@ class Operation:
                 "InputPayload": self.execution_details.input_payload
             }
         if self.context_details:
-            result["ContextDetails"] = {"Result": self.context_details.result}
+            context_dict: MutableMapping[str, Any] = {
+                "Result": self.context_details.result,
+            }
+            if self.context_details.error:
+                context_dict["Error"] = self.context_details.error.to_dict()
+            if self.context_details.replay_children:
+                context_dict["ReplayChildren"] = self.context_details.replay_children
+            result["ContextDetails"] = context_dict
         if self.step_details:
             step_dict: MutableMapping[str, Any] = {"Attempt": self.step_details.attempt}
             if self.step_details.next_attempt_timestamp:

--- a/packages/aws-durable-execution-sdk-python/tests/lambda_service_test.py
+++ b/packages/aws-durable-execution-sdk-python/tests/lambda_service_test.py
@@ -2843,3 +2843,42 @@ def test_timestamp_converter_millisecond_boundaries():
 
 
 # endregion
+
+
+def test_operation_to_dict_serializes_context_error_and_replay_children():
+    """Operation.to_dict includes Error and ReplayChildren in ContextDetails."""
+    op = Operation(
+        operation_id="ctx-1",
+        operation_type=OperationType.CONTEXT,
+        status=OperationStatus.FAILED,
+        context_details=ContextDetails(
+            replay_children=True,
+            result=None,
+            error=ErrorObject(
+                message="boom",
+                type="ChildContextError",
+                data=None,
+                stack_trace=None,
+            ),
+        ),
+    )
+
+    context = op.to_dict()["ContextDetails"]
+
+    assert context["Error"]["ErrorType"] == "ChildContextError"
+    assert context["Error"]["ErrorMessage"] == "boom"
+    assert context["ReplayChildren"] is True
+
+
+def test_operation_to_dict_omits_absent_context_error_and_replay_children():
+    """Operation.to_dict omits Error and ReplayChildren when they are not set."""
+    op = Operation(
+        operation_id="ctx-2",
+        operation_type=OperationType.CONTEXT,
+        status=OperationStatus.SUCCEEDED,
+        context_details=ContextDetails(result='"hello"'),
+    )
+
+    context = op.to_dict()["ContextDetails"]
+
+    assert context == {"Result": '"hello"'}


### PR DESCRIPTION
### What
`Operation.to_dict` now includes `Error` and `ReplayChildren` in `ContextDetails` when they are set. It previously emitted only `Result`.

### Why
`ContextDetails.from_dict` reads `Result`, `Error`, and `ReplayChildren`, and the checkpoint update serializer writes them. `Operation.to_dict` was the only place that dropped `Error` and `ReplayChildren`, so serialized operation state did not round trip.

### Scope of impact
This does not change core SDK runtime behavior for callers. `Operation.to_dict` serializes operation state to feed a handler, which the local test runner does. Normal published SDK execution does not call it on that path. The impact is confined to the local test runner, where a serialized child context failure reconstructed as a generic error and a large payload child context lost its `ReplayChildren` marker.

### Testing
Two unit tests added in `tests/lambda_service_test.py`. One asserts `Error` and `ReplayChildren` appear when set. One asserts they are omitted when absent. Full core suite passes (1272), types clean (63 files), format clean.

Closes #477
