### PR TITLE
feat: context aware replay status

### DIFF
--- a/packages/aws-durable-execution-sdk-python-examples/examples-catalog.json
+++ b/packages/aws-durable-execution-sdk-python-examples/examples-catalog.json
@@ -292,6 +292,21 @@
       "path": "./src/logger_example/logger_example.py"
     },
     {
+      "name": "Replay Logging",
+      "description": "Demonstrating replay-aware logger de-duplication across a wait/replay boundary",
+      "handler": "replay_logging.handler",
+      "integration": true,
+      "durableConfig": {
+        "RetentionPeriodInDays": 7,
+        "ExecutionTimeout": 300
+      },
+      "loggingConfig": {
+        "ApplicationLogLevel": "INFO",
+        "LogFormat": "JSON"
+      },
+      "path": "./src/logger_example/replay_logging.py"
+    },
+    {
       "name": "Steps with Retry",
       "description": "Multiple steps with retry logic in a polling pattern",
       "handler": "steps_with_retry.handler",

--- a/packages/aws-durable-execution-sdk-python-examples/examples-catalog.json
+++ b/packages/aws-durable-execution-sdk-python-examples/examples-catalog.json
@@ -296,6 +296,21 @@
       "path": "./src/logger_example/replay_logging.py"
     },
     {
+      "name": "Replay Logging Concurrent",
+      "description": "Demonstrating per-branch replay-aware logger de-duplication across concurrent parallel branch waits",
+      "handler": "replay_logging_concurrent.handler",
+      "integration": true,
+      "durableConfig": {
+        "RetentionPeriodInDays": 7,
+        "ExecutionTimeout": 300
+      },
+      "loggingConfig": {
+        "ApplicationLogLevel": "INFO",
+        "LogFormat": "JSON"
+      },
+      "path": "./src/logger_example/replay_logging_concurrent.py"
+    },
+    {
       "name": "Steps with Retry",
       "description": "Multiple steps with retry logic in a polling pattern",
       "handler": "steps_with_retry.handler",

--- a/packages/aws-durable-execution-sdk-python-examples/src/logger_example/replay_logging.py
+++ b/packages/aws-durable-execution-sdk-python-examples/src/logger_example/replay_logging.py
@@ -1,0 +1,93 @@
+"""Example demonstrating replay-aware logging across a wait boundary."""
+
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import Duration
+from aws_durable_execution_sdk_python.context import (
+    DurableContext,
+    StepContext,
+    durable_step,
+    durable_with_child_context,
+)
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_step
+def prepare(step_context: StepContext, item: str) -> str:
+    """A step that runs before the wait.
+
+    Its log is emitted on the first invocation. On replay this step is not
+    re-executed (it returns its checkpointed result), so this log does not
+    repeat.
+    """
+    step_context.logger.info("Preparing item", extra={"item": item})
+    return f"prepared:{item}"
+
+
+@durable_step
+def finalize(step_context: StepContext, prepared: str) -> str:
+    """A step that runs after the wait (new work on the replay invocation)."""
+    step_context.logger.info("Finalizing item", extra={"prepared": prepared})
+    return f"done:{prepared}"
+
+
+@durable_with_child_context
+def audit(child_ctx: DurableContext, prepared: str) -> str:
+    """Child context with its own logger and its own replay status."""
+    child_ctx.logger.info(
+        "Auditing in child context (before child wait)",
+        extra={"prepared": prepared, "child_is_replaying": child_ctx.is_replaying()},
+    )
+
+    # The child's own replay boundary.
+    child_ctx.wait(duration=Duration.from_seconds(5), name="audit_cooldown")
+
+    # After the child's wait: emitted as new work on the child's replay.
+    child_ctx.logger.info(
+        "Resumed in child context (after child wait)",
+        extra={"child_is_replaying": child_ctx.is_replaying()},
+    )
+
+    return child_ctx.step(lambda _: f"audited:{prepared}", name="record_audit")
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> dict[str, Any]:
+    """Handler demonstrating replay-aware logging across a wait."""
+    item: str = event.get("item", "widget") if isinstance(event, dict) else "widget"
+
+    # --- Before the wait ---
+    # On the replay invocation these lines are de-duplicated by the replay-aware
+    # logger because the context is still replaying when it reaches them.
+    context.logger.info(
+        "Workflow started (before wait)",
+        extra={"item": item, "is_replaying": context.is_replaying()},
+    )
+
+    prepared: str = context.step(prepare(item), name="prepare")
+
+    context.logger.info(
+        "Prepared, about to wait",
+        extra={"prepared": prepared, "is_replaying": context.is_replaying()},
+    )
+
+    # --- The replay boundary ---
+    # The wait suspends the execution. When it resumes, the handler replays from
+    # the top; everything above is de-duplicated, and everything below is new.
+    context.wait(duration=Duration.from_seconds(5), name="cooldown")
+
+    # --- After the wait ---
+    # These logs are emitted on the replay invocation because the context has
+    # crossed its replay boundary and is no longer replaying.
+    context.logger.info(
+        "Resumed after wait",
+        extra={"is_replaying": context.is_replaying()},
+    )
+
+    audited: str = context.run_in_child_context(audit(prepared), name="audit")
+
+    result: str = context.step(finalize(audited), name="finalize")
+
+    context.logger.info("Workflow completed", extra={"result": result})
+
+    return {"result": result, "item": item}

--- a/packages/aws-durable-execution-sdk-python-examples/src/logger_example/replay_logging_concurrent.py
+++ b/packages/aws-durable-execution-sdk-python-examples/src/logger_example/replay_logging_concurrent.py
@@ -1,0 +1,83 @@
+"""Replay-aware logging across concurrent (parallel) branch replays.
+
+Each parallel branch runs in its own child context with its own replay status.
+A branch that contains a `wait` suspends and is replayed independently of the
+other branches and of the parent. This example demonstrates that the
+replay-aware logger de-duplicates per branch:
+
+- A branch's "before wait" log is emitted once (on the invocation where the
+  branch first reaches its wait) and de-duplicated on the branch's replay.
+- A branch's "after wait" log is emitted once, as new work, when that branch
+  resumes.
+- The branches stagger their waits so they resume on different invocations,
+  making the per-branch independence visible in CloudWatch.
+
+Deploy and invoke asynchronously, then inspect the logs. Each `branch` field
+identifies the emitting branch so you can confirm each line appears exactly
+once across all invocations.
+"""
+
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import Duration, ParallelConfig
+from aws_durable_execution_sdk_python.context import (
+    DurableContext,
+    durable_parallel_branch,
+)
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+def _make_branch(name: str, wait_seconds: int):
+    """Build a parallel branch that logs around its own wait boundary."""
+
+    @durable_parallel_branch(name=name)
+    def branch(ctx: DurableContext) -> str:
+        # Before the branch's wait. On this branch's replay invocation this is
+        # de-duplicated because the branch is still replaying when it reaches
+        # here. This line is the load-bearing case: there is no inner operation
+        # before it, so the branch's child context relies on starting in the
+        # correct replay status.
+        ctx.logger.info(
+            "branch start (before wait)",
+            extra={"branch": name, "is_replaying": ctx.is_replaying()},
+        )
+
+        # The branch's own replay boundary. Different per branch so the branches
+        # resume on different invocations.
+        ctx.wait(duration=Duration.from_seconds(wait_seconds), name=f"{name}_wait")
+
+        # After the branch's wait: emitted as new work on the branch's replay.
+        ctx.logger.info(
+            "branch resumed (after wait)",
+            extra={"branch": name, "is_replaying": ctx.is_replaying()},
+        )
+
+        return ctx.step(lambda _: f"{name}-done", name=f"{name}_finalize")
+
+    return branch
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> dict[str, Any]:
+    """Run concurrent branches that each log around their own wait."""
+    context.logger.info(
+        "workflow started",
+        extra={"is_replaying": context.is_replaying()},
+    )
+
+    results: list[str] = context.parallel(
+        functions=[
+            _make_branch("alpha", 3)(),
+            _make_branch("bravo", 6)(),
+            _make_branch("charlie", 9)(),
+        ],
+        name="concurrent_branches",
+        config=ParallelConfig(max_concurrency=3),
+    ).get_results()
+
+    context.logger.info(
+        "workflow completed",
+        extra={"results": results, "is_replaying": context.is_replaying()},
+    )
+
+    return {"results": results}

--- a/packages/aws-durable-execution-sdk-python-examples/template.yaml
+++ b/packages/aws-durable-execution-sdk-python-examples/template.yaml
@@ -492,6 +492,24 @@
         }
       }
     },
+    "ReplayLogging": {
+      "Type": "AWS::Serverless::Function",
+      "Properties": {
+        "CodeUri": "build/",
+        "Handler": "replay_logging.handler",
+        "Description": "Demonstrating replay-aware logger de-duplication across a wait/replay boundary",
+        "Role": {
+          "Fn::GetAtt": [
+            "DurableFunctionRole",
+            "Arn"
+          ]
+        },
+        "DurableConfig": {
+          "RetentionPeriodInDays": 7,
+          "ExecutionTimeout": 300
+        }
+      }
+    },
     "StepsWithRetry": {
       "Type": "AWS::Serverless::Function",
       "Properties": {

--- a/packages/aws-durable-execution-sdk-python-examples/template.yaml
+++ b/packages/aws-durable-execution-sdk-python-examples/template.yaml
@@ -510,6 +510,24 @@
         }
       }
     },
+    "ReplayLoggingConcurrent": {
+      "Type": "AWS::Serverless::Function",
+      "Properties": {
+        "CodeUri": "build/",
+        "Handler": "replay_logging_concurrent.handler",
+        "Description": "Demonstrating per-branch replay-aware logger de-duplication across concurrent parallel branch waits",
+        "Role": {
+          "Fn::GetAtt": [
+            "DurableFunctionRole",
+            "Arn"
+          ]
+        },
+        "DurableConfig": {
+          "RetentionPeriodInDays": 7,
+          "ExecutionTimeout": 300
+        }
+      }
+    },
     "StepsWithRetry": {
       "Type": "AWS::Serverless::Function",
       "Properties": {

--- a/packages/aws-durable-execution-sdk-python-examples/test/logger_example/test_logger_example.py
+++ b/packages/aws-durable-execution-sdk-python-examples/test/logger_example/test_logger_example.py
@@ -1,9 +1,11 @@
 """Tests for logger_example."""
 
+import logging
+
 import pytest
+
 from aws_durable_execution_sdk_python.execution import InvocationStatus
 from aws_durable_execution_sdk_python.lambda_service import OperationType
-
 from src.logger_example import logger_example
 from test.conftest import deserialize_operation_payload
 
@@ -33,3 +35,46 @@ def test_logger_example(durable_runner):
         op for op in result.operations if op.operation_type.value == "CONTEXT"
     ]
     assert len(context_ops) >= 1
+
+
+@pytest.mark.example
+@pytest.mark.durable_execution(
+    handler=logger_example.handler,
+    lambda_function_name="logger example",
+)
+def test_logger_example_emits_expected_logs(durable_runner, caplog):
+    """Verify the durable logger emits the expected messages and enriched extras.
+
+    The SDK logger wraps the stdlib root logger, so ``caplog`` captures every
+    record emitted from both the top-level context and from inside steps. Step
+    logs are enriched with the operation name and attempt number, which we
+    assert on via the LogRecord attributes.
+
+    Log capture only works in local mode (the handler runs in-process); in cloud
+    mode the handler runs in a deployed Lambda, so this test is skipped there.
+    """
+    if durable_runner.mode != "local":
+        pytest.skip("Log capture is only available in local (in-process) mode")
+
+    with caplog.at_level(logging.INFO):
+        with durable_runner:
+            result = durable_runner.run(input={"id": "test-123"}, timeout=10)
+
+    assert result.status is InvocationStatus.SUCCEEDED
+
+    messages = [record.getMessage() for record in caplog.records]
+    # Top-level context logs (no step_id) and in-step logs both appear.
+    assert "Starting workflow" in messages
+    assert "Hello from my_step" in messages
+    assert "Workflow completed" in messages
+
+    # The warning emitted inside my_step is enriched with the step's extra
+    # (my_arg) and with the operation name the SDK attaches automatically.
+    warning = next(
+        record
+        for record in caplog.records
+        if record.getMessage() == "Warning from my_step"
+    )
+    assert warning.levelno == logging.WARNING
+    assert warning.my_arg == 123
+    assert warning.operationName == "my_step"

--- a/packages/aws-durable-execution-sdk-python-examples/test/logger_example/test_replay_logging.py
+++ b/packages/aws-durable-execution-sdk-python-examples/test/logger_example/test_replay_logging.py
@@ -1,10 +1,13 @@
 """Tests for the replay_logging example.
 
-These tests do not assert on emitted log lines (the replay-aware
-de-duplication is best observed in CloudWatch after deploying). They verify the
-workflow runs end-to-end across the wait/replay boundary and produces the
-expected operations and result.
+Most assertions here verify the workflow runs end-to-end across the
+wait/replay boundary and produces the expected operations and result. One test
+additionally asserts on the replay-aware logger: messages emitted before the
+wait are de-duplicated on replay, so each appears exactly once despite the
+handler replaying from the top after the wait resumes.
 """
+
+import logging
 
 import pytest
 
@@ -50,3 +53,42 @@ def test_replay_logging(durable_runner):
         op for op in result.operations if op.operation_type.value == "CONTEXT"
     ]
     assert len(context_ops) >= 1
+
+
+@pytest.mark.example
+@pytest.mark.durable_execution(
+    handler=replay_logging.handler,
+    lambda_function_name="Replay Logging",
+)
+def test_replay_logging_dedupes_logs_across_wait(durable_runner, caplog):
+    """Verify the replay-aware logger de-duplicates messages across the wait.
+
+    The handler logs before the wait, suspends, then replays from the top when
+    the wait resumes. The replay-aware logger suppresses logs while the context
+    is replaying, so a message emitted before the wait must appear exactly once
+    even though the code that produces it runs again on replay. Messages emitted
+    after the wait are new work and also appear exactly once.
+
+    This only holds in local mode, where every invocation runs in-process and is
+    captured by a single ``caplog``; cloud mode spreads invocations across
+    separate Lambda executions, so the test is skipped there.
+    """
+    if durable_runner.mode != "local":
+        pytest.skip("Log capture is only available in local (in-process) mode")
+
+    with caplog.at_level(logging.INFO):
+        with durable_runner:
+            result = durable_runner.run(input={"item": "widget"}, timeout=30)
+
+    assert result.status is InvocationStatus.SUCCEEDED
+
+    messages = [record.getMessage() for record in caplog.records]
+
+    # Emitted before the wait: the handler replays past this line, but the
+    # replay-aware logger suppresses the duplicate, so it appears exactly once.
+    assert messages.count("Workflow started (before wait)") == 1
+    assert messages.count("Prepared, about to wait") == 1
+
+    # Emitted after the wait as new work: also exactly once.
+    assert messages.count("Resumed after wait") == 1
+    assert messages.count("Workflow completed") == 1

--- a/packages/aws-durable-execution-sdk-python-examples/test/logger_example/test_replay_logging.py
+++ b/packages/aws-durable-execution-sdk-python-examples/test/logger_example/test_replay_logging.py
@@ -1,0 +1,52 @@
+"""Tests for the replay_logging example.
+
+These tests do not assert on emitted log lines (the replay-aware
+de-duplication is best observed in CloudWatch after deploying). They verify the
+workflow runs end-to-end across the wait/replay boundary and produces the
+expected operations and result.
+"""
+
+import pytest
+
+from aws_durable_execution_sdk_python.execution import InvocationStatus
+from aws_durable_execution_sdk_python.lambda_service import OperationType
+from src.logger_example import replay_logging
+from test.conftest import deserialize_operation_payload
+
+
+@pytest.mark.example
+@pytest.mark.durable_execution(
+    handler=replay_logging.handler,
+    lambda_function_name="Replay Logging",
+)
+def test_replay_logging(durable_runner):
+    """Test the replay-aware logging example runs across the wait boundary."""
+    with durable_runner:
+        result = durable_runner.run(input={"item": "widget"}, timeout=30)
+
+    assert result.status is InvocationStatus.SUCCEEDED
+    assert deserialize_operation_payload(result.result) == {
+        "result": "done:audited:prepared:widget",
+        "item": "widget",
+    }
+
+    # Two wait operations force suspend/replay cycles: one in the parent context
+    # and one inside the child (audit) context. This exercises per-context replay
+    # status in different contexts.
+    wait_ops = [
+        op for op in result.operations if op.operation_type == OperationType.WAIT
+    ]
+    assert len(wait_ops) >= 1
+
+    # Steps before (prepare) and after (finalize) the wait both ran. The child
+    # context's record_audit step is nested inside the CONTEXT operation.
+    step_ops = [
+        op for op in result.operations if op.operation_type == OperationType.STEP
+    ]
+    assert len(step_ops) >= 2
+
+    # The audit child context produces a CONTEXT operation.
+    context_ops = [
+        op for op in result.operations if op.operation_type.value == "CONTEXT"
+    ]
+    assert len(context_ops) >= 1

--- a/packages/aws-durable-execution-sdk-python-examples/test/logger_example/test_replay_logging_concurrent.py
+++ b/packages/aws-durable-execution-sdk-python-examples/test/logger_example/test_replay_logging_concurrent.py
@@ -1,0 +1,101 @@
+"""Tests for the replay_logging_concurrent example.
+
+These tests verify the workflow runs end-to-end across the per-branch
+wait/replay boundaries and produces the expected result. One test additionally
+asserts on the replay-aware logger: each branch logs around its own wait, and
+those lines are de-duplicated per branch so each appears exactly once across all
+replay invocations.
+"""
+
+import logging
+
+import pytest
+
+from aws_durable_execution_sdk_python.execution import InvocationStatus
+from aws_durable_execution_sdk_python.lambda_service import OperationType
+from src.logger_example import replay_logging_concurrent
+from test.conftest import deserialize_operation_payload
+
+
+@pytest.mark.example
+@pytest.mark.durable_execution(
+    handler=replay_logging_concurrent.handler,
+    lambda_function_name="Replay Logging Concurrent",
+)
+def test_replay_logging_concurrent(durable_runner):
+    """Test the concurrent replay-aware logging example runs across branch waits."""
+    with durable_runner:
+        result = durable_runner.run(input={}, timeout=60)
+
+    assert result.status is InvocationStatus.SUCCEEDED
+    assert deserialize_operation_payload(result.result) == {
+        "results": ["alpha-done", "bravo-done", "charlie-done"]
+    }
+
+    # The parallel container holds one child branch per function.
+    parallel_op = result.get_context("concurrent_branches")
+    assert parallel_op is not None
+    assert len(parallel_op.child_operations) == 3
+
+    # Each branch has its own wait (forcing an independent suspend/replay cycle)
+    # and its own finalize step, both nested inside the branch's child context.
+    for branch in parallel_op.child_operations:
+        wait_ops = [
+            op
+            for op in branch.child_operations
+            if op.operation_type == OperationType.WAIT
+        ]
+        step_ops = [
+            op
+            for op in branch.child_operations
+            if op.operation_type == OperationType.STEP
+        ]
+        assert len(wait_ops) == 1
+        assert len(step_ops) == 1
+
+
+@pytest.mark.example
+@pytest.mark.durable_execution(
+    handler=replay_logging_concurrent.handler,
+    lambda_function_name="Replay Logging Concurrent",
+)
+def test_replay_logging_concurrent_dedupes_logs_per_branch(durable_runner, caplog):
+    """Verify the replay-aware logger de-duplicates per branch.
+
+    Each branch runs in its own child context with its own replay status and its
+    own wait boundary, so the branches suspend and replay independently. The
+    replay-aware logger must de-duplicate each branch's "before wait" line
+    (suppressed while that branch is replaying) and emit each "after wait" line
+    once as new work. We assert exactly one record per branch per message via the
+    ``branch`` extra the example attaches.
+
+    Only valid in local mode, where all invocations run in-process under a single
+    ``caplog``; cloud mode is skipped.
+    """
+    if durable_runner.mode != "local":
+        pytest.skip("Log capture is only available in local (in-process) mode")
+
+    with caplog.at_level(logging.INFO):
+        with durable_runner:
+            result = durable_runner.run(input={}, timeout=60)
+
+    assert result.status is InvocationStatus.SUCCEEDED
+
+    branches = ("alpha", "bravo", "charlie")
+    for branch in branches:
+        before = [
+            record
+            for record in caplog.records
+            if record.getMessage() == "branch start (before wait)"
+            and getattr(record, "branch", None) == branch
+        ]
+        after = [
+            record
+            for record in caplog.records
+            if record.getMessage() == "branch resumed (after wait)"
+            and getattr(record, "branch", None) == branch
+        ]
+        # Each branch logs its before/after-wait lines exactly once despite the
+        # per-branch replay cycle.
+        assert len(before) == 1, f"branch {branch} 'before wait' not deduped"
+        assert len(after) == 1, f"branch {branch} 'after wait' not deduped"

--- a/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/concurrency/executor.py
+++ b/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/concurrency/executor.py
@@ -489,7 +489,6 @@ class ConcurrentExecutor(ABC, Generic[CallableType, ResultType]):
                 is_virtual=is_virtual,
             ),
         )
-        child_context.state.track_replay(operation_id=operation_id)
         return result
 
     def replay(self, execution_state: ExecutionState, executor_context: DurableContext):

--- a/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/concurrency/executor.py
+++ b/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/concurrency/executor.py
@@ -475,6 +475,27 @@ class ConcurrentExecutor(ABC, Generic[CallableType, ResultType]):
             name=name,
         )
 
+        # The branch/iteration container op is resolved here via child_handler,
+        # bypassing context.run_in_child_context and therefore the parent's
+        # `_replay_aware`. Replicate the two things `_replay_aware` would have
+        # done for this container op while replaying:
+        #   1. Existence flip: a brand-new branch (no checkpoint) is new work,
+        #      so the child must start in NEW rather than inheriting REPLAY —
+        #      otherwise logs before the branch's first inner op are wrongly
+        #      de-duplicated during a map/parallel replay.
+        #   2. Replay hook: a branch that already has a checkpoint was observed
+        #      in a prior invocation, so emit the plugin replay hook (once).
+        # Virtual (FLAT) branches do not checkpoint themselves, so neither
+        # applies; their inner operations still self-correct via `_replay_aware`.
+        if not is_virtual and child_context.is_replaying():
+            branch_checkpoint = child_context.state.get_checkpoint_result(operation_id)
+            if not branch_checkpoint.is_existent():
+                child_context._set_replay_status_new()  # noqa: SLF001
+            elif branch_checkpoint.operation is not None:
+                child_context.state.emit_operation_replay_hook(
+                    branch_checkpoint.operation
+                )
+
         def run_in_child_handler() -> ResultType:
             return self.execute_item(child_context, executable)
 

--- a/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/context.py
+++ b/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/context.py
@@ -481,32 +481,62 @@ class DurableContext(DurableContextProtocol):
         ).is_existent()
 
     @contextmanager
-    def _replay_aware(self):
+    def _replay_aware(self, *, executes_user_code: bool = False):
         """Wrap a single operation with replay-boundary detection.
 
-        The boundary has three parts:
+        Args:
+            executes_user_code: True for operations that invoke a user-provided
+                function on (re-)entry — `step` and `wait_for_condition`'s check
+                (and, transitively, `wait_for_callback`'s submitter, which runs
+                as a step). When such an operation actually runs the user
+                function it is, by definition, doing new work (a cached
+                SUCCEEDED operation returns its checkpoint without invoking the
+                function). So a non-terminal user-code operation flips the
+                context to NEW *before* its body runs, including on retries. For
+                all other operations (default False), a non-terminal next
+                operation is a pure resume point with no user body, so we keep
+                replay status through it and flip afterwards.
+
+        The boundary has these parts:
 
         - Existence flip (before the op): if we are replaying and the next
           operation has no checkpoint at all, it is brand-new code, so flip to
           NEW immediately so the operation and its logs count as new.
-        - Deferred status flip (after the op): if we are replaying and the next
-          operation exists but is NOT terminal, that operation is the resume
-          point. We keep replay status through the operation and flip to NEW
-          afterwards, so the resuming operation's own logs stay de-duplicated
-          but subsequent code counts as new.
+        - User-code flip (before the op): if `executes_user_code` and the next
+          operation is non-terminal (brand-new OR retrying/re-executing), the
+          user function is about to run, so flip to NEW before it.
+        - Deferred status flip (after the op): for non-user-code operations, if
+          we are replaying and the next operation exists but is NOT terminal,
+          that operation is the resume point. We keep replay status through the
+          operation and flip to NEW afterwards, so the resuming operation's own
+          logs stay de-duplicated but subsequent code counts as new.
         - Post-op existence flip (after the op): if we are still replaying once
           the operation completes and the *following* operation does not exist
           yet, we have reached the replay boundary.
         """
         was_replaying: bool = self.is_replaying()
-        # Status: exists but not terminal -> defer flip until after the op runs.
+        # Only peek when replaying; avoids unnecessary checkpoint lookups (and
+        # any step-id side effects) on the common non-replay path.
+        next_exists: bool = was_replaying and self._next_operation_exists()
+        next_terminal: bool = (
+            was_replaying and self._next_operation_is_terminal_checkpoint()
+        )
+
+        # Deferred flip applies only to non-user-code resume points. For
+        # user-code ops we flip before instead, so don't defer.
         flip_after: bool = (
             was_replaying
-            and self._next_operation_exists()
-            and not self._next_operation_is_terminal_checkpoint()
+            and not executes_user_code
+            and next_exists
+            and not next_terminal
         )
-        # Existence: brand-new next op -> flip before the op runs.
-        if was_replaying and not self._next_operation_exists():
+        # Before-the-op flips:
+        # - brand-new next op (no checkpoint): always flip to NEW.
+        # - user-code op that is non-terminal (brand-new or retrying): the user
+        #   function is about to run real work, so flip to NEW before it.
+        if was_replaying and (
+            not next_exists or (executes_user_code and not next_terminal)
+        ):
             self._set_replay_status_new()
         try:
             yield
@@ -747,7 +777,7 @@ class DurableContext(DurableContextProtocol):
         logger.debug("Step name: %s", step_name)
         if not config:
             config = StepConfig()
-        with self._replay_aware():
+        with self._replay_aware(executes_user_code=True):
             operation_id = self._create_step_id()
             executor: StepOperationExecutor[T] = StepOperationExecutor(
                 func=func,
@@ -830,7 +860,7 @@ class DurableContext(DurableContextProtocol):
             msg = "`config` is required for wait_for_condition"
             raise ValidationError(msg)
 
-        with self._replay_aware():
+        with self._replay_aware(executes_user_code=True):
             operation_id = self._create_step_id()
             executor: WaitForConditionOperationExecutor[T] = (
                 WaitForConditionOperationExecutor(

--- a/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/context.py
+++ b/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/context.py
@@ -486,8 +486,8 @@ class DurableContext(DurableContextProtocol):
         - Existence flip (before the op): if we are replaying and the next
           operation has no checkpoint at all, it is brand-new code, so flip to
           NEW immediately so the operation and its logs count as new.
-        - Deferred status flip (after the op): a non-terminal next operation is a pure
-          resume point with no user body. We keep replay status through the
+        - Deferred status flip (after the op): a non-terminal next operation is
+          a pure resume point with no user body. We keep replay status through the
           operation and flip to NEW afterwards, so the resuming operation's own
           logs stay de-duplicated but subsequent code counts as new.
         - Post-op existence flip (after the op): if we are still replaying once
@@ -503,8 +503,8 @@ class DurableContext(DurableContextProtocol):
         next_exists: bool = (
             next_checkpoint.is_existent() if next_checkpoint is not None else False
         )
-        next_terminal: bool = next_checkpoint is not None and (
-            next_checkpoint.is_succeeded() or next_checkpoint.is_failed()
+        next_terminal: bool = (
+            next_checkpoint is not None and next_checkpoint.is_terminal()
         )
 
         next_is_step: bool = (

--- a/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/context.py
+++ b/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/context.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import hashlib
 import logging
+from contextlib import contextmanager
 from dataclasses import dataclass
+from threading import Lock
 from typing import TYPE_CHECKING, Any, Concatenate, Generic, ParamSpec, TypeVar
 
 from aws_durable_execution_sdk_python.config import (
@@ -46,7 +48,10 @@ from aws_durable_execution_sdk_python.serdes import (
     SerDes,
     deserialize,
 )
-from aws_durable_execution_sdk_python.state import ExecutionState  # noqa: TCH001
+from aws_durable_execution_sdk_python.state import (  # noqa: TCH001
+    ExecutionState,
+    ReplayStatus,
+)
 from aws_durable_execution_sdk_python.threading import OrderedCounter
 from aws_durable_execution_sdk_python.types import Callback as CallbackProtocol
 from aws_durable_execution_sdk_python.types import (
@@ -289,6 +294,7 @@ class DurableContext(DurableContextProtocol):
         parent_id: str | None = None,
         logger: Logger | None = None,
         step_id_prefix: str | None = None,
+        replay_status: ReplayStatus = ReplayStatus.NEW,
     ) -> None:
         self.state: ExecutionState = state
         self.execution_context: ExecutionContext = execution_context
@@ -304,15 +310,30 @@ class DurableContext(DurableContextProtocol):
         self._is_virtual: bool = self._parent_id != self._step_id_prefix
         self._step_counter: OrderedCounter = OrderedCounter()
 
+        # Replay status is tracked per-context.
+        # A context starts in the status inherited from its creator and refines
+        # itself to NEW via look-ahead as it reaches its own replay boundary.
+        # Concurrent branches each get their own child context, so the lock
+        # guards refinement when branches share a context reference.
+        self._replay_status: ReplayStatus = replay_status
+        self._replay_status_lock: Lock = Lock()
+
         log_info = LogInfo(
             execution_state=state,
             parent_id=parent_id,
         )
         self._log_info = log_info
-        self.logger: Logger = logger or Logger.from_log_info(
-            logger=logging.getLogger(),
-            info=log_info,
-        )
+        # The logger consults THIS context's replay status for de-duplication.
+        # A child inherits the parent's underlying logger/extra but must report
+        # its own status, so rebind the replay source onto self.
+        if logger is not None:
+            self.logger: Logger = logger.with_is_replaying(self.is_replaying)
+        else:
+            self.logger = Logger.from_log_info(
+                logger=logging.getLogger(),
+                info=log_info,
+                is_replaying=self.is_replaying,
+            )
 
     @property
     def is_virtual(self) -> bool:
@@ -331,6 +352,7 @@ class DurableContext(DurableContextProtocol):
     def from_lambda_context(
         state: ExecutionState,
         lambda_context: LambdaContext,
+        replay_status: ReplayStatus = ReplayStatus.NEW,
     ):
         return DurableContext(
             state=state,
@@ -339,6 +361,7 @@ class DurableContext(DurableContextProtocol):
             ),
             lambda_context=lambda_context,
             parent_id=None,
+            replay_status=replay_status,
         )
 
     def create_child_context(
@@ -374,6 +397,11 @@ class DurableContext(DurableContextProtocol):
             lambda_context=self.lambda_context,
             parent_id=child_parent_id,
             step_id_prefix=operation_id,
+            # Inherit the creator's current replay status; the child refines
+            # itself to NEW via look-ahead against its own step ids.
+            replay_status=(
+                ReplayStatus.REPLAY if self.is_replaying() else ReplayStatus.NEW
+            ),
             logger=self.logger.with_log_info(
                 LogInfo(
                     execution_state=self.state,
@@ -399,6 +427,7 @@ class DurableContext(DurableContextProtocol):
         self.logger = Logger.from_log_info(
             logger=new_logger,
             info=self._log_info,
+            is_replaying=self.is_replaying,
         )
 
     def _create_step_id_for_logical_step(self, step: int) -> str:
@@ -419,6 +448,75 @@ class DurableContext(DurableContextProtocol):
         """
         new_counter: int = self._step_counter.increment()
         return self._create_step_id_for_logical_step(new_counter)
+
+    # region replay status
+
+    def is_replaying(self) -> bool:
+        """Return True if this context is currently replaying prior operations."""
+        with self._replay_status_lock:
+            return self._replay_status is ReplayStatus.REPLAY
+
+    def _set_replay_status_new(self) -> None:
+        with self._replay_status_lock:
+            self._replay_status = ReplayStatus.NEW
+
+    def _peek_next_operation_id(self) -> str:
+        """Return the operation id the next operation will take, without consuming it."""
+        return self._create_step_id_for_logical_step(
+            self._step_counter.get_current() + 1
+        )
+
+    def _next_operation_is_terminal_checkpoint(self) -> bool:
+        """True if this context's next operation already completed in a prior invocation."""
+        result: CheckpointedResult = self.state.get_checkpoint_result(
+            self._peek_next_operation_id()
+        )
+
+        return result.is_succeeded() or result.is_failed()
+
+    def _next_operation_exists(self) -> bool:
+        """True if a checkpoint exists for this context's next operation."""
+        return self.state.get_checkpoint_result(
+            self._peek_next_operation_id()
+        ).is_existent()
+
+    @contextmanager
+    def _replay_aware(self):
+        """Wrap a single operation with replay-boundary detection.
+
+        The boundary has three parts:
+
+        - Existence flip (before the op): if we are replaying and the next
+          operation has no checkpoint at all, it is brand-new code, so flip to
+          NEW immediately so the operation and its logs count as new.
+        - Deferred status flip (after the op): if we are replaying and the next
+          operation exists but is NOT terminal, that operation is the resume
+          point. We keep replay status through the operation and flip to NEW
+          afterwards, so the resuming operation's own logs stay de-duplicated
+          but subsequent code counts as new.
+        - Post-op existence flip (after the op): if we are still replaying once
+          the operation completes and the *following* operation does not exist
+          yet, we have reached the replay boundary.
+        """
+        was_replaying: bool = self.is_replaying()
+        # Status: exists but not terminal -> defer flip until after the op runs.
+        flip_after: bool = (
+            was_replaying
+            and self._next_operation_exists()
+            and not self._next_operation_is_terminal_checkpoint()
+        )
+        # Existence: brand-new next op -> flip before the op runs.
+        if was_replaying and not self._next_operation_exists():
+            self._set_replay_status_new()
+        try:
+            yield
+        finally:
+            if flip_after:
+                self._set_replay_status_new()
+            elif self.is_replaying() and not self._next_operation_exists():
+                self._set_replay_status_new()
+
+    # endregion replay status
 
     # region Operations
 
@@ -441,26 +539,25 @@ class DurableContext(DurableContextProtocol):
         """
         if not config:
             config = CallbackConfig()
-        operation_id: str = self._create_step_id()
-        executor: CallbackOperationExecutor = CallbackOperationExecutor(
-            state=self.state,
-            operation_identifier=OperationIdentifier(
+        with self._replay_aware():
+            operation_id: str = self._create_step_id()
+            executor: CallbackOperationExecutor = CallbackOperationExecutor(
+                state=self.state,
+                operation_identifier=OperationIdentifier(
+                    operation_id=operation_id,
+                    sub_type=OperationSubType.CALLBACK,
+                    parent_id=self._parent_id,
+                    name=name,
+                ),
+                config=config,
+            )
+            callback_id: str = executor.process()
+            return Callback(
+                callback_id=callback_id,
                 operation_id=operation_id,
-                sub_type=OperationSubType.CALLBACK,
-                parent_id=self._parent_id,
-                name=name,
-            ),
-            config=config,
-        )
-        callback_id: str = executor.process()
-        result: Callback = Callback(
-            callback_id=callback_id,
-            operation_id=operation_id,
-            state=self.state,
-            serdes=config.serdes,
-        )
-        self.state.track_replay(operation_id=operation_id)
-        return result
+                state=self.state,
+                serdes=config.serdes,
+            )
 
     def invoke(
         self,
@@ -482,22 +579,21 @@ class DurableContext(DurableContextProtocol):
         """
         if not config:
             config = InvokeConfig[P, R]()
-        operation_id = self._create_step_id()
-        executor: InvokeOperationExecutor[R] = InvokeOperationExecutor(
-            function_name=function_name,
-            payload=payload,
-            state=self.state,
-            operation_identifier=OperationIdentifier(
-                operation_id=operation_id,
-                sub_type=OperationSubType.CHAINED_INVOKE,
-                parent_id=self._parent_id,
-                name=name,
-            ),
-            config=config,
-        )
-        result: R = executor.process()
-        self.state.track_replay(operation_id=operation_id)
-        return result
+        with self._replay_aware():
+            operation_id = self._create_step_id()
+            executor: InvokeOperationExecutor[R] = InvokeOperationExecutor(
+                function_name=function_name,
+                payload=payload,
+                state=self.state,
+                operation_identifier=OperationIdentifier(
+                    operation_id=operation_id,
+                    sub_type=OperationSubType.CHAINED_INVOKE,
+                    parent_id=self._parent_id,
+                    name=name,
+                ),
+                config=config,
+            )
+            return executor.process()
 
     def map(
         self,
@@ -509,44 +605,43 @@ class DurableContext(DurableContextProtocol):
         """Execute a callable for each item in parallel."""
         map_name: str | None = self._resolve_step_name(name, func)
 
-        operation_id = self._create_step_id()
-        operation_identifier = OperationIdentifier(
-            operation_id=operation_id,
-            sub_type=OperationSubType.MAP,
-            parent_id=self._parent_id,
-            name=map_name,
-        )
-        map_context = self.create_child_context(operation_id=operation_id)
-
-        def map_in_child_context() -> BatchResult[R]:
-            # map_context is a child_context of the context upon which `.map`
-            # was called. We are calling it `map_context` to make it explicit
-            # that any operations happening from hereon are done on the context
-            # that owns the branches
-            return map_handler(
-                items=inputs,
-                func=func,
-                config=config,
-                execution_state=self.state,
-                map_context=map_context,
-                operation_identifier=operation_identifier,
-            )
-
-        result: BatchResult[R] = child_handler(
-            func=map_in_child_context,
-            state=self.state,
-            operation_identifier=operation_identifier,
-            config=ChildConfig(
+        with self._replay_aware():
+            operation_id = self._create_step_id()
+            operation_identifier = OperationIdentifier(
+                operation_id=operation_id,
                 sub_type=OperationSubType.MAP,
-                serdes=getattr(config, "serdes", None),
-                # child_handler should only know the serdes of the parent serdes,
-                # the item serdes will be passed when we are actually executing
-                # the branch within its own child_handler.
-                item_serdes=None,
-            ),
-        )
-        self.state.track_replay(operation_id=operation_id)
-        return result
+                parent_id=self._parent_id,
+                name=map_name,
+            )
+            map_context = self.create_child_context(operation_id=operation_id)
+
+            def map_in_child_context() -> BatchResult[R]:
+                # map_context is a child_context of the context upon which `.map`
+                # was called. We are calling it `map_context` to make it explicit
+                # that any operations happening from hereon are done on the context
+                # that owns the branches
+                return map_handler(
+                    items=inputs,
+                    func=func,
+                    config=config,
+                    execution_state=self.state,
+                    map_context=map_context,
+                    operation_identifier=operation_identifier,
+                )
+
+            return child_handler(
+                func=map_in_child_context,
+                state=self.state,
+                operation_identifier=operation_identifier,
+                config=ChildConfig(
+                    sub_type=OperationSubType.MAP,
+                    serdes=getattr(config, "serdes", None),
+                    # child_handler should only know the serdes of the parent serdes,
+                    # the item serdes will be passed when we are actually executing
+                    # the branch within its own child_handler.
+                    item_serdes=None,
+                ),
+            )
 
     def parallel(
         self,
@@ -555,44 +650,43 @@ class DurableContext(DurableContextProtocol):
         config: ParallelConfig | None = None,
     ) -> BatchResult[T]:
         """Execute multiple callables in parallel."""
-        # _create_step_id() is thread-safe. rest of method is safe, since using local copy of parent id
-        operation_id = self._create_step_id()
-        parallel_context = self.create_child_context(operation_id=operation_id)
-        operation_identifier = OperationIdentifier(
-            operation_id=operation_id,
-            sub_type=OperationSubType.PARALLEL,
-            parent_id=self._parent_id,
-            name=name,
-        )
-
-        def parallel_in_child_context() -> BatchResult[T]:
-            # parallel_context is a child_context of the context upon which `.map`
-            # was called. We are calling it `parallel_context` to make it explicit
-            # that any operations happening from hereon are done on the context
-            # that owns the branches
-            return parallel_handler(
-                callables=functions,
-                config=config,
-                execution_state=self.state,
-                parallel_context=parallel_context,
-                operation_identifier=operation_identifier,
+        with self._replay_aware():
+            # _create_step_id() is thread-safe. rest of method is safe, since using local copy of parent id
+            operation_id = self._create_step_id()
+            parallel_context = self.create_child_context(operation_id=operation_id)
+            operation_identifier = OperationIdentifier(
+                operation_id=operation_id,
+                sub_type=OperationSubType.PARALLEL,
+                parent_id=self._parent_id,
+                name=name,
             )
 
-        result: BatchResult[T] = child_handler(
-            func=parallel_in_child_context,
-            state=self.state,
-            operation_identifier=operation_identifier,
-            config=ChildConfig(
-                sub_type=OperationSubType.PARALLEL,
-                serdes=getattr(config, "serdes", None),
-                # child_handler should only know the serdes of the parent serdes,
-                # the item serdes will be passed when we are actually executing
-                # the branch within its own child_handler.
-                item_serdes=None,
-            ),
-        )
-        self.state.track_replay(operation_id=operation_id)
-        return result
+            def parallel_in_child_context() -> BatchResult[T]:
+                # parallel_context is a child_context of the context upon which `.map`
+                # was called. We are calling it `parallel_context` to make it explicit
+                # that any operations happening from hereon are done on the context
+                # that owns the branches
+                return parallel_handler(
+                    callables=functions,
+                    config=config,
+                    execution_state=self.state,
+                    parallel_context=parallel_context,
+                    operation_identifier=operation_identifier,
+                )
+
+            return child_handler(
+                func=parallel_in_child_context,
+                state=self.state,
+                operation_identifier=operation_identifier,
+                config=ChildConfig(
+                    sub_type=OperationSubType.PARALLEL,
+                    serdes=getattr(config, "serdes", None),
+                    # child_handler should only know the serdes of the parent serdes,
+                    # the item serdes will be passed when we are actually executing
+                    # the branch within its own child_handler.
+                    item_serdes=None,
+                ),
+            )
 
     def run_in_child_context(
         self,
@@ -613,36 +707,35 @@ class DurableContext(DurableContextProtocol):
             T: The result of the callable.
         """
         step_name: str | None = self._resolve_step_name(name, func)
-        # _create_step_id() is thread-safe. rest of method is safe, since using local copy of parent id
-        operation_id = self._create_step_id()
-        sub_type = (
-            config.sub_type
-            if config and config.sub_type
-            else OperationSubType.RUN_IN_CHILD_CONTEXT
-        )
-
-        is_virtual: bool = config.is_virtual if config else False
-
-        def callable_with_child_context():
-            return func(
-                self.create_child_context(
-                    operation_id=operation_id, is_virtual=is_virtual
-                )
+        with self._replay_aware():
+            # _create_step_id() is thread-safe. rest of method is safe, since using local copy of parent id
+            operation_id = self._create_step_id()
+            sub_type = (
+                config.sub_type
+                if config and config.sub_type
+                else OperationSubType.RUN_IN_CHILD_CONTEXT
             )
 
-        result: T = child_handler(
-            func=callable_with_child_context,
-            state=self.state,
-            operation_identifier=OperationIdentifier(
-                operation_id=operation_id,
-                sub_type=sub_type,
-                parent_id=self._parent_id,
-                name=step_name,
-            ),
-            config=config,
-        )
-        self.state.track_replay(operation_id=operation_id)
-        return result
+            is_virtual: bool = config.is_virtual if config else False
+
+            def callable_with_child_context():
+                return func(
+                    self.create_child_context(
+                        operation_id=operation_id, is_virtual=is_virtual
+                    )
+                )
+
+            return child_handler(
+                func=callable_with_child_context,
+                state=self.state,
+                operation_identifier=OperationIdentifier(
+                    operation_id=operation_id,
+                    sub_type=sub_type,
+                    parent_id=self._parent_id,
+                    name=step_name,
+                ),
+                config=config,
+            )
 
     def step(
         self,
@@ -654,22 +747,21 @@ class DurableContext(DurableContextProtocol):
         logger.debug("Step name: %s", step_name)
         if not config:
             config = StepConfig()
-        operation_id = self._create_step_id()
-        executor: StepOperationExecutor[T] = StepOperationExecutor(
-            func=func,
-            config=config,
-            state=self.state,
-            operation_identifier=OperationIdentifier(
-                operation_id=operation_id,
-                sub_type=OperationSubType.STEP,
-                parent_id=self._parent_id,
-                name=step_name,
-            ),
-            context_logger=self.logger,
-        )
-        result: T = executor.process()
-        self.state.track_replay(operation_id=operation_id)
-        return result
+        with self._replay_aware():
+            operation_id = self._create_step_id()
+            executor: StepOperationExecutor[T] = StepOperationExecutor(
+                func=func,
+                config=config,
+                state=self.state,
+                operation_identifier=OperationIdentifier(
+                    operation_id=operation_id,
+                    sub_type=OperationSubType.STEP,
+                    parent_id=self._parent_id,
+                    name=step_name,
+                ),
+                context_logger=self.logger,
+            )
+            return executor.process()
 
     def wait(self, duration: Duration, name: str | None = None) -> None:
         """Wait for a specified amount of time.
@@ -682,20 +774,20 @@ class DurableContext(DurableContextProtocol):
         if seconds < 1:
             msg = "duration must be at least 1 second"
             raise ValidationError(msg)
-        operation_id = self._create_step_id()
-        wait_seconds = duration.seconds
-        executor: WaitOperationExecutor = WaitOperationExecutor(
-            seconds=wait_seconds,
-            state=self.state,
-            operation_identifier=OperationIdentifier(
-                operation_id=operation_id,
-                sub_type=OperationSubType.WAIT,
-                parent_id=self._parent_id,
-                name=name,
-            ),
-        )
-        executor.process()
-        self.state.track_replay(operation_id=operation_id)
+        with self._replay_aware():
+            operation_id = self._create_step_id()
+            wait_seconds = duration.seconds
+            executor: WaitOperationExecutor = WaitOperationExecutor(
+                seconds=wait_seconds,
+                state=self.state,
+                operation_identifier=OperationIdentifier(
+                    operation_id=operation_id,
+                    sub_type=OperationSubType.WAIT,
+                    parent_id=self._parent_id,
+                    name=name,
+                ),
+            )
+            executor.process()
 
     def wait_for_callback(
         self,
@@ -738,24 +830,23 @@ class DurableContext(DurableContextProtocol):
             msg = "`config` is required for wait_for_condition"
             raise ValidationError(msg)
 
-        operation_id = self._create_step_id()
-        executor: WaitForConditionOperationExecutor[T] = (
-            WaitForConditionOperationExecutor(
-                check=check,
-                config=config,
-                state=self.state,
-                operation_identifier=OperationIdentifier(
-                    operation_id=operation_id,
-                    sub_type=OperationSubType.WAIT_FOR_CONDITION,
-                    parent_id=self._parent_id,
-                    name=name,
-                ),
-                context_logger=self.logger,
+        with self._replay_aware():
+            operation_id = self._create_step_id()
+            executor: WaitForConditionOperationExecutor[T] = (
+                WaitForConditionOperationExecutor(
+                    check=check,
+                    config=config,
+                    state=self.state,
+                    operation_identifier=OperationIdentifier(
+                        operation_id=operation_id,
+                        sub_type=OperationSubType.WAIT_FOR_CONDITION,
+                        parent_id=self._parent_id,
+                        name=name,
+                    ),
+                    context_logger=self.logger,
+                )
             )
-        )
-        result: T = executor.process()
-        self.state.track_replay(operation_id=operation_id)
-        return result
+            return executor.process()
 
 
 # endregion Operations

--- a/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/execution.py
+++ b/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/execution.py
@@ -227,7 +227,6 @@ def durable_execution(
             initial_checkpoint_token=invocation_input.checkpoint_token,
             operations={},
             service_client=service_client,
-            replay_status=ReplayStatus.NEW,
             plugin_executor=plugin_executor,
         )
 
@@ -252,7 +251,11 @@ def durable_execution(
                 ).to_dict()
             raise
 
-        execution_state.mark_replaying_if_prior_operations_exist()
+        # Determine whether this is a replay (prior operations exist) at the
+        # execution level. This seeds the root context's replay status and the
+        # plugin's is_first_invocation flag. Replay status itself is then
+        # tracked per-context as execution proceeds.
+        has_prior_operations: bool = execution_state.has_prior_operations()
 
         raw_input_payload: str | None = execution_state.get_input_payload()
 
@@ -270,7 +273,11 @@ def durable_execution(
                 raise
 
         durable_context: DurableContext = DurableContext.from_lambda_context(
-            state=execution_state, lambda_context=context
+            state=execution_state,
+            lambda_context=context,
+            replay_status=(
+                ReplayStatus.REPLAY if has_prior_operations else ReplayStatus.NEW
+            ),
         )
 
         # Use ThreadPoolExecutor for concurrent execution of user code and background checkpoint processing
@@ -291,7 +298,7 @@ def durable_execution(
                     if execution_operation is not None
                     else None
                 ),
-                is_first_invocation=not execution_state.is_replaying(),
+                is_first_invocation=not has_prior_operations,
             )
             # Thread 1: Run background checkpoint processing
             executor.submit(execution_state.checkpoint_batches_forever)

--- a/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/logger.py
+++ b/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/logger.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 from aws_durable_execution_sdk_python.types import LoggerInterface
 
+
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping, MutableMapping
 
@@ -54,15 +55,25 @@ class Logger(LoggerInterface):
         self,
         logger: LoggerInterface,
         default_extra: Mapping[str, object],
-        execution_state: ExecutionState,
+        is_replaying: Callable[[], bool] = lambda: False,
     ) -> None:
         self._logger = logger
         self._default_extra = default_extra
-        self._execution_state = execution_state
+        # Replay status is owned by the DurableContext this logger belongs to,
+        # not by the execution as a whole. This callable reads that context's
+        # current replay status so log de-duplication is decided per-context.
+        # The default (never replaying) suits a standalone logger with no
+        # owning context, so it always logs.
+        self._is_replaying = is_replaying
 
     @classmethod
-    def from_log_info(cls, logger: LoggerInterface, info: LogInfo) -> Logger:
-        """Create a new logger with the given LogInfo."""
+    def from_log_info(
+        cls,
+        logger: LoggerInterface,
+        info: LogInfo,
+        is_replaying: Callable[[], bool] = lambda: False,
+    ) -> Logger:
+        """Create a new logger with the given LogInfo and replay-status source."""
         extra: MutableMapping[str, object] = {
             "executionArn": info.execution_state.durable_execution_arn
         }
@@ -75,15 +86,26 @@ class Logger(LoggerInterface):
             extra["attempt"] = info.attempt
         if info.operation_id:
             extra["operationId"] = info.operation_id
-        return cls(
-            logger=logger, default_extra=extra, execution_state=info.execution_state
-        )
+        return cls(logger=logger, default_extra=extra, is_replaying=is_replaying)
 
     def with_log_info(self, info: LogInfo) -> Logger:
-        """Clone the existing logger with new LogInfo."""
+        """Clone the existing logger with new LogInfo, preserving the replay-status source."""
         return Logger.from_log_info(
             logger=self._logger,
             info=info,
+            is_replaying=self._is_replaying,
+        )
+
+    def with_is_replaying(self, is_replaying: Callable[[], bool]) -> Logger:
+        """Clone the logger, rebinding it to a new replay-status source.
+
+        Used when a child context inherits a parent's underlying logger but must
+        report its own (the child's) replay status rather than the parent's.
+        """
+        return Logger(
+            logger=self._logger,
+            default_extra=self._default_extra,
+            is_replaying=is_replaying,
         )
 
     def get_logger(self) -> LoggerInterface:
@@ -128,4 +150,4 @@ class Logger(LoggerInterface):
         log_func(msg, *args, extra=merged_extra)
 
     def _should_log(self) -> bool:
-        return not self._execution_state.is_replaying()
+        return not self._is_replaying()

--- a/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/state.py
+++ b/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/state.py
@@ -76,6 +76,19 @@ class QueuedOperation:
     completion_event: CompletionEvent | None = None
 
 
+# Statuses indicating an operation has finished and will not change on a later
+# replay. Includes TIMED_OUT/CANCELLED/STOPPED in addition to SUCCEEDED/FAILED
+_TERMINAL_OPERATION_STATUSES: frozenset[OperationStatus] = frozenset(
+    {
+        OperationStatus.SUCCEEDED,
+        OperationStatus.FAILED,
+        OperationStatus.CANCELLED,
+        OperationStatus.TIMED_OUT,
+        OperationStatus.STOPPED,
+    }
+)
+
+
 @dataclass(frozen=True)
 class CheckpointedResult:
     """Result of a checkpointed operation.
@@ -197,6 +210,13 @@ class CheckpointedResult:
         if not op:
             return False
         return op.status is OperationStatus.TIMED_OUT
+
+    def is_terminal(self) -> bool:
+        """Return True if the checkpointed operation is in any terminal status."""
+        op = self.operation
+        if not op:
+            return False
+        return op.status in _TERMINAL_OPERATION_STATUSES
 
     def is_replay_children(self) -> bool:
         op = self.operation

--- a/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/state.py
+++ b/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/state.py
@@ -11,7 +11,7 @@ import time
 from dataclasses import dataclass
 from enum import Enum
 from threading import Lock
-from typing import TYPE_CHECKING, Callable, Any
+from typing import TYPE_CHECKING, Any, Callable
 
 from aws_durable_execution_sdk_python.exceptions import (
     BackgroundThreadError,
@@ -29,16 +29,17 @@ from aws_durable_execution_sdk_python.lambda_service import (
     Operation,
     OperationAction,
     OperationStatus,
+    OperationSubType,
     OperationType,
     OperationUpdate,
     StateOutput,
-    OperationSubType,
 )
 from aws_durable_execution_sdk_python.plugin import (
     PluginExecutor,
     UserFunctionStartInfo,
 )
 from aws_durable_execution_sdk_python.threading import CompletionEvent, OrderedLock
+
 
 if TYPE_CHECKING:
     import datetime
@@ -246,7 +247,6 @@ class ExecutionState:
         service_client: DurableServiceClient,
         plugin_executor: PluginExecutor,
         batcher_config: CheckpointBatcherConfig | None = None,
-        replay_status: ReplayStatus = ReplayStatus.NEW,
     ):
         self.durable_execution_arn: str = durable_execution_arn
         self._current_checkpoint_token: str = initial_checkpoint_token
@@ -275,9 +275,6 @@ class ExecutionState:
 
         # Protects parent_to_children and parent_done
         self._parent_done_lock: Lock = Lock()
-        self._replay_status: ReplayStatus = replay_status
-        self._replay_status_lock: Lock = Lock()
-        self._visited_operations: set[str] = set()
 
     @property
     def operations(self) -> dict[str, Operation]:
@@ -367,62 +364,19 @@ class ExecutionState:
 
         return candidate
 
-    def track_replay(self, operation_id: str) -> None:
-        """Check if operation exists with completed status; if not, transition to NEW status.
+    def has_prior_operations(self) -> bool:
+        """Return True if any non-execution operation already exists.
 
-        This method is called before each operation (step, wait, invoke, etc.) to determine
-        if we've reached the replay boundary. Once we encounter an operation that doesn't
-        exist or isn't completed, we transition from REPLAY to NEW status, which enables
-        logging for all subsequent code.
-
-        Args:
-            operation_id: The operation ID to check
+        Used at execution setup to decide whether this invocation is a replay
+        (prior operations were checkpointed in an earlier invocation) versus a
+        first invocation. Per-operation replay status is tracked per-context on
+        DurableContext, not here.
         """
-        with self._replay_status_lock:
-            if self._replay_status == ReplayStatus.REPLAY:
-                self._visited_operations.add(operation_id)
-                # Lock order: _replay_status_lock then _operations_lock.
-                with self._operations_lock:
-                    completed_ops = {
-                        op_id
-                        for op_id, op in self._operations.items()
-                        if op.operation_type != OperationType.EXECUTION
-                        and op.status
-                        in {
-                            OperationStatus.SUCCEEDED,
-                            OperationStatus.FAILED,
-                            OperationStatus.CANCELLED,
-                            OperationStatus.STOPPED,
-                            OperationStatus.TIMED_OUT,
-                        }
-                    }
-                if completed_ops.issubset(self._visited_operations):
-                    logger.debug(
-                        "Transitioning from REPLAY to NEW status at operation %s",
-                        operation_id,
-                    )
-                    self._replay_status = ReplayStatus.NEW
-
-    def is_replaying(self) -> bool:
-        """Check if execution is currently in replay mode.
-
-        Returns:
-            True if in REPLAY status, False if in NEW status
-        """
-        with self._replay_status_lock:
-            return self._replay_status is ReplayStatus.REPLAY
-
-    def mark_replaying_if_prior_operations_exist(self) -> None:
-        """Mark execution state as replaying when non-execution operations exist."""
         with self._operations_lock:
-            has_prior_operations: bool = any(
+            return any(
                 op.operation_type is not OperationType.EXECUTION
                 for op in self._operations.values()
             )
-
-        if has_prior_operations:
-            with self._replay_status_lock:
-                self._replay_status = ReplayStatus.REPLAY
 
     def get_checkpoint_result(self, checkpoint_id: str) -> CheckpointedResult:
         """Get checkpoint result.

--- a/packages/aws-durable-execution-sdk-python/tests/concurrency_test.py
+++ b/packages/aws-durable-execution-sdk-python/tests/concurrency_test.py
@@ -26,10 +26,10 @@ from aws_durable_execution_sdk_python.concurrency.models import (
     ExecutionCounters,
 )
 from aws_durable_execution_sdk_python.config import (
+    ChildConfig,
     CompletionConfig,
     MapConfig,
     NestingType,
-    ChildConfig,
 )
 from aws_durable_execution_sdk_python.context import (
     DurableContext,
@@ -44,9 +44,13 @@ from aws_durable_execution_sdk_python.exceptions import (
 from aws_durable_execution_sdk_python.identifier import OperationIdentifier
 from aws_durable_execution_sdk_python.lambda_service import (
     ErrorObject,
+    Operation,
+    OperationStatus,
     OperationSubType,
+    OperationType,
 )
 from aws_durable_execution_sdk_python.operation.map import MapExecutor
+from aws_durable_execution_sdk_python.state import CheckpointedResult
 
 
 def test_batch_item_status_enum():
@@ -1182,6 +1186,139 @@ def test_concurrent_executor_execute_item_in_child_context():
         executor_context, executables[0]
     )
     assert result == "result_0"
+
+
+def test_execute_item_brand_new_branch_during_replay_starts_new():
+    """A brand-new branch during a map/parallel replay must start in NEW status.
+
+    The branch container op is resolved via child_handler, bypassing the
+    parent's _replay_aware existence flip. _execute_item_in_child_context must
+    replicate that flip so logs before the branch's first inner op are not
+    wrongly de-duplicated.
+    """
+
+    class TestExecutor(ConcurrentExecutor):
+        def execute_item(self, child_context, executable):
+            return f"result_{executable.index}"
+
+    executables = [Executable(0, lambda: "test")]
+    executor = TestExecutor(
+        executables=executables,
+        max_concurrency=1,
+        completion_config=CompletionConfig(
+            min_successful=1,
+            tolerated_failure_count=None,
+            tolerated_failure_percentage=None,
+        ),
+        sub_type_top="TOP",
+        sub_type_iteration="ITER",
+        name_prefix="test_",
+        serdes=None,
+        nesting_type=NestingType.NESTED,
+    )
+
+    # Parent (executor) context is replaying.
+    executor_context = Mock()
+    executor_context.is_replaying = lambda: True
+    executor_context._create_step_id_for_logical_step = lambda *args: "branch-1"  # noqa: SLF001
+    executor_context._parent_id = "parent"  # noqa: SLF001
+
+    # Brand-new branch: no checkpoint for the branch op.
+    not_found = CheckpointedResult.create_not_found()
+    child_context = Mock()
+    child_context.state.get_checkpoint_result = lambda _id: not_found
+    child_context.state.wrap_user_function = lambda func, *args, **kwargs: func
+    executor_context.create_child_context = lambda *args, **kwargs: child_context
+
+    executor._execute_item_in_child_context(executor_context, executables[0])  # noqa: SLF001
+
+    # The brand-new branch's child context was flipped to NEW.
+    child_context._set_replay_status_new.assert_called_once()  # noqa: SLF001
+
+
+def test_execute_item_replayed_branch_emits_replay_hook():
+    """A branch that already has a checkpoint emits the replay hook (once)."""
+
+    class TestExecutor(ConcurrentExecutor):
+        def execute_item(self, child_context, executable):
+            return f"result_{executable.index}"
+
+    executables = [Executable(0, lambda: "test")]
+    executor = TestExecutor(
+        executables=executables,
+        max_concurrency=1,
+        completion_config=CompletionConfig(
+            min_successful=1,
+            tolerated_failure_count=None,
+            tolerated_failure_percentage=None,
+        ),
+        sub_type_top="TOP",
+        sub_type_iteration="ITER",
+        name_prefix="test_",
+        serdes=None,
+        nesting_type=NestingType.NESTED,
+    )
+
+    executor_context = Mock()
+    executor_context.is_replaying = lambda: True
+    executor_context._create_step_id_for_logical_step = lambda *args: "branch-1"  # noqa: SLF001
+    executor_context._parent_id = "parent"  # noqa: SLF001
+
+    # Replayed branch: a terminal checkpoint exists for the branch op.
+    branch_op = Operation(
+        operation_id="branch-1",
+        operation_type=OperationType.CONTEXT,
+        status=OperationStatus.SUCCEEDED,
+        sub_type=OperationSubType.PARALLEL_BRANCH,
+    )
+    existing = CheckpointedResult.create_from_operation(branch_op)
+    child_context = Mock()
+    child_context.state.get_checkpoint_result = lambda _id: existing
+    child_context.state.wrap_user_function = lambda func, *args, **kwargs: func
+    executor_context.create_child_context = lambda *args, **kwargs: child_context
+
+    executor._execute_item_in_child_context(executor_context, executables[0])  # noqa: SLF001
+
+    child_context.state.emit_operation_replay_hook.assert_called_once_with(branch_op)
+    child_context._set_replay_status_new.assert_not_called()  # noqa: SLF001
+
+
+def test_execute_item_virtual_branch_skips_replay_status_handling():
+    """FLAT (virtual) branches don't checkpoint, so no flip or hook is attempted."""
+
+    class TestExecutor(ConcurrentExecutor):
+        def execute_item(self, child_context, executable):
+            return f"result_{executable.index}"
+
+    executables = [Executable(0, lambda: "test")]
+    executor = TestExecutor(
+        executables=executables,
+        max_concurrency=1,
+        completion_config=CompletionConfig(
+            min_successful=1,
+            tolerated_failure_count=None,
+            tolerated_failure_percentage=None,
+        ),
+        sub_type_top="TOP",
+        sub_type_iteration="ITER",
+        name_prefix="test_",
+        serdes=None,
+        nesting_type=NestingType.FLAT,
+    )
+
+    executor_context = Mock()
+    executor_context.is_replaying = lambda: True
+    executor_context._create_step_id_for_logical_step = lambda *args: "branch-1"  # noqa: SLF001
+    executor_context._parent_id = "parent"  # noqa: SLF001
+
+    child_context = Mock()
+    child_context.state.wrap_user_function = lambda func, *args, **kwargs: func
+    executor_context.create_child_context = lambda *args, **kwargs: child_context
+
+    executor._execute_item_in_child_context(executor_context, executables[0])  # noqa: SLF001
+
+    child_context.state.emit_operation_replay_hook.assert_not_called()
+    child_context._set_replay_status_new.assert_not_called()  # noqa: SLF001
 
 
 def test_execution_counters_impossible_to_succeed():

--- a/packages/aws-durable-execution-sdk-python/tests/context_test.py
+++ b/packages/aws-durable-execution-sdk-python/tests/context_test.py
@@ -2515,4 +2515,85 @@ def test_replay_aware_stays_replaying_between_two_completed_ops():
     assert ctx.is_replaying() is True
 
 
+def test_replay_aware_user_code_flips_before_retrying_op():
+    """A retrying/re-executing user-code op flips to NEW BEFORE the body runs.
+
+    A step whose checkpoint is non-terminal (e.g. PENDING/STARTED from a retry)
+    is about to re-run the user function, which is real new work. With
+    executes_user_code=True the context flips to NEW before the body so the
+    step's logs (and future plugin state) reflect an executing attempt.
+    """
+    ctx = DurableContext(
+        state=_replay_state({}),
+        execution_context=ExecutionContext(durable_execution_arn="arn"),
+        replay_status=ReplayStatus.REPLAY,
+    )
+    next_id = ctx._peek_next_operation_id()  # noqa: SLF001
+    # STARTED == non-terminal: a retry attempt about to re-execute.
+    ctx.state._operations[next_id] = _step_op(  # noqa: SLF001
+        next_id, OperationStatus.STARTED
+    )
+
+    inside_status: list[bool] = []
+    with ctx._replay_aware(executes_user_code=True):  # noqa: SLF001
+        ctx._create_step_id()  # noqa: SLF001
+        inside_status.append(ctx.is_replaying())
+
+    # Flipped BEFORE the body (contrast with the non-user-code resume point,
+    # which stays replaying through the op).
+    assert inside_status == [False]
+    assert ctx.is_replaying() is False
+
+
+def test_replay_aware_user_code_stays_replaying_for_completed_op():
+    """A cached SUCCEEDED user-code op does not run its body, so stays replaying."""
+    ctx = DurableContext(
+        state=_replay_state({}),
+        execution_context=ExecutionContext(durable_execution_arn="arn"),
+        replay_status=ReplayStatus.REPLAY,
+    )
+    # Wrapped op completed; a following op also completed so nothing flips.
+    first_id = ctx._create_step_id_for_logical_step(1)  # noqa: SLF001
+    second_id = ctx._create_step_id_for_logical_step(2)  # noqa: SLF001
+    ctx.state._operations[first_id] = _step_op(  # noqa: SLF001
+        first_id, OperationStatus.SUCCEEDED
+    )
+    ctx.state._operations[second_id] = _step_op(  # noqa: SLF001
+        second_id, OperationStatus.SUCCEEDED
+    )
+
+    with ctx._replay_aware(executes_user_code=True):  # noqa: SLF001
+        ctx._create_step_id()  # noqa: SLF001
+        assert ctx.is_replaying() is True
+
+    assert ctx.is_replaying() is True
+
+
+def test_replay_aware_non_user_code_stays_replaying_through_resume_point():
+    """A non-user-code resume point (e.g. wait) stays replaying through the op.
+
+    Contrast with the user-code case: a non-terminal wait is a pure resume
+    point with no user body, so logs emitted by the resuming op stay
+    de-duplicated and the flip is deferred until after.
+    """
+    ctx = DurableContext(
+        state=_replay_state({}),
+        execution_context=ExecutionContext(durable_execution_arn="arn"),
+        replay_status=ReplayStatus.REPLAY,
+    )
+    next_id = ctx._peek_next_operation_id()  # noqa: SLF001
+    ctx.state._operations[next_id] = _step_op(  # noqa: SLF001
+        next_id, OperationStatus.STARTED
+    )
+
+    inside_status: list[bool] = []
+    with ctx._replay_aware():  # noqa: SLF001 - executes_user_code defaults False
+        ctx._create_step_id()  # noqa: SLF001
+        inside_status.append(ctx.is_replaying())
+
+    # Stayed replaying THROUGH the op, flipped after.
+    assert inside_status == [True]
+    assert ctx.is_replaying() is False
+
+
 # endregion per-context replay status

--- a/packages/aws-durable-execution-sdk-python/tests/context_test.py
+++ b/packages/aws-durable-execution-sdk-python/tests/context_test.py
@@ -2524,6 +2524,50 @@ def test_replay_aware_stays_replaying_between_two_completed_ops():
     assert ctx.is_replaying() is True
 
 
+@pytest.mark.parametrize(
+    "terminal_status",
+    [
+        OperationStatus.TIMED_OUT,
+        OperationStatus.CANCELLED,
+        OperationStatus.STOPPED,
+        OperationStatus.SUCCEEDED,
+        OperationStatus.FAILED,
+    ],
+)
+def test_replay_aware_terminal_non_success_op_stays_replaying(terminal_status):
+    """TIMED_OUT/CANCELLED/STOPPED ops are terminal, so we stay replaying after them.
+
+    Regression test for issue #262: a handled timeout/cancel/stop is done, and
+    operations after it may also be completed replayed work. The context must
+    NOT flip to NEW after such an op (which would wrongly re-enable logging for
+    subsequent replayed operations).
+    """
+    ctx = DurableContext(
+        state=_replay_state({}),
+        execution_context=ExecutionContext(durable_execution_arn="arn"),
+        replay_status=ReplayStatus.REPLAY,
+    )
+    # op1: terminal-but-not-succeeded/failed (e.g. a handled invoke/callback timeout).
+    # op2: a completed step that ran after it.
+    first_id = ctx._create_step_id_for_logical_step(1)  # noqa: SLF001
+    second_id = ctx._create_step_id_for_logical_step(2)  # noqa: SLF001
+    ctx.state._operations[first_id] = Operation(  # noqa: SLF001
+        operation_id=first_id,
+        operation_type=OperationType.CHAINED_INVOKE,
+        status=terminal_status,
+    )
+    ctx.state._operations[second_id] = _step_op(  # noqa: SLF001
+        second_id, OperationStatus.SUCCEEDED
+    )
+
+    with ctx._replay_aware():  # noqa: SLF001
+        ctx._create_step_id()  # noqa: SLF001 - consume the terminal op
+        assert ctx.is_replaying() is True
+
+    # Terminal op + completed next op => still replaying (no spurious flip).
+    assert ctx.is_replaying() is True
+
+
 def test_replay_aware_step_flips_before_retrying_op():
     """A retrying/re-executing STEP op flips to NEW BEFORE the body runs.
 

--- a/packages/aws-durable-execution-sdk-python/tests/context_test.py
+++ b/packages/aws-durable-execution-sdk-python/tests/context_test.py
@@ -35,10 +35,15 @@ from aws_durable_execution_sdk_python.lambda_service import (
     ErrorObject,
     Operation,
     OperationStatus,
-    OperationType,
     OperationSubType,
+    OperationType,
 )
-from aws_durable_execution_sdk_python.state import CheckpointedResult, ExecutionState
+from aws_durable_execution_sdk_python.plugin import PluginExecutor
+from aws_durable_execution_sdk_python.state import (
+    CheckpointedResult,
+    ExecutionState,
+    ReplayStatus,
+)
 from aws_durable_execution_sdk_python.waits import (
     WaitForConditionConfig,
     WaitForConditionDecision,
@@ -2320,3 +2325,194 @@ def test_durable_parallel_branch_is_compatible_with_parallel_functions_arg():
 
 
 # endregion durable_parallel_branch
+
+
+# region per-context replay status
+
+
+def _replay_state(operations: dict[str, Operation]) -> ExecutionState:
+    """Build a real ExecutionState seeded with the given operations."""
+    return ExecutionState(
+        durable_execution_arn="arn:aws:durable:us-east-1:123456789012:execution/test",
+        initial_checkpoint_token="token",  # noqa: S106
+        operations=operations,
+        service_client=Mock(),
+        plugin_executor=PluginExecutor(plugins=None),
+    )
+
+
+def _step_op(operation_id: str, status: OperationStatus) -> Operation:
+    return Operation(
+        operation_id=operation_id,
+        operation_type=OperationType.STEP,
+        status=status,
+    )
+
+
+def test_is_replaying_defaults_to_new_for_fresh_context():
+    """A context created without a replay seed is not replaying."""
+    ctx = create_test_context(state=_replay_state({}))
+    assert ctx.is_replaying() is False
+
+
+def test_replay_aware_flips_before_brand_new_operation():
+    """When replaying and the next op has no checkpoint, flip to NEW before it runs."""
+    ctx = DurableContext(
+        state=_replay_state({}),
+        execution_context=ExecutionContext(durable_execution_arn="arn"),
+        replay_status=ReplayStatus.REPLAY,
+    )
+    assert ctx.is_replaying() is True
+
+    inside_status: list[bool] = []
+    with ctx._replay_aware():  # noqa: SLF001
+        inside_status.append(ctx.is_replaying())
+
+    # Brand-new op (no checkpoint) flips before the body runs.
+    assert inside_status == [False]
+    assert ctx.is_replaying() is False
+
+
+def test_replay_aware_flips_after_completed_op_when_nothing_follows():
+    """A completed op with no following checkpoint crosses the boundary after the op.
+
+    The op stays replaying through its own execution (so its logs de-dup), then
+    flips to NEW afterwards because the next operation is brand-new.
+    """
+    ctx = DurableContext(
+        state=_replay_state({}),
+        execution_context=ExecutionContext(durable_execution_arn="arn"),
+        replay_status=ReplayStatus.REPLAY,
+    )
+    # The next op id this context will allocate.
+    next_id = ctx._peek_next_operation_id()  # noqa: SLF001
+    ctx.state._operations[next_id] = _step_op(  # noqa: SLF001
+        next_id, OperationStatus.SUCCEEDED
+    )
+
+    inside_status: list[bool] = []
+    with ctx._replay_aware():  # noqa: SLF001
+        # consume the id so the counter advances like a real operation
+        ctx._create_step_id()  # noqa: SLF001
+        inside_status.append(ctx.is_replaying())
+
+    # Still replaying THROUGH the completed op, then flips because nothing follows.
+    assert inside_status == [True]
+    assert ctx.is_replaying() is False
+
+
+def test_replay_aware_defers_flip_until_after_resume_point():
+    """A next op that exists but is NOT terminal is the resume point.
+
+    The context stays replaying through the op's execution (so its logs are still
+    de-duplicated) and flips to NEW only afterwards.
+    """
+    ctx = DurableContext(
+        state=_replay_state({}),
+        execution_context=ExecutionContext(durable_execution_arn="arn"),
+        replay_status=ReplayStatus.REPLAY,
+    )
+    next_id = ctx._peek_next_operation_id()  # noqa: SLF001
+    # STARTED is non-terminal: e.g. a wait whose timer just fired.
+    ctx.state._operations[next_id] = _step_op(  # noqa: SLF001
+        next_id, OperationStatus.STARTED
+    )
+
+    inside_status: list[bool] = []
+    with ctx._replay_aware():  # noqa: SLF001
+        ctx._create_step_id()  # noqa: SLF001
+        inside_status.append(ctx.is_replaying())
+
+    # Still replaying THROUGH the resume op, then flipped afterwards.
+    assert inside_status == [True]
+    assert ctx.is_replaying() is False
+
+
+def test_child_context_inherits_replaying_status():
+    """A child context inherits the parent's current replay status at creation."""
+    state = _replay_state({})
+    parent = DurableContext(
+        state=state,
+        execution_context=ExecutionContext(durable_execution_arn="arn"),
+        replay_status=ReplayStatus.REPLAY,
+    )
+    child = parent.create_child_context(operation_id="op-1")
+    assert child.is_replaying() is True
+
+    parent._set_replay_status_new()  # noqa: SLF001
+    child_after = parent.create_child_context(operation_id="op-2")
+    assert child_after.is_replaying() is False
+
+
+def test_child_context_replay_status_is_independent_of_parent():
+    """Refining a child's status does not mutate the parent's, and vice versa."""
+    state = _replay_state({})
+    parent = DurableContext(
+        state=state,
+        execution_context=ExecutionContext(durable_execution_arn="arn"),
+        replay_status=ReplayStatus.REPLAY,
+    )
+    child = parent.create_child_context(operation_id="op-1")
+
+    child._set_replay_status_new()  # noqa: SLF001
+
+    assert child.is_replaying() is False
+    assert parent.is_replaying() is True
+
+
+def test_replay_aware_flips_after_completed_op_when_next_is_brand_new():
+    """A completed op followed by a brand-new op crosses the boundary after the op.
+
+    This covers logs emitted between a completed operation (e.g. a `wait` that
+    already fired) and the next, not-yet-existing operation. Such logs must be
+    treated as new work rather than suppressed.
+    """
+    ctx = DurableContext(
+        state=_replay_state({}),
+        execution_context=ExecutionContext(durable_execution_arn="arn"),
+        replay_status=ReplayStatus.REPLAY,
+    )
+    # Next op (the one this _replay_aware wraps) already completed; the op AFTER
+    # it has no checkpoint yet.
+    next_id = ctx._peek_next_operation_id()  # noqa: SLF001
+    ctx.state._operations[next_id] = _step_op(  # noqa: SLF001
+        next_id, OperationStatus.SUCCEEDED
+    )
+
+    inside_status: list[bool] = []
+    with ctx._replay_aware():  # noqa: SLF001
+        ctx._create_step_id()  # noqa: SLF001 - consume the completed op's id
+        inside_status.append(ctx.is_replaying())
+
+    # Still replaying THROUGH the completed op, then flipped because the next
+    # operation is brand-new.
+    assert inside_status == [True]
+    assert ctx.is_replaying() is False
+
+
+def test_replay_aware_stays_replaying_between_two_completed_ops():
+    """Logs between two completed ops stay suppressed (still replaying)."""
+    ctx = DurableContext(
+        state=_replay_state({}),
+        execution_context=ExecutionContext(durable_execution_arn="arn"),
+        replay_status=ReplayStatus.REPLAY,
+    )
+    # Both the wrapped op and the following op already completed.
+    first_id = ctx._create_step_id_for_logical_step(1)  # noqa: SLF001
+    second_id = ctx._create_step_id_for_logical_step(2)  # noqa: SLF001
+    ctx.state._operations[first_id] = _step_op(  # noqa: SLF001
+        first_id, OperationStatus.SUCCEEDED
+    )
+    ctx.state._operations[second_id] = _step_op(  # noqa: SLF001
+        second_id, OperationStatus.SUCCEEDED
+    )
+
+    with ctx._replay_aware():  # noqa: SLF001
+        ctx._create_step_id()  # noqa: SLF001 - consume first completed op
+        assert ctx.is_replaying() is True
+
+    # Next op also completed, so we remain replaying.
+    assert ctx.is_replaying() is True
+
+
+# endregion per-context replay status

--- a/packages/aws-durable-execution-sdk-python/tests/execution_test.py
+++ b/packages/aws-durable-execution-sdk-python/tests/execution_test.py
@@ -34,6 +34,7 @@ from aws_durable_execution_sdk_python.lambda_service import (
     CheckpointOutput,
     CheckpointUpdatedExecutionState,
     ContextDetails,
+    DurableExecutionInvocationOutput,
     DurableServiceClient,
     ErrorObject,
     ExecutionDetails,
@@ -45,9 +46,9 @@ from aws_durable_execution_sdk_python.lambda_service import (
     StateOutput,
     StepDetails,
     WaitDetails,
-    DurableExecutionInvocationOutput,
 )
 from aws_durable_execution_sdk_python.plugin import DurableInstrumentationPlugin
+
 
 LARGE_RESULT = "large_success" * 1024 * 1024
 
@@ -2708,7 +2709,7 @@ def test_durable_execution_replays_when_paginated_state_has_prior_operations():
 
     @durable_execution
     def test_handler(event: Any, context: DurableContext) -> dict:
-        return {"is_replaying": context.state.is_replaying()}
+        return {"is_replaying": context.is_replaying()}
 
     result = test_handler(invocation_input, _make_lambda_context())
 

--- a/packages/aws-durable-execution-sdk-python/tests/logger_test.py
+++ b/packages/aws-durable-execution-sdk-python/tests/logger_test.py
@@ -8,12 +8,12 @@ from aws_durable_execution_sdk_python.identifier import OperationIdentifier
 from aws_durable_execution_sdk_python.lambda_service import (
     Operation,
     OperationStatus,
-    OperationType,
     OperationSubType,
+    OperationType,
 )
 from aws_durable_execution_sdk_python.logger import Logger, LoggerInterface, LogInfo
 from aws_durable_execution_sdk_python.plugin import PluginExecutor
-from aws_durable_execution_sdk_python.state import ExecutionState, ReplayStatus
+from aws_durable_execution_sdk_python.state import ExecutionState
 
 
 class PowertoolsLoggerStub:
@@ -375,50 +375,49 @@ def test_logger_replay_no_logging():
         operation_type=OperationType.STEP,
         status=OperationStatus.SUCCEEDED,
     )
-    replay_execution_state = ExecutionState(
+    execution_state = ExecutionState(
         durable_execution_arn="arn:aws:test",
         initial_checkpoint_token="test_token",  # noqa: S106
         operations={"op1": operation},
         service_client=Mock(),
-        replay_status=ReplayStatus.REPLAY,
         plugin_executor=PluginExecutor([]),
     )
-    log_info = LogInfo(replay_execution_state, "parent123", "test_name", 5)
+    log_info = LogInfo(execution_state, "parent123", "test_name", 5)
     mock_logger = Mock()
-    logger = Logger.from_log_info(mock_logger, log_info)
+    # Logger consults its owning context's replay status. While replaying, it
+    # suppresses logs.
+    logger = Logger.from_log_info(mock_logger, log_info, is_replaying=lambda: True)
     logger.info("logging info")
-    replay_execution_state.track_replay(operation_id="op1")
 
     mock_logger.info.assert_not_called()
 
 
 def test_logger_replay_then_new_logging():
-    operation1 = Operation(
+    operation = Operation(
         operation_id="op1",
-        operation_type=OperationType.STEP,
-        status=OperationStatus.SUCCEEDED,
-    )
-    operation2 = Operation(
-        operation_id="op2",
         operation_type=OperationType.STEP,
         status=OperationStatus.SUCCEEDED,
     )
     execution_state = ExecutionState(
         durable_execution_arn="arn:aws:test",
         initial_checkpoint_token="test_token",  # noqa: S106
-        operations={"op1": operation1, "op2": operation2},
+        operations={"op1": operation},
         service_client=Mock(),
-        replay_status=ReplayStatus.REPLAY,
         plugin_executor=PluginExecutor([]),
     )
     log_info = LogInfo(execution_state, "parent123", "test_name", 5)
     mock_logger = Mock()
-    logger = Logger.from_log_info(mock_logger, log_info)
-    execution_state.track_replay(operation_id="op1")
-    logger.info("logging info")
+    # Drive the replay status through a mutable flag standing in for the
+    # owning context's per-context status.
+    replaying = {"value": True}
+    logger = Logger.from_log_info(
+        mock_logger, log_info, is_replaying=lambda: replaying["value"]
+    )
 
+    logger.info("logging info")
     mock_logger.info.assert_not_called()
 
-    execution_state.track_replay(operation_id="op2")
+    # Once the context reaches its replay boundary, logging resumes.
+    replaying["value"] = False
     logger.info("logging info")
     mock_logger.info.assert_called_once()

--- a/packages/aws-durable-execution-sdk-python/tests/state_test.py
+++ b/packages/aws-durable-execution-sdk-python/tests/state_test.py
@@ -9,7 +9,7 @@ import threading
 import time
 import unittest.mock
 from concurrent.futures import ThreadPoolExecutor
-from unittest.mock import Mock, call, patch, create_autospec
+from unittest.mock import Mock, call, create_autospec, patch
 
 import pytest
 
@@ -32,11 +32,11 @@ from aws_durable_execution_sdk_python.lambda_service import (
     Operation,
     OperationAction,
     OperationStatus,
+    OperationSubType,
     OperationType,
     OperationUpdate,
     StateOutput,
     StepDetails,
-    OperationSubType,
 )
 from aws_durable_execution_sdk_python.plugin import (
     DurableInstrumentationPlugin,
@@ -47,7 +47,6 @@ from aws_durable_execution_sdk_python.state import (
     CheckpointedResult,
     ExecutionState,
     QueuedOperation,
-    ReplayStatus,
 )
 from aws_durable_execution_sdk_python.threading import CompletionEvent
 
@@ -3452,64 +3451,47 @@ def test_create_checkpoint_sync_always_synchronous():
         executor.shutdown(wait=True)
 
 
-def test_state_replay_mode():
+def test_state_has_prior_operations_true_when_non_execution_op_exists():
     operation1 = Operation(
         operation_id="op1",
-        operation_type=OperationType.STEP,
-        status=OperationStatus.SUCCEEDED,
-    )
-    operation2 = Operation(
-        operation_id="op2",
         operation_type=OperationType.STEP,
         status=OperationStatus.SUCCEEDED,
     )
     execution_state = ExecutionState(
         durable_execution_arn="arn:aws:test",
         initial_checkpoint_token="test_token",  # noqa: S106
-        operations={"op1": operation1, "op2": operation2},
+        operations={"op1": operation1},
         service_client=Mock(),
         plugin_executor=PluginExecutor(plugins=None),
-        replay_status=ReplayStatus.REPLAY,
     )
-    assert execution_state.is_replaying() is True
-    execution_state.track_replay(operation_id="op1")
-    assert execution_state.is_replaying() is True
-    execution_state.track_replay(operation_id="op2")
-    assert execution_state.is_replaying() is False
+    assert execution_state.has_prior_operations() is True
 
 
-def test_state_replay_mode_with_timed_out():
-    """Test that TIMED_OUT operations are treated as terminal states for replay tracking.
-
-    This test verifies that when an operation has TIMED_OUT status, it is correctly
-    recognized as a completed/terminal state, allowing the replay status to transition
-    from REPLAY to NEW once all completed operations have been visited.
-
-    Regression test for: https://github.com/aws/aws-durable-execution-sdk-python/issues/262
-    """
-    operation1 = Operation(
-        operation_id="op1",
-        operation_type=OperationType.STEP,
-        status=OperationStatus.TIMED_OUT,
-    )
-    operation2 = Operation(
-        operation_id="op2",
-        operation_type=OperationType.STEP,
-        status=OperationStatus.SUCCEEDED,
+def test_state_has_prior_operations_false_when_only_execution_op_exists():
+    execution_op = Operation(
+        operation_id="exec1",
+        operation_type=OperationType.EXECUTION,
+        status=OperationStatus.STARTED,
     )
     execution_state = ExecutionState(
         durable_execution_arn="arn:aws:test",
         initial_checkpoint_token="test_token",  # noqa: S106
-        operations={"op1": operation1, "op2": operation2},
+        operations={"exec1": execution_op},
         service_client=Mock(),
         plugin_executor=PluginExecutor(plugins=None),
-        replay_status=ReplayStatus.REPLAY,
     )
-    assert execution_state.is_replaying() is True
-    execution_state.track_replay(operation_id="op1")
-    assert execution_state.is_replaying() is True
-    execution_state.track_replay(operation_id="op2")
-    assert execution_state.is_replaying() is False
+    assert execution_state.has_prior_operations() is False
+
+
+def test_state_has_prior_operations_false_when_empty():
+    execution_state = ExecutionState(
+        durable_execution_arn="arn:aws:test",
+        initial_checkpoint_token="test_token",  # noqa: S106
+        operations={},
+        service_client=Mock(),
+        plugin_executor=PluginExecutor(plugins=None),
+    )
+    assert execution_state.has_prior_operations() is False
 
 
 # Tests for empty checkpoint coalescing (issue #325)
@@ -4262,16 +4244,13 @@ def test_plugin_executor_not_called_for_pending_operations():
 # endregion Plugin Executor Integration Tests
 
 
-def _make_execution_state_for_operations(
-    mock_lambda_client, *, replay_status=ReplayStatus.NEW, operations=None
-):
+def _make_execution_state_for_operations(mock_lambda_client, *, operations=None):
     return ExecutionState(
         durable_execution_arn="test_arn",
         initial_checkpoint_token="token123",  # noqa: S106
         operations=operations or {},
         service_client=mock_lambda_client,
         plugin_executor=PluginExecutor(plugins=None),
-        replay_status=replay_status,
     )
 
 
@@ -4295,18 +4274,16 @@ def test_operations_property_returns_snapshot_copy():
     assert len(state.operations) == 1
 
 
-def test_track_replay_iteration_safe_under_concurrent_update():
-    """track_replay must not raise when operations are updated concurrently.
+def test_has_prior_operations_iteration_safe_under_concurrent_update():
+    """has_prior_operations must not raise when operations are updated concurrently.
 
-    A worker thread iterates operations inside track_replay while the checkpoint
-    path updates the same map. Without consistent locking this raises
+    A worker thread iterates operations inside has_prior_operations while the
+    checkpoint path updates the same map. Without consistent locking this raises
     "dictionary changed size during iteration".
     """
     mock_lambda_client = Mock(spec=LambdaClient)
-    state = _make_execution_state_for_operations(
-        mock_lambda_client, replay_status=ReplayStatus.REPLAY
-    )
-    # Seed completed operations so track_replay keeps iterating (stays REPLAY).
+    state = _make_execution_state_for_operations(mock_lambda_client)
+    # Seed completed operations so iteration has work to do.
     for i in range(50):
         state._operations[f"seed{i}"] = Operation(
             operation_id=f"seed{i}",
@@ -4331,7 +4308,7 @@ def test_track_replay_iteration_safe_under_concurrent_update():
     def reader():
         try:
             for _ in range(2000):
-                state.track_replay(operation_id="probe")
+                state.has_prior_operations()
         except Exception as e:  # noqa: BLE001
             errors.append(e)
 
@@ -4343,4 +4320,4 @@ def test_track_replay_iteration_safe_under_concurrent_update():
     stop.set()
     writer_t.join(timeout=5)
 
-    assert not errors, f"track_replay raced with concurrent update: {errors}"
+    assert not errors, f"has_prior_operations raced with concurrent update: {errors}"

--- a/packages/aws-durable-execution-sdk-python/tests/state_test.py
+++ b/packages/aws-durable-execution-sdk-python/tests/state_test.py
@@ -643,6 +643,46 @@ def test_checkpointed_result_is_timed_out_false_for_other_statuses():
         )
 
 
+def test_checkpointed_result_is_terminal():
+    """Test CheckpointedResult.is_terminal for terminal vs non-terminal statuses."""
+    terminal_statuses = [
+        OperationStatus.SUCCEEDED,
+        OperationStatus.FAILED,
+        OperationStatus.CANCELLED,
+        OperationStatus.TIMED_OUT,
+        OperationStatus.STOPPED,
+    ]
+    for status in terminal_statuses:
+        operation = Operation(
+            operation_id="op1",
+            operation_type=OperationType.STEP,
+            status=status,
+        )
+        result = CheckpointedResult.create_from_operation(operation)
+        assert result.is_terminal() is True, (
+            f"is_terminal should be True for status {status}"
+        )
+
+    non_terminal_statuses = [
+        OperationStatus.STARTED,
+        OperationStatus.PENDING,
+        OperationStatus.READY,
+    ]
+    for status in non_terminal_statuses:
+        operation = Operation(
+            operation_id="op1",
+            operation_type=OperationType.STEP,
+            status=status,
+        )
+        result = CheckpointedResult.create_from_operation(operation)
+        assert result.is_terminal() is False, (
+            f"is_terminal should be False for status {status}"
+        )
+
+    # Test with no operation
+    assert CheckpointedResult.create_not_found().is_terminal() is False
+
+
 def test_fetch_paginated_operations_with_marker():
     mock_lambda_client = Mock(spec=LambdaClient)
 


### PR DESCRIPTION
*Issue #, if available:* first piece of #389

## Summary

Track replay status per-context instead of as a single execution-wide flag.

## Changes

- **`context.py`**: `DurableContext` owns its replay status, seeded from its
  creator and refined per-operation via a `_replay_aware()` context manager.
  Added public `context.is_replaying()`.
- **`logger.py`**: `Logger` consults a per-context `is_replaying` callable
  instead of holding `ExecutionState`.
- **`state.py`**: removed the global replay machinery (`track_replay`,
  `is_replaying`, `_visited_operations`); added `has_prior_operations()` for
  execution-level first-invocation detection.
- **`execution.py`**: seeds the root context's status; uses
  `has_prior_operations()` for the plugin `is_first_invocation` flag.
- **`concurrency/executor.py`**: branches track their own status; removed the
  per-branch `track_replay` call.

## Replay boundary behavior

`_replay_aware()` flips REPLAY→NEW at three points:
- **before** an op with no checkpoint (brand-new code),
- **after** a non-terminal op (the resume point — its own logs stay deduped),
- **after** a completed op when the next op doesn't exist yet (so bare logs
  immediately after a `wait` are treated as new, not suppressed).

The third case fixes a regression where a log right after a `wait` was
silently dropped on replay.

## Testing
Logging from examples:

### Invocation 1 (requestId 8b1e9590) — first run, suspends at parent wait
| message                        | is_replaying | operationName |
|--------------------------------|--------------|---------------|
| Workflow started (before wait) | false        | —             |
| Preparing item                 | —            | prepare       |
| Prepared, about to wait        | false        | —             |

### Invocation 2 (requestId a46ca6bd) — parent wait fired
| message                                    | is_replaying / child_is_replaying |
|--------------------------------------------|-----------------------------------|
| Resumed after wait                         | false                             |
| Auditing in child context (before child wait) | false (child)                 |
*(before-wait lines from invocation 1 are NOT repeated — de-duplicated)*

### Invocation 3 (requestId 22d99bc2) — child wait fired
| message                                   | child_is_replaying | operationName |
|-------------------------------------------|--------------------|---------------|
| Resumed in child context (after child wait) | false            | —             |
| Finalizing item                           | —                  | finalize      |
| Workflow completed                        | —                  | —             |
*(all parent + child before-wait lines NOT repeated — de-duplicated)*



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
