### PR TITLE
chore(lint): Enable Pyflakes rules across all packages

### DIFF
--- a/.github/scripts/tests/test_lintcommit.py
+++ b/.github/scripts/tests/test_lintcommit.py
@@ -9,7 +9,6 @@ from unittest.mock import patch
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
-import pytest
 from lintcommit import lint_range, validate_message, validate_subject
 
 # region validate_subject: valid subjects

--- a/packages/aws-durable-execution-sdk-python-examples/cli.py
+++ b/packages/aws-durable-execution-sdk-python-examples/cli.py
@@ -1,0 +1,502 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import time
+import zipfile
+from pathlib import Path
+
+
+# Configure logging
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+
+try:
+    import boto3
+
+    from aws_durable_execution_sdk_python.lambda_service import LambdaClient  # noqa: F401
+except ImportError:
+    sys.exit(1)
+
+
+def load_catalog():
+    """Load examples catalog."""
+    catalog_path = Path(__file__).parent / "examples-catalog.json"
+    with open(catalog_path) as f:
+        return json.load(f)
+
+
+def build_examples():
+    """Build examples with SDK dependencies."""
+
+    build_dir = Path(__file__).parent / "build"
+    src_dir = Path(__file__).parent / "src"
+    packages_dir = Path(__file__).parent.parent
+
+    logger.info("Building examples...")
+
+    # Clean and create build directory
+    if build_dir.exists():
+        logger.info("Cleaning existing build directory")
+        shutil.rmtree(build_dir)
+    build_dir.mkdir()
+
+    # Install local packages so their runtime dependencies are included in
+    # the Lambda deployment package.
+    runtime_packages = [
+        packages_dir / "aws-durable-execution-sdk-python",
+        packages_dir / "aws-durable-execution-sdk-python-otel",
+        packages_dir / "aws-durable-execution-sdk-python-testing",
+    ]
+    try:
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                "--upgrade",
+                "--target",
+                str(build_dir),
+                *[str(package) for package in runtime_packages],
+            ],
+            check=True,
+        )
+    except subprocess.CalledProcessError:
+        logger.exception("Failed to install runtime dependencies")
+        return False
+
+    # Copy example functions
+    logger.info("Copying examples from %s", src_dir)
+    for file_path in src_dir.rglob("*"):
+        if file_path.is_file():
+            shutil.copy2(file_path, build_dir / file_path.name)
+
+    logger.info("Build completed successfully")
+    return True
+
+
+def create_kms_key(kms_client, account_id):
+    """Create KMS key for durable functions encryption."""
+    key_policy = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "Enable IAM User Permissions",
+                "Effect": "Allow",
+                "Principal": {"AWS": f"arn:aws:iam::{account_id}:root"},
+                "Action": "kms:*",
+                "Resource": "*",
+            },
+            {
+                "Sid": "Allow Lambda service",
+                "Effect": "Allow",
+                "Principal": {"Service": "lambda.amazonaws.com"},
+                "Action": ["kms:Decrypt", "kms:Encrypt", "kms:CreateGrant"],
+                "Resource": "*",
+            },
+        ],
+    }
+
+    try:
+        response = kms_client.create_key(
+            Description="KMS key for Lambda Durable Functions environment variable encryption",
+            KeyUsage="ENCRYPT_DECRYPT",
+            KeySpec="SYMMETRIC_DEFAULT",
+            Policy=json.dumps(key_policy),
+        )
+
+        return response["KeyMetadata"]["Arn"]
+
+    except (kms_client.exceptions.ClientError, KeyError):
+        return None
+
+
+def bootstrap_account():
+    """Bootstrap account with necessary IAM role and KMS key."""
+    account_id = os.getenv("AWS_ACCOUNT_ID")
+    region = os.getenv("AWS_REGION", "us-west-2")
+
+    if not account_id:
+        return False
+
+    # Create KMS key first
+    kms_client = boto3.client("kms", region_name=region)
+    kms_key_arn = create_kms_key(kms_client, account_id)
+    if not kms_key_arn:
+        return False
+
+    iam_client = boto3.client("iam", region_name=region)
+    role_name = "DurableFunctionsIntegrationTestRole"
+
+    trust_policy = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": {
+                    "Service": ["lambda.amazonaws.com", "devo.lambda.aws.internal"]
+                },
+                "Action": "sts:AssumeRole",
+            }
+        ],
+    }
+
+    lambda_policy = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Action": [
+                    "lambda:CheckpointDurableExecution",
+                    "lambda:GetDurableExecutionState",
+                ],
+                "Resource": "*",
+                "Effect": "Allow",
+            }
+        ],
+    }
+
+    logs_policy = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Action": [
+                    "logs:CreateLogGroup",
+                    "logs:CreateLogStream",
+                    "logs:PutLogEvents",
+                ],
+                "Resource": "*",
+                "Effect": "Allow",
+            }
+        ],
+    }
+
+    kms_policy = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Action": ["kms:CreateGrant", "kms:Decrypt", "kms:Encrypt"],
+                "Resource": kms_key_arn,
+                "Effect": "Allow",
+            }
+        ],
+    }
+
+    try:
+        iam_client.create_role(
+            RoleName=role_name,
+            AssumeRolePolicyDocument=json.dumps(trust_policy),
+            Description="Role for AWS Durable Functions integration testing",
+        )
+
+        iam_client.put_role_policy(
+            RoleName=role_name,
+            PolicyName="LambdaPolicy",
+            PolicyDocument=json.dumps(lambda_policy),
+        )
+
+        iam_client.put_role_policy(
+            RoleName=role_name,
+            PolicyName="LogsPolicy",
+            PolicyDocument=json.dumps(logs_policy),
+        )
+
+        iam_client.put_role_policy(
+            RoleName=role_name,
+            PolicyName="DurableFunctionsLambdaStagingKMSPolicy",
+            PolicyDocument=json.dumps(kms_policy),
+        )
+
+    except iam_client.exceptions.EntityAlreadyExistsException:
+        pass
+    except iam_client.exceptions.ClientError:
+        return False
+    else:
+        return True
+
+    return True
+
+
+def create_deployment_package(example_name: str) -> Path:
+    """Create deployment package for example."""
+
+    build_dir = Path(__file__).parent / "build"
+    if not build_dir.exists() and not build_examples():
+        msg = "Failed to build examples"
+        raise ValueError(msg)
+
+    zip_path = Path(__file__).parent / f"{example_name}.zip"
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        # Add SDK dependencies
+        for file_path in build_dir.rglob("*"):
+            if file_path.is_file() and not file_path.is_relative_to(build_dir / "src"):
+                zf.write(file_path, file_path.relative_to(build_dir))
+
+        # Add example files at root level
+        src_dir = build_dir / "src"
+        for file_path in src_dir.rglob("*"):
+            if file_path.is_file():
+                zf.write(file_path, file_path.relative_to(src_dir))
+
+    return zip_path
+
+
+def get_aws_config():
+    """Get AWS configuration from environment."""
+    config = {
+        "region": os.getenv("AWS_REGION", "us-west-2"),
+        "lambda_endpoint": os.getenv(
+            "LAMBDA_ENDPOINT", "https://lambda.us-west-2.amazonaws.com"
+        ),
+        "account_id": os.getenv("AWS_ACCOUNT_ID"),
+        "kms_key_arn": os.getenv("KMS_KEY_ARN"),
+    }
+
+    if not config["account_id"]:
+        msg = "Missing AWS_ACCOUNT_ID"
+        raise ValueError(msg)
+
+    return config
+
+
+def get_lambda_client():
+    """Get configured Lambda client."""
+    config = get_aws_config()
+    return boto3.client(
+        "lambda",
+        endpoint_url=config["lambda_endpoint"],
+        region_name=config["region"],
+        config=boto3.session.Config(parameter_validation=False),
+    )
+
+
+def retry_on_resource_conflict(func, *args, max_retries=5, **kwargs):
+    """Retry function on ResourceConflictException."""
+    for attempt in range(max_retries):
+        try:
+            return func(*args, **kwargs)
+        except Exception as e:
+            if (
+                hasattr(e, "response")
+                and e.response.get("Error", {}).get("Code")
+                == "ResourceConflictException"
+                and attempt < max_retries - 1
+            ):
+                wait_time = 2**attempt  # Exponential backoff
+                logger.info(
+                    "ResourceConflictException on attempt %d, retrying in %ds...",
+                    attempt + 1,
+                    wait_time,
+                )
+                time.sleep(wait_time)
+                continue
+            raise
+    return None
+
+
+def deploy_function(example_name: str, function_name: str | None = None):
+    """Deploy function to AWS Lambda."""
+    catalog = load_catalog()
+
+    example_config = None
+    for example in catalog["examples"]:
+        if example["name"] == example_name:
+            example_config = example
+            break
+
+    if not example_config:
+        logger.error("Example not found: '%s'", example_name)
+        list_examples()
+        return False
+
+    if not function_name:
+        function_name = f"{example_name.replace(' ', '')}-Python"
+
+    handler_file = example_config["handler"].replace(".handler", "")
+    zip_path = create_deployment_package(handler_file)
+    config = get_aws_config()
+    lambda_client = get_lambda_client()
+
+    role_arn = (
+        f"arn:aws:iam::{config['account_id']}:role/DurableFunctionsIntegrationTestRole"
+    )
+
+    env_vars = {"AWS_ENDPOINT_URL_LAMBDA": config["lambda_endpoint"]}
+    env_vars.update(example_config.get("environment", {}))
+
+    function_config = {
+        "FunctionName": function_name,
+        "Runtime": "python3.13",
+        "Role": role_arn,
+        "Handler": example_config["handler"],
+        "Description": example_config["description"],
+        "Timeout": 60,
+        "MemorySize": 128,
+        "Environment": {"Variables": env_vars},
+        "DurableConfig": example_config["durableConfig"],
+        "LoggingConfig": example_config.get("loggingConfig", {}),
+    }
+
+    if "layers" in example_config:
+        function_config["Layers"] = example_config["layers"]
+
+    if "tracing" in example_config:
+        function_config["TracingConfig"] = {"Mode": example_config["tracing"]}
+
+    if config["kms_key_arn"]:
+        function_config["KMSKeyArn"] = config["kms_key_arn"]
+
+    with open(zip_path, "rb") as f:
+        zip_content = f.read()
+
+    try:
+        lambda_client.get_function(FunctionName=function_name)
+        retry_on_resource_conflict(
+            lambda_client.update_function_code,
+            FunctionName=function_name,
+            ZipFile=zip_content,
+            max_retries=8,
+        )
+        retry_on_resource_conflict(
+            lambda_client.update_function_configuration, **function_config
+        )
+
+    except lambda_client.exceptions.ResourceNotFoundException:
+        lambda_client.create_function(**function_config, Code={"ZipFile": zip_content})
+
+    logger.info("Function deployed successfully! %s", function_name)
+    return True
+
+
+def invoke_function(function_name: str, payload: str = "{}"):
+    """Invoke a deployed function."""
+    lambda_client = get_lambda_client()
+
+    try:
+        response = lambda_client.invoke(FunctionName=function_name, Payload=payload)
+
+        result = json.loads(response["Payload"].read())
+
+        if "DurableExecutionArn" in result:
+            pass
+
+        return result.get("DurableExecutionArn")
+
+    except lambda_client.exceptions.ClientError:
+        return None
+
+
+def get_execution(execution_arn: str):
+    """Get execution details."""
+    lambda_client = get_lambda_client()
+
+    try:
+        return lambda_client.get_durable_execution(DurableExecutionArn=execution_arn)
+    except lambda_client.exceptions.ClientError:
+        return None
+
+
+def get_execution_history(execution_arn: str):
+    """Get execution history."""
+    lambda_client = get_lambda_client()
+
+    try:
+        return lambda_client.get_durable_execution_history(
+            DurableExecutionArn=execution_arn
+        )
+    except lambda_client.exceptions.ClientError:
+        return None
+
+
+def get_function_policy(function_name: str):
+    """Get function resource policy."""
+    lambda_client = get_lambda_client()
+
+    try:
+        response = lambda_client.get_policy(FunctionName=function_name)
+        return json.loads(response["Policy"])
+    except lambda_client.exceptions.ResourceNotFoundException:
+        return None
+    except (lambda_client.exceptions.ClientError, json.JSONDecodeError):
+        return None
+
+
+def list_examples():
+    """List available examples."""
+    catalog = load_catalog()
+    logger.info("Available examples:")
+    for example in catalog["examples"]:
+        logger.info("  - %s: %s", example["name"], example["description"])
+
+
+def main():
+    """Main CLI function."""
+    parser = argparse.ArgumentParser(description="Durable Functions Examples CLI")
+    subparsers = parser.add_subparsers(dest="command", help="Available commands")
+
+    # Bootstrap command
+    subparsers.add_parser("bootstrap", help="Bootstrap account with necessary IAM role")
+
+    # Build command
+    subparsers.add_parser("build", help="Build examples with dependencies")
+
+    # List command
+    subparsers.add_parser("list", help="List available examples")
+
+    # Deploy command
+    deploy_parser = subparsers.add_parser("deploy", help="Deploy an example")
+    deploy_parser.add_argument("example_name", help="Name of example to deploy")
+    deploy_parser.add_argument("--function-name", help="Custom function name")
+
+    # Invoke command
+    invoke_parser = subparsers.add_parser("invoke", help="Invoke a deployed function")
+    invoke_parser.add_argument("function_name", help="Name of function to invoke")
+    invoke_parser.add_argument("--payload", default="{}", help="JSON payload to send")
+
+    # Get command
+    get_parser = subparsers.add_parser("get", help="Get execution details")
+    get_parser.add_argument("execution_arn", help="Execution ARN")
+
+    # Policy command
+    policy_parser = subparsers.add_parser("policy", help="Get function resource policy")
+    policy_parser.add_argument("function_name", help="Function name")
+
+    # History command
+    history_parser = subparsers.add_parser("history", help="Get execution history")
+    history_parser.add_argument("execution_arn", help="Execution ARN")
+
+    args = parser.parse_args()
+
+    if not args.command:
+        parser.print_help()
+        return
+
+    try:
+        if args.command == "bootstrap":
+            bootstrap_account()
+        elif args.command == "build":
+            build_examples()
+        elif args.command == "list":
+            list_examples()
+        elif args.command == "deploy":
+            deploy_function(args.example_name, args.function_name)
+        elif args.command == "invoke":
+            invoke_function(args.function_name, args.payload)
+        elif args.command == "policy":
+            get_function_policy(args.function_name)
+        elif args.command == "get":
+            get_execution(args.execution_arn)
+        elif args.command == "history":
+            get_execution_history(args.execution_arn)
+    except (KeyboardInterrupt, SystemExit):
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/aws-durable-execution-sdk-python-examples/pyproject.toml
+++ b/packages/aws-durable-execution-sdk-python-examples/pyproject.toml
@@ -22,7 +22,7 @@ target-version = "py311"
 
 [tool.ruff.lint]
 preview = true
-select = ["TID252"]  # Enforce absolute imports (ban relative imports)
+select = ["E4", "E7", "E9", "F", "TID252"]  # pycodestyle (E4/E7/E9) + Pyflakes + absolute imports
 
 [tool.ruff.lint.isort]
 known-first-party = ["aws_durable_execution_sdk_python"]

--- a/packages/aws-durable-execution-sdk-python-examples/src/callback/callback_mixed_ops.py
+++ b/packages/aws-durable-execution-sdk-python-examples/src/callback/callback_mixed_ops.py
@@ -1,6 +1,5 @@
 """Demonstrates createCallback mixed with steps, waits, and other operations."""
 
-import time
 from typing import Any
 
 from aws_durable_execution_sdk_python.config import CallbackConfig, Duration

--- a/packages/aws-durable-execution-sdk-python-examples/src/callback/callback_serdes.py
+++ b/packages/aws-durable-execution-sdk-python-examples/src/callback/callback_serdes.py
@@ -1,7 +1,7 @@
 """Demonstrates createCallback with custom serialization/deserialization for Date objects."""
 
 import json
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any, Optional
 
 from aws_durable_execution_sdk_python.config import CallbackConfig, Duration

--- a/packages/aws-durable-execution-sdk-python-examples/src/filesystem_serdes/filesystem_serdes_basic.py
+++ b/packages/aws-durable-execution-sdk-python-examples/src/filesystem_serdes/filesystem_serdes_basic.py
@@ -18,8 +18,6 @@ from aws_durable_execution_sdk_python.config import StepConfig
 from aws_durable_execution_sdk_python.context import DurableContext
 from aws_durable_execution_sdk_python.execution import durable_execution
 from aws_durable_execution_sdk_python.filesystem_serdes import (
-    FileSystemSerDesConfig,
-    FileSystemSerDesMode,
     FileSystemSerDes,
 )
 

--- a/packages/aws-durable-execution-sdk-python-examples/src/map/map_completion.py
+++ b/packages/aws-durable-execution-sdk-python-examples/src/map/map_completion.py
@@ -35,7 +35,7 @@ def handler(_event: Any, context: DurableContext) -> dict[str, Any]:
     )
 
     context.logger.info(
-        f"Starting map with config: min_successful=2, tolerated_failure_percentage=50"
+        "Starting map with config: min_successful=2, tolerated_failure_percentage=50"
     )
     context.logger.info(
         f"Items pattern: {', '.join(['FAIL' if i['shouldFail'] else 'SUCCESS' for i in items])}"

--- a/packages/aws-durable-execution-sdk-python-examples/src/wait_for_callback/wait_for_callback_serdes.py
+++ b/packages/aws-durable-execution-sdk-python-examples/src/wait_for_callback/wait_for_callback_serdes.py
@@ -2,7 +2,7 @@
 
 import json
 from datetime import datetime
-from typing import Any, Optional, TypedDict
+from typing import Any, TypedDict
 
 from aws_durable_execution_sdk_python.config import Duration, WaitForCallbackConfig
 from aws_durable_execution_sdk_python.context import DurableContext

--- a/packages/aws-durable-execution-sdk-python-examples/src/wait_for_callback/wait_for_callback_submitter_failure.py
+++ b/packages/aws-durable-execution-sdk-python-examples/src/wait_for_callback/wait_for_callback_submitter_failure.py
@@ -32,7 +32,7 @@ def handler(event: dict[str, Any], context: DurableContext) -> dict[str, Any]:
         ),
     )
 
-    result: str = context.wait_for_callback(
+    context.wait_for_callback(
         submitter,
         name="retry-submitter-callback",
         config=config,

--- a/packages/aws-durable-execution-sdk-python-examples/test/callback/test_callback_mixed_ops.py
+++ b/packages/aws-durable-execution-sdk-python-examples/test/callback/test_callback_mixed_ops.py
@@ -1,7 +1,6 @@
 """Tests for create_callback_mixed_ops."""
 
 import json
-import time
 
 import pytest
 from aws_durable_execution_sdk_python.execution import InvocationStatus

--- a/packages/aws-durable-execution-sdk-python-examples/test/callback/test_callback_serdes.py
+++ b/packages/aws-durable-execution-sdk-python-examples/test/callback/test_callback_serdes.py
@@ -1,6 +1,5 @@
 """Tests for create_callback_serdes."""
 
-import json
 from datetime import datetime, timezone
 
 import pytest

--- a/packages/aws-durable-execution-sdk-python-examples/test/map/test_map_operations.py
+++ b/packages/aws-durable-execution-sdk-python-examples/test/map/test_map_operations.py
@@ -4,7 +4,6 @@ import pytest
 from aws_durable_execution_sdk_python.execution import InvocationStatus
 from aws_durable_execution_sdk_python.lambda_service import (
     OperationStatus,
-    OperationType,
 )
 
 from src.map import map_operations

--- a/packages/aws-durable-execution-sdk-python-examples/test/wait_for_callback/test_wait_for_callback_multiple_invocations.py
+++ b/packages/aws-durable-execution-sdk-python-examples/test/wait_for_callback/test_wait_for_callback_multiple_invocations.py
@@ -1,7 +1,6 @@
 """Tests for wait_for_callback_multiple_invocations."""
 
 import json
-import time
 
 import pytest
 from aws_durable_execution_sdk_python.execution import InvocationStatus

--- a/packages/aws-durable-execution-sdk-python-examples/test/wait_for_callback/test_wait_for_callback_serdes.py
+++ b/packages/aws-durable-execution-sdk-python-examples/test/wait_for_callback/test_wait_for_callback_serdes.py
@@ -1,6 +1,5 @@
 """Tests for wait_for_callback_serdes."""
 
-import json
 from datetime import datetime, timezone
 
 import pytest

--- a/packages/aws-durable-execution-sdk-python-examples/test/wait_for_callback/test_wait_for_callback_submitter_failure.py
+++ b/packages/aws-durable-execution-sdk-python-examples/test/wait_for_callback/test_wait_for_callback_submitter_failure.py
@@ -1,7 +1,5 @@
 """Tests for wait_for_callback_submitter_retry_success."""
 
-import json
-
 import pytest
 from aws_durable_execution_sdk_python.execution import InvocationStatus
 

--- a/packages/aws-durable-execution-sdk-python-examples/test/wait_for_callback/test_wait_for_callback_submitter_failure_catchable.py
+++ b/packages/aws-durable-execution-sdk-python-examples/test/wait_for_callback/test_wait_for_callback_submitter_failure_catchable.py
@@ -1,7 +1,6 @@
 """Tests for wait_for_callback_failing_submitter."""
 
 import pytest
-from aws_durable_execution_sdk_python.execution import InvocationStatus
 
 from src.wait_for_callback import wait_for_callback_submitter_failure_catchable
 from test.conftest import deserialize_operation_payload

--- a/packages/aws-durable-execution-sdk-python-examples/test/wait_for_condition/test_wait_for_condition.py
+++ b/packages/aws-durable-execution-sdk-python-examples/test/wait_for_condition/test_wait_for_condition.py
@@ -1,10 +1,8 @@
 """Tests for wait_for_condition."""
 
 import pytest
-from aws_durable_execution_sdk_python.execution import InvocationStatus
 
 from src.wait_for_condition import wait_for_condition
-from test.conftest import deserialize_operation_payload
 
 
 @pytest.mark.example

--- a/packages/aws-durable-execution-sdk-python-otel/pyproject.toml
+++ b/packages/aws-durable-execution-sdk-python-otel/pyproject.toml
@@ -72,7 +72,7 @@ target-version = "py311"
 
 [tool.ruff.lint]
 preview = true
-select = ["TID252"]
+select = ["E4", "E7", "E9", "F", "TID252"]  # pycodestyle (E4/E7/E9) + Pyflakes + absolute imports
 
 [tool.ruff.lint.isort]
 known-first-party = ["aws_durable_execution_sdk_python_otel"]

--- a/packages/aws-durable-execution-sdk-python-otel/tests/test_deterministic_id_generator.py
+++ b/packages/aws-durable-execution-sdk-python-otel/tests/test_deterministic_id_generator.py
@@ -9,7 +9,6 @@ from datetime import UTC, datetime
 from opentelemetry.sdk.trace import IdGenerator, RandomIdGenerator
 
 from aws_durable_execution_sdk_python_otel.deterministic_id_generator import (
-    HASHED_ID_PATTERN,
     DeterministicIdGenerator,
     _parse_xray_root_trace_id,
     _to_otel_trace_id,

--- a/packages/aws-durable-execution-sdk-python-testing/pyproject.toml
+++ b/packages/aws-durable-execution-sdk-python-testing/pyproject.toml
@@ -104,8 +104,8 @@ line-length = 88
 target-version = "py311"
 
 [tool.ruff.lint]
-preview = false
-select = ["TID252"]  # Enforce absolute imports (ban relative imports)
+preview = true
+select = ["E4", "E7", "E9", "F", "TID252"]  # pycodestyle (E4/E7/E9) + Pyflakes + absolute imports
 
 [tool.ruff.lint.isort]
 known-first-party = ["aws_durable_execution_sdk_python_testing"]

--- a/packages/aws-durable-execution-sdk-python-testing/src/aws_durable_execution_sdk_python_testing/checkpoint/transformer.py
+++ b/packages/aws-durable-execution-sdk-python-testing/src/aws_durable_execution_sdk_python_testing/checkpoint/transformer.py
@@ -40,7 +40,6 @@ if TYPE_CHECKING:
     from collections.abc import Callable, MutableMapping
 
     from aws_durable_execution_sdk_python.lambda_service import (
-        Operation,
         OperationUpdate,
     )
 

--- a/packages/aws-durable-execution-sdk-python-testing/src/aws_durable_execution_sdk_python_testing/cli.py
+++ b/packages/aws-durable-execution-sdk-python-testing/src/aws_durable_execution_sdk_python_testing/cli.py
@@ -19,7 +19,6 @@ from dataclasses import dataclass
 from typing import Any
 from urllib.parse import urljoin
 
-import aws_durable_execution_sdk_python
 import boto3  # type: ignore
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen

--- a/packages/aws-durable-execution-sdk-python-testing/src/aws_durable_execution_sdk_python_testing/executor.py
+++ b/packages/aws-durable-execution-sdk-python-testing/src/aws_durable_execution_sdk_python_testing/executor.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import threading
-import time
 import uuid
 from datetime import UTC, datetime
 from enum import Enum
@@ -26,7 +25,6 @@ from aws_durable_execution_sdk_python.lambda_service import (
     CallbackOptions,
     CallbackTimeoutType,
     StepDetails,
-    StepOptions,
 )
 
 from aws_durable_execution_sdk_python_testing.checkpoint.core import CheckpointCore
@@ -40,7 +38,6 @@ from aws_durable_execution_sdk_python_testing.checkpoint.validators.checkpoint i
     CheckpointValidator,
 )
 from aws_durable_execution_sdk_python_testing.exceptions import (
-    ExecutionAlreadyStartedException,
     IllegalStateException,
     InvalidParameterValueException,
     ResourceNotFoundException,
@@ -54,7 +51,6 @@ from aws_durable_execution_sdk_python_testing.model import (
     CheckpointDurableExecutionResponse,
     CheckpointUpdatedExecutionState,
     EventCreationContext,
-    EventType,
     GetDurableExecutionHistoryResponse,
     GetDurableExecutionResponse,
     GetDurableExecutionStateResponse,

--- a/packages/aws-durable-execution-sdk-python-testing/src/aws_durable_execution_sdk_python_testing/runner.py
+++ b/packages/aws-durable-execution-sdk-python-testing/src/aws_durable_execution_sdk_python_testing/runner.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import time
 import warnings
 from dataclasses import dataclass, field
@@ -17,7 +16,6 @@ from typing import (
     cast,
 )
 
-import aws_durable_execution_sdk_python
 import boto3  # type: ignore
 from botocore.exceptions import ClientError  # type: ignore
 from aws_durable_execution_sdk_python.execution import (
@@ -757,7 +755,7 @@ class DurableFunctionTestRunner:
                 )
                 if callback_id:
                     return callback_id
-            except ResourceNotFoundException as e:
+            except ResourceNotFoundException:
                 pass
             except Exception as e:
                 msg = f"Failed to fetch execution history: {e}"

--- a/packages/aws-durable-execution-sdk-python-testing/src/aws_durable_execution_sdk_python_testing/web/handlers.py
+++ b/packages/aws-durable-execution-sdk-python-testing/src/aws_durable_execution_sdk_python_testing/web/handlers.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import base64
 import json
 import logging
 from abc import ABC, abstractmethod
@@ -26,7 +25,6 @@ from aws_durable_execution_sdk_python_testing.model import (
     ListDurableExecutionsResponse,
     SendDurableExecutionCallbackFailureRequest,
     SendDurableExecutionCallbackFailureResponse,
-    SendDurableExecutionCallbackHeartbeatRequest,
     SendDurableExecutionCallbackHeartbeatResponse,
     SendDurableExecutionCallbackSuccessResponse,
     StartDurableExecutionInput,

--- a/packages/aws-durable-execution-sdk-python-testing/src/aws_durable_execution_sdk_python_testing/web/serialization.py
+++ b/packages/aws-durable-execution-sdk-python-testing/src/aws_durable_execution_sdk_python_testing/web/serialization.py
@@ -7,11 +7,10 @@ along with AWS-compatible implementations using boto's rest-json serializers.
 from __future__ import annotations
 
 import json
-import os
+import os  # noqa: F401 - accessed via module namespace in tests (mock.patch)
 from typing import Any, Protocol
 from datetime import datetime
 
-import aws_durable_execution_sdk_python
 import botocore.loaders  # type: ignore
 from botocore.model import ServiceModel  # type: ignore
 from botocore.parsers import create_parser  # type: ignore

--- a/packages/aws-durable-execution-sdk-python-testing/tests/checkpoint/processors/base_test.py
+++ b/packages/aws-durable-execution-sdk-python-testing/tests/checkpoint/processors/base_test.py
@@ -213,7 +213,7 @@ def test_create_context_details_with_replay_children():
 
     assert isinstance(result, ContextDetails)
     assert result.result == "test-payload"
-    assert result.replay_children == True
+    assert result.replay_children is True
 
 
 def test_create_step_details_non_step_type():

--- a/packages/aws-durable-execution-sdk-python-testing/tests/executor_invariants_test.py
+++ b/packages/aws-durable-execution-sdk-python-testing/tests/executor_invariants_test.py
@@ -368,7 +368,7 @@ def test_invariant_token_sequence_never_retreats():
     )
     history.append(store.load(arn).token_sequence)
     # Accepted
-    r2 = executor.checkpoint_execution(
+    executor.checkpoint_execution(
         execution_arn=arn,
         checkpoint_token=r1.checkpoint_token,
         updates=[],

--- a/packages/aws-durable-execution-sdk-python-testing/tests/executor_test.py
+++ b/packages/aws-durable-execution-sdk-python-testing/tests/executor_test.py
@@ -26,7 +26,6 @@ from aws_durable_execution_sdk_python.lambda_service import (
     ExecutionDetails,
 )
 from aws_durable_execution_sdk_python_testing.exceptions import (
-    ExecutionAlreadyStartedException,
     IllegalStateException,
     InvalidParameterValueException,
     ResourceNotFoundException,

--- a/packages/aws-durable-execution-sdk-python-testing/tests/invoker_test.py
+++ b/packages/aws-durable-execution-sdk-python-testing/tests/invoker_test.py
@@ -32,7 +32,6 @@ from aws_durable_execution_sdk_python_testing.invoker import (
     InProcessInvoker,
     LambdaInvoker,
     _LAMBDA_CLIENT_CONFIG,
-    create_lambda_client,
     create_test_lambda_context,
 )
 from aws_durable_execution_sdk_python_testing.model import (

--- a/packages/aws-durable-execution-sdk-python-testing/tests/runner_test.py
+++ b/packages/aws-durable-execution-sdk-python-testing/tests/runner_test.py
@@ -1360,9 +1360,6 @@ def test_cloud_runner_run_bad_status_code(mock_boto3):
 @patch("aws_durable_execution_sdk_python_testing.runner.boto3")
 def test_cloud_runner_run_function_error(mock_boto3):
     """Test DurableFunctionCloudTestRunner.run with function error."""
-    from aws_durable_execution_sdk_python_testing.exceptions import (
-        DurableFunctionsTestError,
-    )
     from aws_durable_execution_sdk_python_testing.runner import (
         DurableFunctionCloudTestRunner,
     )
@@ -1490,8 +1487,6 @@ def test_durable_function_test_result_from_execution_history_filters_execution_t
     """Test from_execution_history filters out EXECUTION type operations."""
     import datetime
 
-    from aws_durable_execution_sdk_python.execution import InvocationStatus
-
     from aws_durable_execution_sdk_python_testing.model import (
         Event,
         GetDurableExecutionHistoryResponse,
@@ -1562,8 +1557,6 @@ def test_durable_function_test_result_from_execution_history_unknown_status():
 def test_durable_function_test_result_from_execution_history_with_parent_operations():
     """Test from_execution_history filters operations with parent_id."""
     import datetime
-
-    from aws_durable_execution_sdk_python.execution import InvocationStatus
 
     from aws_durable_execution_sdk_python_testing.model import (
         Event,

--- a/packages/aws-durable-execution-sdk-python-testing/tests/stores/filesystem_store_test.py
+++ b/packages/aws-durable-execution-sdk-python-testing/tests/stores/filesystem_store_test.py
@@ -14,8 +14,6 @@ from aws_durable_execution_sdk_python_testing.stores.filesystem import (
     FileSystemExecutionStore,
 )
 
-from datetime import datetime, timezone
-
 
 @pytest.fixture
 def temp_storage_dir():

--- a/packages/aws-durable-execution-sdk-python-testing/tests/web/handlers_test.py
+++ b/packages/aws-durable-execution-sdk-python-testing/tests/web/handlers_test.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import base64
-import json
 from typing import TYPE_CHECKING, Any
 from unittest.mock import Mock
 

--- a/packages/aws-durable-execution-sdk-python-testing/tests/web/models_test.py
+++ b/packages/aws-durable-execution-sdk-python-testing/tests/web/models_test.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import datetime
 import json
 from unittest.mock import Mock, patch
 

--- a/packages/aws-durable-execution-sdk-python/pyproject.toml
+++ b/packages/aws-durable-execution-sdk-python/pyproject.toml
@@ -63,7 +63,7 @@ target-version = "py311"
 
 [tool.ruff.lint]
 preview = true
-select = ["TID252"]  # Enforce absolute imports (ban relative imports)
+select = ["E4", "E7", "E9", "F", "TID252"]  # pycodestyle (E4/E7/E9) + Pyflakes + absolute imports
 
 [tool.ruff.lint.isort]
 known-first-party = ["aws_durable_execution_sdk_python"]

--- a/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/concurrency/executor.py
+++ b/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/concurrency/executor.py
@@ -30,7 +30,7 @@ from aws_durable_execution_sdk_python.exceptions import (
     TimedSuspendExecution,
 )
 from aws_durable_execution_sdk_python.identifier import OperationIdentifier
-from aws_durable_execution_sdk_python.lambda_service import ErrorObject, OperationType
+from aws_durable_execution_sdk_python.lambda_service import ErrorObject
 from aws_durable_execution_sdk_python.operation.child import child_handler
 
 

--- a/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/execution.py
+++ b/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/execution.py
@@ -14,7 +14,6 @@ from aws_durable_execution_sdk_python.exceptions import (
     BackgroundThreadError,
     BotoClientError,
     CheckpointError,
-    DurableExecutionsError,
     ExecutionError,
     InvocationError,
     SuspendExecution,
@@ -26,7 +25,6 @@ from aws_durable_execution_sdk_python.lambda_service import (
     InvocationStatus,
     LambdaClient,
     Operation,
-    OperationType,
     OperationUpdate,
 )
 from aws_durable_execution_sdk_python.plugin import (

--- a/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/filesystem_serdes.py
+++ b/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/filesystem_serdes.py
@@ -29,7 +29,6 @@ from typing import Any, Protocol
 from urllib.parse import quote
 
 from aws_durable_execution_sdk_python.constants import CHECKPOINT_SIZE_LIMIT_BYTES
-from aws_durable_execution_sdk_python.preview import build_preview
 from aws_durable_execution_sdk_python.serdes import (
     EXTENDED_TYPES_SERDES,
     SerDes,

--- a/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/operation/step.py
+++ b/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/operation/step.py
@@ -13,19 +13,16 @@ from aws_durable_execution_sdk_python.exceptions import (
     ExecutionError,
     InvalidStateError,
     StepInterruptedError,
-    SuspendExecution,
 )
 from aws_durable_execution_sdk_python.lambda_service import (
     ErrorObject,
     OperationUpdate,
-    OperationType,
 )
 from aws_durable_execution_sdk_python.logger import Logger, LogInfo
 from aws_durable_execution_sdk_python.operation.base import (
     CheckResult,
     OperationExecutor,
 )
-from aws_durable_execution_sdk_python.plugin import UserFunctionStartInfo
 from aws_durable_execution_sdk_python.retries import RetryDecision, RetryPresets
 from aws_durable_execution_sdk_python.serdes import deserialize, serialize
 from aws_durable_execution_sdk_python.suspend import (

--- a/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/operation/wait_for_condition.py
+++ b/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/operation/wait_for_condition.py
@@ -11,8 +11,6 @@ from aws_durable_execution_sdk_python.exceptions import (
 from aws_durable_execution_sdk_python.lambda_service import (
     ErrorObject,
     OperationUpdate,
-    OperationType,
-    OperationSubType,
 )
 from aws_durable_execution_sdk_python.logger import LogInfo
 from aws_durable_execution_sdk_python.operation.base import (

--- a/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/state.py
+++ b/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/state.py
@@ -11,7 +11,7 @@ import time
 from dataclasses import dataclass
 from enum import Enum
 from threading import Lock
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Callable
 
 from aws_durable_execution_sdk_python.exceptions import (
     BackgroundThreadError,
@@ -29,14 +29,12 @@ from aws_durable_execution_sdk_python.lambda_service import (
     Operation,
     OperationAction,
     OperationStatus,
-    OperationSubType,
     OperationType,
     OperationUpdate,
     StateOutput,
 )
 from aws_durable_execution_sdk_python.plugin import (
     PluginExecutor,
-    UserFunctionStartInfo,
 )
 from aws_durable_execution_sdk_python.threading import CompletionEvent, OrderedLock
 

--- a/packages/aws-durable-execution-sdk-python/tests/concurrency_test.py
+++ b/packages/aws-durable-execution-sdk-python/tests/concurrency_test.py
@@ -41,7 +41,6 @@ from aws_durable_execution_sdk_python.exceptions import (
     SuspendExecution,
     TimedSuspendExecution,
 )
-from aws_durable_execution_sdk_python.identifier import OperationIdentifier
 from aws_durable_execution_sdk_python.lambda_service import (
     ErrorObject,
     Operation,

--- a/packages/aws-durable-execution-sdk-python/tests/e2e/checkpoint_response_int_test.py
+++ b/packages/aws-durable-execution-sdk-python/tests/e2e/checkpoint_response_int_test.py
@@ -28,7 +28,7 @@ from aws_durable_execution_sdk_python.lambda_service import (
 )
 
 if TYPE_CHECKING:
-    from aws_durable_execution_sdk_python.types import StepContext, LambdaContext
+    from aws_durable_execution_sdk_python.types import StepContext
 
 
 def create_mock_checkpoint_with_operations():

--- a/packages/aws-durable-execution-sdk-python/tests/e2e/filesystem_serdes_int_test.py
+++ b/packages/aws-durable-execution-sdk-python/tests/e2e/filesystem_serdes_int_test.py
@@ -5,17 +5,13 @@ Tests the full execution flow with filesystem serdes:
 - Replay: step deserializes from checkpointed envelope, reads from filesystem
 """
 
-from __future__ import annotations
-
 import json
 import os
-from typing import TYPE_CHECKING, Any
+from typing import Any
 from unittest.mock import Mock, patch
 
-import pytest
-
 from aws_durable_execution_sdk_python.config import StepConfig
-from aws_durable_execution_sdk_python.context import DurableContext, durable_step
+from aws_durable_execution_sdk_python.context import DurableContext
 from aws_durable_execution_sdk_python.execution import (
     InvocationStatus,
     durable_execution,
@@ -36,15 +32,8 @@ from aws_durable_execution_sdk_python.serdes import EXTENDED_TYPES_SERDES
 from aws_durable_execution_sdk_python.lambda_service import (
     CheckpointOutput,
     CheckpointUpdatedExecutionState,
-    Operation,
     OperationAction,
-    OperationStatus,
-    OperationType,
-    StepDetails,
 )
-
-if TYPE_CHECKING:
-    from aws_durable_execution_sdk_python.types import StepContext
 
 
 def _create_lambda_context():
@@ -185,7 +174,6 @@ def test_filesystem_serdes_replay_from_checkpoint(tmp_path):
     step_id = next(operation_id_sequence())
 
     # Pre-create the file that would have been written in the first invocation
-    arn = "arn:aws:lambda:us-east-1:123456789012:function:test-func:1/durable-execution/exec-001/inv-001"
     dir_path = os.path.join(mount_path, "test-func", "exec-001", "inv-001")
     os.makedirs(dir_path, exist_ok=True)
 

--- a/packages/aws-durable-execution-sdk-python/tests/filesystem_serdes_test.py
+++ b/packages/aws-durable-execution-sdk-python/tests/filesystem_serdes_test.py
@@ -10,7 +10,6 @@ from aws_durable_execution_sdk_python.filesystem_serdes import (
     FileSystemPathEncoding,
     FileSystemSerDesConfig,
     FileSystemSerDesMode,
-    _OVERFLOW_THRESHOLD_BYTES,
     _encode_segment,
     _resolve_execution_dir,
     _write_to_file,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,7 +165,7 @@ exclude = [".github/scripts/*.sh", ".github/workflows"]
 
 [tool.ruff.lint]
 preview = true
-select = ["TID252"]  # Enforce absolute imports (ban relative imports)
+select = ["E4", "E7", "E9", "F", "TID252"]  # pycodestyle (E4/E7/E9) + Pyflakes + absolute imports
 
 [tool.ruff.lint.isort]
 known-first-party = [


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-durable-execution-sdk-python/issues/479

*Description of changes:*
Enables the Pyflakes (`F`) rule category in ruff across all packages. reviously only `TID252` (ban relative imports) was enforced, meaning unused imports, undefined names, and unused variables went undetected.

Testing - 
- `ci-checks.sh` passes (tests, coverage, typecheck, fmt for all packages)
- `ruff check --select F,TID252` reports zero violations

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
