### PR TITLE
Enhance OTel durable operation metadata

### DIFF
--- a/packages/aws-durable-execution-sdk-python-examples/src/otel/otel_logger_example.py
+++ b/packages/aws-durable-execution-sdk-python-examples/src/otel/otel_logger_example.py
@@ -2,8 +2,8 @@
 
 The OtelPlugin installs a logging filter on the root logger
 (enrich_logger=True by default) when the plugin is constructed. The filter
-stamps the active OpenTelemetry trace context (otel_trace_id, otel_span_id,
-otel_trace_sampled) onto every log record that flows through the root handler.
+stamps the active OpenTelemetry trace context (traceId, spanId,
+otelTraceSampled) onto every log record that flows through the root handler.
 This includes logs emitted via context.logger / step_context.logger as well as
 direct logging.getLogger() calls and third-party library logs, so logs
 correlate to the spans the plugin emits without any user code changes.

--- a/packages/aws-durable-execution-sdk-python-otel/README.md
+++ b/packages/aws-durable-execution-sdk-python-otel/README.md
@@ -210,9 +210,9 @@ When `enrich_logger=True` (the default), the plugin installs a logging filter on
 the root logger at invocation start. The filter stamps the active OTel trace
 context onto every emitted log record using these attributes:
 
-- `otel_trace_id`: 32-char hex trace identifier
-- `otel_span_id`: 16-char hex span identifier
-- `otel_trace_sampled`: boolean indicating if the trace is sampled
+- `traceId`: 32-char hex trace identifier
+- `spanId`: 16-char hex span identifier
+- `otelTraceSampled`: boolean indicating if the trace is sampled
 
 These attributes are only set when a valid span context is active, so any log
 formatter or schema must treat the fields as optional.
@@ -228,7 +228,7 @@ After deploying your function with the plugin configured:
    - Child spans for each durable operation (named after your step names)
    - All invocations of the same execution grouped under one trace ID
 
-3. **Check log correlation** — verify that your logs include `otel_trace_id` and `otel_span_id` fields matching the spans in X-Ray.
+3. **Check log correlation** — verify that your logs include `traceId` and `spanId` fields matching the spans in X-Ray.
 
 4. **Confirm sampling** — If you set `OTEL_TRACES_SAMPLER=traceidratio` and `OTEL_TRACES_SAMPLER_ARG` to a value less than 1.0, verify that only the expected proportion of traces appear.
 

--- a/packages/aws-durable-execution-sdk-python-otel/src/aws_durable_execution_sdk_python_otel/log_filter.py
+++ b/packages/aws-durable-execution-sdk-python-otel/src/aws_durable_execution_sdk_python_otel/log_filter.py
@@ -4,12 +4,11 @@ The filter attaches to a stdlib logging handler and enriches *every* record
 that flows through it: direct ``logging.getLogger().info(...)`` calls,
 child-logger records that propagate to root, and third-party library logs.
 
-The span/trace identifiers are added as ``LogRecord`` attributes (using
-underscore names, since dotted names are not valid record attributes):
+The span/trace identifiers are added as ``LogRecord`` attributes:
 
-    - ``otel_trace_id``: 32-char hex trace identifier
-    - ``otel_span_id``: 16-char hex span identifier
-    - ``otel_trace_sampled``: boolean indicating if the trace is sampled
+    - ``traceId``: 32-char hex trace identifier
+    - ``spanId``: 16-char hex span identifier
+    - ``otelTraceSampled``: boolean indicating if the trace is sampled
 
 These attributes are only set when a valid span context is active. Records
 emitted outside an active invocation (e.g. during Lambda teardown) pass through
@@ -53,9 +52,9 @@ class OtelContextLogFilter(logging.Filter):
         """Stamp the active span context onto the record, then allow it through."""
         span_context = self._plugin.get_current_span_context()
         if span_context and span_context.is_valid:
-            record.otel_trace_id = format(span_context.trace_id, "032x")
-            record.otel_span_id = format(span_context.span_id, "016x")
-            record.otel_trace_sampled = bool(
+            record.traceId = format(span_context.trace_id, "032x")
+            record.spanId = format(span_context.span_id, "016x")
+            record.otelTraceSampled = bool(
                 span_context.trace_flags & TraceFlags.SAMPLED
             )
         return True

--- a/packages/aws-durable-execution-sdk-python-otel/src/aws_durable_execution_sdk_python_otel/plugin.py
+++ b/packages/aws-durable-execution-sdk-python-otel/src/aws_durable_execution_sdk_python_otel/plugin.py
@@ -378,6 +378,8 @@ class OtelPlugin(DurableInstrumentationPlugin):
                 parent_span=parent_span,
                 existed=True,
             )
+        else:
+            span.set_attributes(self._extract_attributes(info))
 
         if info.error:
             span.set_status(StatusCode.ERROR, info.error.message or "")
@@ -488,6 +490,8 @@ class OtelPlugin(DurableInstrumentationPlugin):
             attributes["durable.operation.id"] = info.operation_id
         if hasattr(info, "operation_type") and info.operation_type is not None:
             attributes["durable.operation.type"] = info.operation_type.value
+        if hasattr(info, "status") and info.status is not None:
+            attributes["durable.operation.status"] = info.status.value
         if hasattr(info, "name") and info.name is not None:
             attributes["durable.operation.name"] = info.name
         # Per-attempt fields are meaningful for STEP (each attempt is retried)

--- a/packages/aws-durable-execution-sdk-python-otel/src/aws_durable_execution_sdk_python_otel/plugin.py
+++ b/packages/aws-durable-execution-sdk-python-otel/src/aws_durable_execution_sdk_python_otel/plugin.py
@@ -493,6 +493,8 @@ class OtelPlugin(DurableInstrumentationPlugin):
             attributes["durable.operation.id"] = info.operation_id
         if hasattr(info, "operation_type") and info.operation_type is not None:
             attributes["durable.operation.type"] = info.operation_type.value
+        if hasattr(info, "sub_type") and info.sub_type is not None:
+            attributes["durable.operation.subtype"] = info.sub_type.value
         if hasattr(info, "status") and info.status is not None:
             attributes["durable.operation.status"] = info.status.value
         if hasattr(info, "name") and info.name is not None:

--- a/packages/aws-durable-execution-sdk-python-otel/src/aws_durable_execution_sdk_python_otel/plugin.py
+++ b/packages/aws-durable-execution-sdk-python-otel/src/aws_durable_execution_sdk_python_otel/plugin.py
@@ -414,8 +414,8 @@ class OtelPlugin(DurableInstrumentationPlugin):
         parent_span = self._resolve_parent_span(info.parent_id)
         attributes = self._extract_attributes(info)
         span_name = info.name or info.operation_id
-        if info.operation_type is OperationType.STEP and info.attempt is not None:
-            span_name = f"{span_name} attempt {info.attempt}"
+        if info.operation_type is OperationType.STEP:
+            span_name = f"{span_name} attempt {info.attempt or 1}"
         span = self._start_span(
             operation_id=info.operation_id,
             name=span_name,

--- a/packages/aws-durable-execution-sdk-python-otel/src/aws_durable_execution_sdk_python_otel/plugin.py
+++ b/packages/aws-durable-execution-sdk-python-otel/src/aws_durable_execution_sdk_python_otel/plugin.py
@@ -413,9 +413,12 @@ class OtelPlugin(DurableInstrumentationPlugin):
             )
         parent_span = self._resolve_parent_span(info.parent_id)
         attributes = self._extract_attributes(info)
+        span_name = info.name or info.operation_id
+        if info.operation_type is OperationType.STEP and info.attempt is not None:
+            span_name = f"{span_name} attempt {info.attempt}"
         span = self._start_span(
             operation_id=info.operation_id,
-            name=info.name or info.operation_id,
+            name=span_name,
             attributes=attributes,
             start_time=info.start_time,
             parent_span=parent_span,

--- a/packages/aws-durable-execution-sdk-python-otel/tests/test_log_filter.py
+++ b/packages/aws-durable-execution-sdk-python-otel/tests/test_log_filter.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import logging
 from datetime import UTC, datetime
 
-from aws_durable_execution_sdk_python.lambda_service import OperationType
+from aws_durable_execution_sdk_python.lambda_service import (
+    OperationStatus,
+    OperationType,
+)
 from aws_durable_execution_sdk_python.plugin import (
     InvocationStartInfo,
     UserFunctionStartInfo,
@@ -61,6 +64,7 @@ def _user_function_start_info(operation_id: str) -> UserFunctionStartInfo:
         parent_id=None,
         start_time=START_TIME,
         is_replayed=False,
+        status=OperationStatus.STARTED,
         is_replay_children=False,
         attempt=1,
     )

--- a/packages/aws-durable-execution-sdk-python-otel/tests/test_log_filter.py
+++ b/packages/aws-durable-execution-sdk-python-otel/tests/test_log_filter.py
@@ -107,9 +107,9 @@ def test_filter_does_not_set_fields_without_active_span():
     record = _make_record()
     log_filter.filter(record)
 
-    assert not hasattr(record, "otel_trace_id")
-    assert not hasattr(record, "otel_span_id")
-    assert not hasattr(record, "otel_trace_sampled")
+    assert not hasattr(record, "traceId")
+    assert not hasattr(record, "spanId")
+    assert not hasattr(record, "otelTraceSampled")
 
 
 def test_filter_injects_trace_context_from_invocation_span():
@@ -121,9 +121,9 @@ def test_filter_injects_trace_context_from_invocation_span():
     record = _make_record()
     log_filter.filter(record)
 
-    assert len(record.otel_trace_id) == 32
-    assert len(record.otel_span_id) == 16
-    assert isinstance(record.otel_trace_sampled, bool)
+    assert len(record.traceId) == 32
+    assert len(record.spanId) == 16
+    assert isinstance(record.otelTraceSampled, bool)
 
 
 def test_filter_uses_operation_span_inside_user_function():
@@ -138,7 +138,7 @@ def test_filter_uses_operation_span_inside_user_function():
 
     operation_span = plugin._get_span(operation_id)
     expected_span_id = format(operation_span.get_span_context().span_id, "016x")
-    assert record.otel_span_id == expected_span_id
+    assert record.spanId == expected_span_id
 
 
 def test_install_log_filter_attaches_to_handlers():

--- a/packages/aws-durable-execution-sdk-python-otel/tests/test_plugin.py
+++ b/packages/aws-durable-execution-sdk-python-otel/tests/test_plugin.py
@@ -10,6 +10,7 @@ import pytest
 from aws_durable_execution_sdk_python.lambda_service import (
     InvocationStatus,
     OperationStatus,
+    OperationSubType,
     OperationType,
 )
 from aws_durable_execution_sdk_python.plugin import (
@@ -158,7 +159,7 @@ def test_operation_callbacks_emit_child_span_with_deterministic_span_id():
         OperationStartInfo(
             operation_id=operation_id,
             operation_type=OperationType.WAIT,
-            sub_type=None,
+            sub_type=OperationSubType.WAIT,
             name="wait-for-signal",
             parent_id=None,
             start_time=START_TIME,
@@ -172,11 +173,15 @@ def test_operation_callbacks_emit_child_span_with_deterministic_span_id():
         active_wait_span.attributes["durable.operation.status"]
         == OperationStatus.STARTED.value
     )
+    assert (
+        active_wait_span.attributes["durable.operation.subtype"]
+        == OperationSubType.WAIT.value
+    )
     plugin.on_operation_end(
         OperationEndInfo(
             operation_id=operation_id,
             operation_type=OperationType.WAIT,
-            sub_type=None,
+            sub_type=OperationSubType.WAIT,
             name="wait-for-signal",
             parent_id=None,
             start_time=START_TIME,
@@ -195,6 +200,9 @@ def test_operation_callbacks_emit_child_span_with_deterministic_span_id():
     assert wait_span.parent.span_id == invocation_span.context.span_id
     assert wait_span.attributes["durable.operation.id"] == operation_id
     assert wait_span.attributes["durable.operation.type"] == OperationType.WAIT.value
+    assert (
+        wait_span.attributes["durable.operation.subtype"] == OperationSubType.WAIT.value
+    )
     assert (
         wait_span.attributes["durable.operation.status"]
         == OperationStatus.SUCCEEDED.value

--- a/packages/aws-durable-execution-sdk-python-otel/tests/test_plugin.py
+++ b/packages/aws-durable-execution-sdk-python-otel/tests/test_plugin.py
@@ -102,6 +102,7 @@ def _user_function_start_info(
         parent_id=parent_id,
         start_time=START_TIME,
         is_replayed=False,
+        status=OperationStatus.STARTED,
         is_replay_children=False,
         attempt=attempt,
     )
@@ -123,6 +124,7 @@ def _user_function_end_info(
         parent_id=parent_id,
         start_time=START_TIME,
         is_replayed=False,
+        status=OperationStatus.STARTED,
         is_replay_children=False,
         attempt=attempt,
         outcome=outcome,
@@ -161,7 +163,14 @@ def test_operation_callbacks_emit_child_span_with_deterministic_span_id():
             parent_id=None,
             start_time=START_TIME,
             is_replayed=False,
+            status=OperationStatus.STARTED,
         )
+    )
+    active_wait_span = plugin._get_span(operation_id)
+    assert active_wait_span is not None
+    assert (
+        active_wait_span.attributes["durable.operation.status"]
+        == OperationStatus.STARTED.value
     )
     plugin.on_operation_end(
         OperationEndInfo(
@@ -186,6 +195,10 @@ def test_operation_callbacks_emit_child_span_with_deterministic_span_id():
     assert wait_span.parent.span_id == invocation_span.context.span_id
     assert wait_span.attributes["durable.operation.id"] == operation_id
     assert wait_span.attributes["durable.operation.type"] == OperationType.WAIT.value
+    assert (
+        wait_span.attributes["durable.operation.status"]
+        == OperationStatus.SUCCEEDED.value
+    )
 
 
 def test_operation_end_without_start_emits_continuation_span_with_link():
@@ -217,6 +230,9 @@ def test_operation_end_without_start_emits_continuation_span_with_link():
     assert span.name == "existing-wait"
     assert span.context.span_id == random_span_id
     assert span.links[0].context.span_id == operation_id_to_span_id(operation_id)
+    assert (
+        span.attributes["durable.operation.status"] == OperationStatus.SUCCEEDED.value
+    )
 
 
 def test_user_function_callbacks_emit_attempt_span_attributes():
@@ -233,6 +249,7 @@ def test_user_function_callbacks_emit_attempt_span_attributes():
         parent_id=None,
         start_time=START_TIME,
         is_replayed=False,
+        status=OperationStatus.STARTED,
         is_replay_children=False,
         attempt=1,
     )
@@ -254,6 +271,7 @@ def test_user_function_callbacks_emit_attempt_span_attributes():
             parent_id=None,
             start_time=START_TIME,
             is_replayed=False,
+            status=OperationStatus.STARTED,
             is_replay_children=False,
             attempt=1,
             outcome=UserFunctionOutcome.SUCCEEDED,
@@ -296,6 +314,7 @@ def test_context_span_omits_attempt_attributes():
             parent_id=None,
             start_time=START_TIME,
             is_replayed=False,
+            status=OperationStatus.STARTED,
             is_replay_children=False,
             attempt=1,
         )
@@ -309,6 +328,7 @@ def test_context_span_omits_attempt_attributes():
             parent_id=None,
             start_time=START_TIME,
             is_replayed=False,
+            status=OperationStatus.STARTED,
             is_replay_children=False,
             attempt=1,
             outcome=UserFunctionOutcome.SUCCEEDED,

--- a/packages/aws-durable-execution-sdk-python-otel/tests/test_plugin.py
+++ b/packages/aws-durable-execution-sdk-python-otel/tests/test_plugin.py
@@ -281,7 +281,7 @@ def test_user_function_callbacks_emit_attempt_span_attributes():
     )
 
     span = exporter.get_finished_spans()[0]
-    assert span.name == "fetch-user"
+    assert span.name == "fetch-user attempt 1"
     assert span.context.span_id == operation_id_to_span_id(operation_id)
     assert span.attributes["durable.execution.arn"] == EXECUTION_ARN
     assert span.attributes["durable.operation.id"] == operation_id
@@ -292,6 +292,48 @@ def test_user_function_callbacks_emit_attempt_span_attributes():
         span.attributes["durable.attempt.outcome"]
         == UserFunctionOutcome.SUCCEEDED.value
     )
+
+
+def test_step_attempt_span_name_includes_attempt_number():
+    """Step attempt spans include the attempt number in the display name."""
+    plugin, exporter = _create_plugin()
+    plugin.on_invocation_start(_invocation_start_info())
+    operation_id = "step-retry"
+
+    plugin.on_user_function_start(
+        UserFunctionStartInfo(
+            operation_id=operation_id,
+            operation_type=OperationType.STEP,
+            sub_type=None,
+            name="fetch-user",
+            parent_id=None,
+            start_time=START_TIME,
+            is_replayed=False,
+            status=OperationStatus.STARTED,
+            is_replay_children=False,
+            attempt=2,
+        )
+    )
+    plugin.on_user_function_end(
+        UserFunctionEndInfo(
+            operation_id=operation_id,
+            operation_type=OperationType.STEP,
+            sub_type=None,
+            name="fetch-user",
+            parent_id=None,
+            start_time=START_TIME,
+            is_replayed=False,
+            status=OperationStatus.STARTED,
+            is_replay_children=False,
+            attempt=2,
+            outcome=UserFunctionOutcome.SUCCEEDED,
+            end_time=END_TIME,
+            error=None,
+        )
+    )
+
+    span = exporter.get_finished_spans()[0]
+    assert span.name == "fetch-user attempt 2"
 
 
 def test_context_span_omits_attempt_attributes():

--- a/packages/aws-durable-execution-sdk-python-otel/tests/test_plugin.py
+++ b/packages/aws-durable-execution-sdk-python-otel/tests/test_plugin.py
@@ -344,6 +344,48 @@ def test_step_attempt_span_name_includes_attempt_number():
     assert span.name == "fetch-user attempt 2"
 
 
+def test_step_attempt_span_name_defaults_to_first_attempt():
+    """Step attempt spans default to attempt 1 when no attempt is provided."""
+    plugin, exporter = _create_plugin()
+    plugin.on_invocation_start(_invocation_start_info())
+    operation_id = "step-no-attempt"
+
+    plugin.on_user_function_start(
+        UserFunctionStartInfo(
+            operation_id=operation_id,
+            operation_type=OperationType.STEP,
+            sub_type=None,
+            name="fetch-user",
+            parent_id=None,
+            start_time=START_TIME,
+            is_replayed=False,
+            status=OperationStatus.STARTED,
+            is_replay_children=False,
+            attempt=None,
+        )
+    )
+    plugin.on_user_function_end(
+        UserFunctionEndInfo(
+            operation_id=operation_id,
+            operation_type=OperationType.STEP,
+            sub_type=None,
+            name="fetch-user",
+            parent_id=None,
+            start_time=START_TIME,
+            is_replayed=False,
+            status=OperationStatus.STARTED,
+            is_replay_children=False,
+            attempt=None,
+            outcome=UserFunctionOutcome.SUCCEEDED,
+            end_time=END_TIME,
+            error=None,
+        )
+    )
+
+    span = exporter.get_finished_spans()[0]
+    assert span.name == "fetch-user attempt 1"
+
+
 def test_context_span_omits_attempt_attributes():
     """CONTEXT operations do not carry per-attempt attributes.
 

--- a/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/plugin.py
+++ b/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/plugin.py
@@ -36,6 +36,7 @@ class OperationInfo:
     parent_id: str | None
     start_time: datetime.datetime | None
     is_replayed: bool
+    status: OperationStatus
 
 
 @dataclass(frozen=True)
@@ -45,7 +46,6 @@ class OperationStartInfo(OperationInfo):
 
 @dataclass(frozen=True)
 class OperationEndInfo(OperationInfo):
-    status: OperationStatus
     end_time: datetime.datetime | None
     error: ErrorObject | None
 
@@ -93,6 +93,7 @@ class UserFunctionEndInfo(OperationInfo):
             parent_id=start_info.parent_id,
             start_time=start_info.start_time,
             is_replayed=start_info.is_replayed,
+            status=start_info.status,
             is_replay_children=start_info.is_replay_children,
             attempt=start_info.attempt,
             outcome=UserFunctionOutcome.from_error(error),
@@ -300,6 +301,7 @@ class PluginExecutor:
             parent_id=operation_identifier.parent_id,
             start_time=datetime.datetime.now(datetime.UTC),
             is_replayed=False,
+            status=OperationStatus.STARTED,
             is_replay_children=is_replay_children,
             attempt=attempt,
         )
@@ -331,6 +333,7 @@ class PluginExecutor:
                     parent_id=update.parent_id,
                     start_time=datetime.datetime.now(datetime.UTC),
                     is_replayed=False,
+                    status=OperationStatus.STARTED,
                 ),
                 sync=True,
             )
@@ -345,6 +348,7 @@ class PluginExecutor:
             parent_id=operation.parent_id,
             start_time=operation.start_timestamp,
             is_replayed=True,
+            status=operation.status,
         )
         self.execute_plugins(start_info, sync=True)
 

--- a/packages/aws-durable-execution-sdk-python/tests/plugin_test.py
+++ b/packages/aws-durable-execution-sdk-python/tests/plugin_test.py
@@ -41,6 +41,7 @@ OPERATION_START_INFO = OperationStartInfo(
     parent_id="parent-1",
     start_time=START_TS,
     is_replayed=False,
+    status=OperationStatus.STARTED,
 )
 OPERATION_END_INFO = OperationEndInfo(
     operation_id="op-1",
@@ -79,6 +80,7 @@ USER_FUNCTION_START_INFO = UserFunctionStartInfo(
     parent_id="parent-1",
     start_time=START_TS,
     is_replayed=False,
+    status=OperationStatus.STARTED,
 )
 
 USER_FUNCTION_END_INFO = UserFunctionEndInfo(
@@ -89,6 +91,7 @@ USER_FUNCTION_END_INFO = UserFunctionEndInfo(
     parent_id="parent-1",
     start_time=START_TS,
     is_replayed=False,
+    status=OperationStatus.STARTED,
     is_replay_children=False,
     attempt=1,
     outcome=UserFunctionOutcome.FAILED,
@@ -104,6 +107,7 @@ class TestDataClasses(unittest.TestCase):
         self.assertEqual(OPERATION_START_INFO.parent_id, "parent-1")
         self.assertEqual(OPERATION_START_INFO.start_time, START_TS)
         self.assertFalse(OPERATION_START_INFO.is_replayed)
+        self.assertEqual(OPERATION_START_INFO.status, OperationStatus.STARTED)
 
     def test_operation_end_info(self):
         self.assertEqual(OPERATION_END_INFO.status, OperationStatus.FAILED)
@@ -143,6 +147,7 @@ class TestDataClasses(unittest.TestCase):
         self.assertEqual(USER_FUNCTION_START_INFO.name, "func")
         self.assertEqual(USER_FUNCTION_START_INFO.parent_id, "parent-1")
         self.assertEqual(USER_FUNCTION_START_INFO.start_time, START_TS)
+        self.assertEqual(USER_FUNCTION_START_INFO.status, OperationStatus.STARTED)
 
     def test_user_function_end_info(self):
         self.assertEqual(USER_FUNCTION_END_INFO.operation_id, "op-1")
@@ -511,6 +516,15 @@ class TestPluginExecutorOnOperationAction(unittest.TestCase):
         self.executor = PluginExecutor(plugins=[self.plugin])
 
     def test_start_action_fires_operation_start(self):
+        captured: list[OperationStartInfo] = []
+
+        class _CapturingPlugin(_TrackingPlugin):
+            def on_operation_start(self, info: OperationStartInfo) -> None:
+                super().on_operation_start(info)
+                captured.append(info)
+
+        self.plugin = _CapturingPlugin()
+        self.executor = PluginExecutor(plugins=[self.plugin])
         update = MagicMock()
         update.action = OperationAction.START
         update.operation_id = "op-1"
@@ -523,6 +537,7 @@ class TestPluginExecutorOnOperationAction(unittest.TestCase):
             self.executor.on_operation_action(update)
 
         self.assertIn("operation_start:op-1", self.plugin.calls)
+        self.assertEqual(captured[0].status, OperationStatus.STARTED)
 
     def test_non_start_action_does_not_fire(self):
         update = MagicMock()

--- a/packages/aws-durable-execution-sdk-python/tests/state_test.py
+++ b/packages/aws-durable-execution-sdk-python/tests/state_test.py
@@ -4316,14 +4316,14 @@ def test_plugin_executor_emits_start_and_end_for_replayed_terminal_operation():
         sub_type=OperationSubType.STEP,
         step_details=StepDetails(attempt=1, result='"done"'),
     )
-    captured: list[tuple[str, str, bool]] = []
+    captured: list[tuple[str, str, bool, OperationStatus]] = []
 
     class _CapturingPlugin(DurableInstrumentationPlugin):
         def on_operation_start(self, info):
-            captured.append(("start", info.operation_id, info.is_replayed))
+            captured.append(("start", info.operation_id, info.is_replayed, info.status))
 
         def on_operation_end(self, info):
-            captured.append(("end", info.operation_id, info.is_replayed))
+            captured.append(("end", info.operation_id, info.is_replayed, info.status))
 
     plugin_executor = PluginExecutor(plugins=[_CapturingPlugin()])
     with plugin_executor.run():
@@ -4340,8 +4340,8 @@ def test_plugin_executor_emits_start_and_end_for_replayed_terminal_operation():
         assert state.get_checkpoint_result("step-1").is_succeeded()
 
     assert captured == [
-        ("start", "step-1", True),
-        ("end", "step-1", True),
+        ("start", "step-1", True, OperationStatus.SUCCEEDED),
+        ("end", "step-1", True, OperationStatus.SUCCEEDED),
     ]
 
 
@@ -4354,14 +4354,14 @@ def test_plugin_executor_emits_only_start_for_replayed_non_terminal_operation():
         name="my-wait",
         sub_type=OperationSubType.WAIT,
     )
-    captured: list[tuple[str, str, bool]] = []
+    captured: list[tuple[str, str, bool, OperationStatus]] = []
 
     class _CapturingPlugin(DurableInstrumentationPlugin):
         def on_operation_start(self, info):
-            captured.append(("start", info.operation_id, info.is_replayed))
+            captured.append(("start", info.operation_id, info.is_replayed, info.status))
 
         def on_operation_end(self, info):
-            captured.append(("end", info.operation_id, info.is_replayed))
+            captured.append(("end", info.operation_id, info.is_replayed, info.status))
 
     plugin_executor = PluginExecutor(plugins=[_CapturingPlugin()])
     with plugin_executor.run():
@@ -4376,7 +4376,7 @@ def test_plugin_executor_emits_only_start_for_replayed_non_terminal_operation():
 
         assert state.get_checkpoint_result("wait-1").is_started()
 
-    assert captured == [("start", "wait-1", True)]
+    assert captured == [("start", "wait-1", True, OperationStatus.STARTED)]
 
 
 # endregion Plugin Executor Integration Tests


### PR DESCRIPTION
## Summary
- add durable operation status and subtype span attributes
- include step attempt numbers in OTel step span names
- rename OTel log correlation fields to traceId, spanId, and otelTraceSampled

## Tests
- hatch fmt
- hatch run dev-otel:test
- hatch run dev-core:pytest packages/aws-durable-execution-sdk-python/tests/plugin_test.py packages/aws-durable-execution-sdk-python/tests/state_test.py
- hatch run dev-core:test