### PR TITLE
fix(otel): scope operation span ids by execution

### DIFF
--- a/packages/aws-durable-execution-sdk-python-otel/src/aws_durable_execution_sdk_python_otel/deterministic_id_generator.py
+++ b/packages/aws-durable-execution-sdk-python-otel/src/aws_durable_execution_sdk_python_otel/deterministic_id_generator.py
@@ -66,9 +66,10 @@ def _to_otel_trace_id(execution_arn: str, start_timestamp: datetime | None) -> i
     return int(f"{time_part}{hash_part}", 16)
 
 
-def operation_id_to_span_id(operation_id: str) -> int:
-    """Derive a deterministic span ID (64 bits) from an operation ID."""
-    hashed_operation_id = hashlib.blake2b(operation_id.encode()).hexdigest()[:16]
+def operation_id_to_span_id(durable_execution_arn: str, operation_id: str) -> int:
+    """Derive a deterministic span ID (64 bits) from an execution and operation."""
+    plain_value = f"{durable_execution_arn}:{operation_id}"
+    hashed_operation_id = hashlib.blake2b(plain_value.encode()).hexdigest()[:16]
     return int(hashed_operation_id, 16)
 
 

--- a/packages/aws-durable-execution-sdk-python-otel/src/aws_durable_execution_sdk_python_otel/plugin.py
+++ b/packages/aws-durable-execution-sdk-python-otel/src/aws_durable_execution_sdk_python_otel/plugin.py
@@ -237,7 +237,7 @@ class OtelPlugin(DurableInstrumentationPlugin):
             if existed:
                 if not operation_id:
                     raise ValueError("operation id is required")
-                span_id = operation_id_to_span_id(operation_id)
+                span_id = operation_id_to_span_id(self._execution_arn, operation_id)
                 links = [
                     Link(
                         context=SpanContext(
@@ -253,7 +253,9 @@ class OtelPlugin(DurableInstrumentationPlugin):
                 links = []
 
                 self._id_generator.set_next_span_id(
-                    operation_id_to_span_id(operation_id) if operation_id else None
+                    operation_id_to_span_id(self._execution_arn, operation_id)
+                    if operation_id
+                    else None
                 )
             if parent_span is None:
                 # root span

--- a/packages/aws-durable-execution-sdk-python-otel/tests/test_deterministic_id_generator.py
+++ b/packages/aws-durable-execution-sdk-python-otel/tests/test_deterministic_id_generator.py
@@ -90,8 +90,12 @@ def test_to_otel_trace_id_falls_back_to_timestamp_and_execution_arn(monkeypatch)
 
 
 def test_operation_id_to_span_id_returns_deterministic_64_bit_id():
-    """Verify operation IDs map to stable 64-bit span IDs."""
-    assert operation_id_to_span_id("my-operation") == int("ab1f94a6d3c668f3", 16)
+    """Verify execution and operation IDs map to stable 64-bit span IDs."""
+    execution_arn = "arn:aws:lambda:us-west-2:123456789012:function:workflow:$LATEST"
+
+    assert operation_id_to_span_id(execution_arn, "my-operation") == int(
+        "7495b798d83a363a", 16
+    )
 
 
 def test_deterministic_id_generator_returns_cached_trace_id(monkeypatch):

--- a/packages/aws-durable-execution-sdk-python-otel/tests/test_plugin.py
+++ b/packages/aws-durable-execution-sdk-python-otel/tests/test_plugin.py
@@ -196,7 +196,9 @@ def test_operation_callbacks_emit_child_span_with_deterministic_span_id():
     spans_by_name = {span.name: span for span in exporter.get_finished_spans()}
     wait_span = spans_by_name["wait-for-signal"]
     invocation_span = spans_by_name["invocation"]
-    assert wait_span.context.span_id == operation_id_to_span_id(operation_id)
+    assert wait_span.context.span_id == operation_id_to_span_id(
+        EXECUTION_ARN, operation_id
+    )
     assert wait_span.parent.span_id == invocation_span.context.span_id
     assert wait_span.attributes["durable.operation.id"] == operation_id
     assert wait_span.attributes["durable.operation.type"] == OperationType.WAIT.value
@@ -237,7 +239,9 @@ def test_operation_end_without_start_emits_continuation_span_with_link():
     span = exporter.get_finished_spans()[0]
     assert span.name == "existing-wait"
     assert span.context.span_id == random_span_id
-    assert span.links[0].context.span_id == operation_id_to_span_id(operation_id)
+    assert span.links[0].context.span_id == operation_id_to_span_id(
+        EXECUTION_ARN, operation_id
+    )
     assert (
         span.attributes["durable.operation.status"] == OperationStatus.SUCCEEDED.value
     )
@@ -290,7 +294,7 @@ def test_user_function_callbacks_emit_attempt_span_attributes():
 
     span = exporter.get_finished_spans()[0]
     assert span.name == "fetch-user attempt 1"
-    assert span.context.span_id == operation_id_to_span_id(operation_id)
+    assert span.context.span_id == operation_id_to_span_id(EXECUTION_ARN, operation_id)
     assert span.attributes["durable.execution.arn"] == EXECUTION_ARN
     assert span.attributes["durable.operation.id"] == operation_id
     assert span.attributes["durable.operation.type"] == OperationType.STEP.value
@@ -466,7 +470,7 @@ def test_user_function_end_restores_invocation_span():
     # Inside the step, the current span is the operation span.
     assert (
         trace.get_current_span().get_span_context().span_id
-        == operation_id_to_span_id(operation_id)
+        == operation_id_to_span_id(EXECUTION_ARN, operation_id)
     )
 
     plugin.on_user_function_end(_user_function_end_info(operation_id))
@@ -534,7 +538,7 @@ def test_get_current_span_context_returns_operation_span_inside_step():
 
     span_context = plugin.get_current_span_context()
     assert span_context is not None
-    assert span_context.span_id == operation_id_to_span_id(operation_id)
+    assert span_context.span_id == operation_id_to_span_id(EXECUTION_ARN, operation_id)
 
 
 def test_get_current_span_context_returns_invocation_span_between_steps():
@@ -577,7 +581,7 @@ def test_user_function_end_restores_parent_context_span_for_nested_step():
     )
     assert (
         trace.get_current_span().get_span_context().span_id
-        == operation_id_to_span_id(inner_step_id)
+        == operation_id_to_span_id(EXECUTION_ARN, inner_step_id)
     )
 
     plugin.on_user_function_end(


### PR DESCRIPTION
## Summary
- include the durable execution ARN in deterministic operation span ID hashing
- hash span IDs from durableExecutionArn:operationId
- update OTel plugin call sites and span ID tests

## Tests
- hatch fmt
- hatch run dev-otel:test
- python3 .github/scripts/lintcommit.py --range origin/main..HEAD