### PR TITLE
feat(otel): emit logical step spans

### DIFF
--- a/packages/aws-durable-execution-sdk-python-otel/src/aws_durable_execution_sdk_python_otel/plugin.py
+++ b/packages/aws-durable-execution-sdk-python-otel/src/aws_durable_execution_sdk_python_otel/plugin.py
@@ -152,12 +152,18 @@ class OtelPlugin(DurableInstrumentationPlugin):
         with self._operation_spans_lock:
             return self._operation_spans.get(operation_id)
 
+    @staticmethod
+    def _attempt_span_key(info: UserFunctionStartInfo | UserFunctionEndInfo) -> str:
+        """Return the registry key for a STEP attempt span."""
+        return f"{info.operation_id}:attempt:{info.attempt or 1}"
+
     def get_current_span_context(self) -> SpanContext | None:
         """Return the span context to use for log correlation.
 
         Resolution order:
-        1. The span attached to the OTel thread-local context. Inside a step or
-           child context this is the active operation span (attached in
+        1. The span attached to the OTel thread-local context. Inside a step
+           this is the active attempt span, and inside a child context this is
+           the active context span (attached in
            on_user_function_start), and between operations it is the enclosing
            operation span (restored in on_user_function_end).
         2. The invocation span from the plugin registry. This is the path used
@@ -209,6 +215,8 @@ class OtelPlugin(DurableInstrumentationPlugin):
         start_time: datetime.datetime | None = None,
         parent_span: Span | None = None,
         existed: bool = False,
+        span_key: str | None = None,
+        deterministic_span_id: bool = True,
     ) -> Span:
         """Start and store a span for an invocation or durable operation.
 
@@ -223,6 +231,10 @@ class OtelPlugin(DurableInstrumentationPlugin):
             existed: Whether the logical operation already had a previous span.
                 Continuation spans link back to the deterministic span ID for
                 the operation while using a fresh generated span ID.
+            span_key: Optional registry key. Defaults to ``operation_id``.
+            deterministic_span_id: Whether to use the deterministic operation
+                span ID. Attempt spans set this to ``False`` so they can be
+                separate children of the logical operation span.
 
         Returns:
             The started OpenTelemetry span.
@@ -233,8 +245,12 @@ class OtelPlugin(DurableInstrumentationPlugin):
             name,
             parent_span,
         )
+        registry_key = span_key if span_key is not None else operation_id
         with self._operation_spans_lock:
-            if existed:
+            if not deterministic_span_id:
+                links = []
+                self._id_generator.set_next_span_id(None)
+            elif existed:
                 if not operation_id:
                     raise ValueError("operation id is required")
                 span_id = operation_id_to_span_id(self._execution_arn, operation_id)
@@ -271,7 +287,7 @@ class OtelPlugin(DurableInstrumentationPlugin):
                 context=parent_context,
                 links=links,
             )
-            self._operation_spans[operation_id] = span
+            self._operation_spans[registry_key] = span
 
         logger.debug("Started OTel span: %s", span)
         return span
@@ -339,8 +355,8 @@ class OtelPlugin(DurableInstrumentationPlugin):
     def on_operation_start(self, info: OperationStartInfo) -> None:
         """Called when an operation begins. Creates a span for the operation."""
         logger.debug("Durable operation started: %s", info)
-        if info.operation_type in [OperationType.CONTEXT, OperationType.STEP]:
-            # Context and Step operations are tracked using on_user_function_start
+        if info.operation_type is OperationType.CONTEXT:
+            # Context operations are tracked using on_user_function_start.
             return
         parent_span = self._resolve_parent_span(info.parent_id)
         attributes = self._extract_attributes(info)
@@ -363,8 +379,8 @@ class OtelPlugin(DurableInstrumentationPlugin):
         operation span before being ended.
         """
         logger.debug("Durable operation ended: %s", info)
-        if info.operation_type in [OperationType.CONTEXT, OperationType.STEP]:
-            # Context and Step operations are tracked using on_user_function_end
+        if info.operation_type is OperationType.CONTEXT:
+            # Context operations are tracked using on_user_function_end.
             return
         span = self._get_span(info.operation_id)
         if not span:
@@ -401,8 +417,9 @@ class OtelPlugin(DurableInstrumentationPlugin):
 
         This callback runs inside the thread that executes user code so the
         started span can be attached to the OpenTelemetry context for any
-        instrumentation used by that code. Attempts after the first are emitted
-        as continuation spans linked to the logical operation span.
+        instrumentation used by that code. STEP attempts are emitted as child
+        spans beneath the logical STEP operation span created by
+        ``on_operation_start``.
 
         Args:
             info: Information about the operation attempt.
@@ -413,18 +430,30 @@ class OtelPlugin(DurableInstrumentationPlugin):
             raise RuntimeError(
                 "on_user_function_start should only be called for CONTEXT and STEP operations"
             )
-        parent_span = self._resolve_parent_span(info.parent_id)
+        if info.operation_type is OperationType.STEP:
+            parent_span = self._get_span(
+                info.operation_id
+            ) or self._resolve_parent_span(info.parent_id)
+        else:
+            parent_span = self._resolve_parent_span(info.parent_id)
         attributes = self._extract_attributes(info)
         span_name = info.name or info.operation_id
         if info.operation_type is OperationType.STEP:
             span_name = f"{span_name} attempt {info.attempt or 1}"
+        span_key = (
+            self._attempt_span_key(info)
+            if info.operation_type is OperationType.STEP
+            else info.operation_id
+        )
         span = self._start_span(
             operation_id=info.operation_id,
             name=span_name,
             attributes=attributes,
             start_time=info.start_time,
             parent_span=parent_span,
-            existed=info.attempt != 1,
+            existed=info.attempt != 1 and info.operation_type is not OperationType.STEP,
+            span_key=span_key,
+            deterministic_span_id=info.operation_type is not OperationType.STEP,
         )
         context.attach(trace.set_span_in_context(span, self._extracted_context))
 
@@ -444,7 +473,12 @@ class OtelPlugin(DurableInstrumentationPlugin):
                 "on_user_function_end should only be called for CONTEXT and STEP operations"
             )
         # key = f"{info.operation_id}-{int(info.start_time.timestamp())}"
-        span = self._get_span(info.operation_id)
+        span_key = (
+            self._attempt_span_key(info)
+            if info.operation_type is OperationType.STEP
+            else info.operation_id
+        )
+        span = self._get_span(span_key)
         if not span:
             raise RuntimeError(
                 "on_user_function_end called without matching on_user_function_start"
@@ -466,7 +500,7 @@ class OtelPlugin(DurableInstrumentationPlugin):
         end_timestamp = info.end_time
         if end_timestamp is not None and end_timestamp == info.start_time:
             end_timestamp += datetime.timedelta(microseconds=1)
-        self._end_span(info.operation_id, end_timestamp)
+        self._end_span(span_key, end_timestamp)
         # Restore the enclosing operation span as current so code that runs
         # after this operation (e.g. between steps in a child context)
         # correlates to its enclosing operation, not the operation that just

--- a/packages/aws-durable-execution-sdk-python-otel/tests/test_log_filter.py
+++ b/packages/aws-durable-execution-sdk-python-otel/tests/test_log_filter.py
@@ -126,8 +126,8 @@ def test_filter_injects_trace_context_from_invocation_span():
     assert isinstance(record.otelTraceSampled, bool)
 
 
-def test_filter_uses_operation_span_inside_user_function():
-    """span_id reflects the active operation span during user code."""
+def test_filter_uses_attempt_span_inside_user_function():
+    """spanId reflects the active attempt span during user code."""
     plugin, _ = _create_plugin()
     plugin.on_invocation_start(_invocation_start_info())
     operation_id = "step-1"
@@ -136,8 +136,9 @@ def test_filter_uses_operation_span_inside_user_function():
     record = _make_record()
     OtelContextLogFilter(plugin).filter(record)
 
-    operation_span = plugin._get_span(operation_id)
-    expected_span_id = format(operation_span.get_span_context().span_id, "016x")
+    attempt_span = plugin._get_span("step-1:attempt:1")
+    assert attempt_span is not None
+    expected_span_id = format(attempt_span.get_span_context().span_id, "016x")
     assert record.spanId == expected_span_id
 
 

--- a/packages/aws-durable-execution-sdk-python-otel/tests/test_plugin.py
+++ b/packages/aws-durable-execution-sdk-python-otel/tests/test_plugin.py
@@ -247,6 +247,93 @@ def test_operation_end_without_start_emits_continuation_span_with_link():
     )
 
 
+def test_step_operation_span_parents_attempt_span():
+    """STEP operations have a logical span with attempt spans beneath it."""
+    plugin, exporter = _create_plugin()
+    plugin.on_invocation_start(_invocation_start_info())
+    operation_id = "step-1"
+
+    plugin.on_operation_start(
+        OperationStartInfo(
+            operation_id=operation_id,
+            operation_type=OperationType.STEP,
+            sub_type=OperationSubType.STEP,
+            name="fetch-user",
+            parent_id=None,
+            start_time=START_TIME,
+            is_replayed=False,
+            status=OperationStatus.STARTED,
+        )
+    )
+    step_span = plugin._get_span(operation_id)
+    assert step_span is not None
+    assert step_span.name == "fetch-user"
+    assert step_span.context.span_id == operation_id_to_span_id(
+        EXECUTION_ARN, operation_id
+    )
+
+    plugin.on_user_function_start(
+        UserFunctionStartInfo(
+            operation_id=operation_id,
+            operation_type=OperationType.STEP,
+            sub_type=OperationSubType.STEP,
+            name="fetch-user",
+            parent_id=None,
+            start_time=START_TIME,
+            is_replayed=False,
+            status=OperationStatus.STARTED,
+            is_replay_children=False,
+            attempt=1,
+        )
+    )
+    active_attempt_span = trace.get_current_span()
+    assert active_attempt_span.parent.span_id == step_span.context.span_id
+    assert active_attempt_span.get_span_context().span_id != step_span.context.span_id
+
+    plugin.on_user_function_end(
+        UserFunctionEndInfo(
+            operation_id=operation_id,
+            operation_type=OperationType.STEP,
+            sub_type=OperationSubType.STEP,
+            name="fetch-user",
+            parent_id=None,
+            start_time=START_TIME,
+            is_replayed=False,
+            status=OperationStatus.STARTED,
+            is_replay_children=False,
+            attempt=1,
+            outcome=UserFunctionOutcome.SUCCEEDED,
+            end_time=END_TIME,
+            error=None,
+        )
+    )
+    plugin.on_operation_end(
+        OperationEndInfo(
+            operation_id=operation_id,
+            operation_type=OperationType.STEP,
+            sub_type=OperationSubType.STEP,
+            name="fetch-user",
+            parent_id=None,
+            start_time=START_TIME,
+            is_replayed=False,
+            status=OperationStatus.SUCCEEDED,
+            end_time=END_TIME,
+            error=None,
+        )
+    )
+    plugin.on_invocation_end(_invocation_end_info())
+
+    spans_by_name = {span.name: span for span in exporter.get_finished_spans()}
+    finished_step_span = spans_by_name["fetch-user"]
+    attempt_span = spans_by_name["fetch-user attempt 1"]
+    assert attempt_span.parent.span_id == finished_step_span.context.span_id
+    assert (
+        finished_step_span.attributes["durable.operation.status"]
+        == OperationStatus.SUCCEEDED.value
+    )
+    assert attempt_span.attributes["durable.attempt.number"] == 1
+
+
 def test_user_function_callbacks_emit_attempt_span_attributes():
     """Verify user-function end refreshes all extractable span attributes."""
     plugin, exporter = _create_plugin()
@@ -266,7 +353,7 @@ def test_user_function_callbacks_emit_attempt_span_attributes():
         attempt=1,
     )
     plugin.on_user_function_start(start_info)
-    active_span = plugin._get_span(operation_id)
+    active_span = plugin._get_span("step-1:attempt:1")
     assert active_span is not None
     active_span.set_attributes(
         {
@@ -294,7 +381,6 @@ def test_user_function_callbacks_emit_attempt_span_attributes():
 
     span = exporter.get_finished_spans()[0]
     assert span.name == "fetch-user attempt 1"
-    assert span.context.span_id == operation_id_to_span_id(EXECUTION_ARN, operation_id)
     assert span.attributes["durable.execution.arn"] == EXECUTION_ARN
     assert span.attributes["durable.operation.id"] == operation_id
     assert span.attributes["durable.operation.type"] == OperationType.STEP.value
@@ -467,10 +553,12 @@ def test_user_function_end_restores_invocation_span():
 
     operation_id = "step-1"
     plugin.on_user_function_start(_user_function_start_info(operation_id))
-    # Inside the step, the current span is the operation span.
+    # Inside the step, the current span is the attempt span.
+    active_attempt_span = plugin._get_span("step-1:attempt:1")
+    assert active_attempt_span is not None
     assert (
         trace.get_current_span().get_span_context().span_id
-        == operation_id_to_span_id(EXECUTION_ARN, operation_id)
+        == active_attempt_span.get_span_context().span_id
     )
 
     plugin.on_user_function_end(_user_function_end_info(operation_id))
@@ -530,15 +618,17 @@ def test_get_current_span_context_returns_invocation_span_at_top_level():
 
 
 def test_get_current_span_context_returns_operation_span_inside_step():
-    """Verify code inside a step resolves to the operation span context."""
+    """Verify code inside a step resolves to the attempt span context."""
     plugin, _ = _create_plugin()
     plugin.on_invocation_start(_invocation_start_info())
     operation_id = "step-1"
     plugin.on_user_function_start(_user_function_start_info(operation_id))
 
     span_context = plugin.get_current_span_context()
+    active_attempt_span = plugin._get_span("step-1:attempt:1")
     assert span_context is not None
-    assert span_context.span_id == operation_id_to_span_id(EXECUTION_ARN, operation_id)
+    assert active_attempt_span is not None
+    assert span_context.span_id == active_attempt_span.get_span_context().span_id
 
 
 def test_get_current_span_context_returns_invocation_span_between_steps():
@@ -579,9 +669,11 @@ def test_user_function_end_restores_parent_context_span_for_nested_step():
     plugin.on_user_function_start(
         _user_function_start_info(inner_step_id, parent_id=context_id)
     )
+    active_attempt_span = plugin._get_span("ctx-1-step:attempt:1")
+    assert active_attempt_span is not None
     assert (
         trace.get_current_span().get_span_context().span_id
-        == operation_id_to_span_id(EXECUTION_ARN, inner_step_id)
+        == active_attempt_span.get_span_context().span_id
     )
 
     plugin.on_user_function_end(


### PR DESCRIPTION
## Summary
- create logical STEP operation spans from operation start/end callbacks
- keep per-attempt spans from user-function callbacks as children of the STEP span
- update log correlation and plugin tests for active attempt spans

## Tests
- hatch fmt
- hatch run dev-otel:test
- python3 .github/scripts/lintcommit.py --range origin/main..HEAD