### PR TITLE
fix: configure slow branch test mock

### DIFF
--- a/packages/aws-durable-execution-sdk-python-examples/test/map/test_map_with_min_successful.py
+++ b/packages/aws-durable-execution-sdk-python-examples/test/map/test_map_with_min_successful.py
@@ -64,7 +64,8 @@ def test_map_with_min_successful(durable_runner):
         op for op in map_op.child_operations if op.status is OperationStatus.STARTED
     ]
 
-    # Should have 6-7 successes, 0 failures, and remaining in STARTED state
-    assert len(succeeded) == result_data["success_count"]
+    # The operation tree may observe one already-running child completing after
+    # the BatchResult snapshot used by the handler response.
+    assert result_data["success_count"] <= len(succeeded) <= 7
     assert len(failed) == 0
-    assert len(started) == 10 - result_data["success_count"]
+    assert len(started) == 10 - len(succeeded)

--- a/packages/aws-durable-execution-sdk-python/tests/concurrency_test.py
+++ b/packages/aws-durable-execution-sdk-python/tests/concurrency_test.py
@@ -3292,6 +3292,7 @@ def test_executor_returns_before_slow_branch_completes():
 
     execution_state = Mock()
     execution_state.create_checkpoint = Mock()
+    execution_state.wrap_user_function = lambda func, *args, **kwargs: func
     executor_context = Mock()
     executor_context._create_step_id_for_logical_step = lambda idx: f"step_{idx}"  # noqa: SLF001
     executor_context._parent_id = "parent"  # noqa: SLF001


### PR DESCRIPTION
## Summary
- Configure test_executor_returns_before_slow_branch_completes to use the real user-function wrapper behavior.
- Relax the map_with_min_successful example assertion to allow the operation tree to observe an already-running child that completes after the handler's BatchResult snapshot.

## Root Cause Analysis

### Finding 1: Unit test mock bypassed branch execution

test_executor_returns_before_slow_branch_completes creates a mocked ExecutionState but did not configure wrap_user_function. Concurrent branch execution goes through child_handler, which calls state.wrap_user_function(...) and then invokes the returned wrapper. With an unconfigured Mock, that call returns another Mock instead of the original function wrapper, so the fast and slow branch bodies can be bypassed. In that state the slow branch may not execute its sleep path, making the test timing dependent and allowing both branches to appear completed.

The fix configures execution_state.wrap_user_function to return the original function, matching the real ExecutionState behavior used by the neighboring tests.

### Finding 2: Example test assumed two snapshots stay identical

map_with_min_successful returns once min_successful is reached. The returned BatchResult is a snapshot taken by the handler at that point. The operation tree inspected later by the test can legitimately be slightly newer because already-running child operations may still finish and checkpoint after the BatchResult snapshot is built. That is why the handler result can report 6 successes while map_op.child_operations later shows 7 succeeded children.

This behavior is acceptable for min_successful concurrency. The test now keeps the important checks strict: no failed child operations, bounded successful child count, and STARTED count consistent with the operation-tree view.

Refs #405

## Verification
- hatch run test:all packages/aws-durable-execution-sdk-python-examples/test/map/test_map_with_min_successful.py::test_map_with_min_successful packages/aws-durable-execution-sdk-python/tests/concurrency_test.py::test_executor_returns_before_slow_branch_completes