### PR TITLE
feat: add operation change plugin hook

### DIFF
--- a/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/plugin.py
+++ b/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/plugin.py
@@ -5,9 +5,10 @@ import datetime
 import functools
 import logging
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Callable, MutableMapping
+from collections.abc import Mapping, Sequence
+from typing import Any, Callable, MutableMapping, cast
 
 from aws_durable_execution_sdk_python.identifier import OperationIdentifier
 from aws_durable_execution_sdk_python.lambda_service import (
@@ -27,6 +28,33 @@ from aws_durable_execution_sdk_python.types import LambdaContext
 logger = logging.getLogger(__name__)
 
 
+def _extract_result(operation: Operation) -> str | None:
+    if operation.step_details and operation.step_details.result is not None:
+        return operation.step_details.result
+    if operation.callback_details and operation.callback_details.result is not None:
+        return operation.callback_details.result
+    if (
+        operation.chained_invoke_details
+        and operation.chained_invoke_details.result is not None
+    ):
+        return operation.chained_invoke_details.result
+    if operation.context_details and operation.context_details.result is not None:
+        return operation.context_details.result
+    return None
+
+
+def _extract_error(operation: Operation) -> ErrorObject | None:
+    if operation.step_details and operation.step_details.error:
+        return operation.step_details.error
+    if operation.callback_details and operation.callback_details.error:
+        return operation.callback_details.error
+    if operation.chained_invoke_details and operation.chained_invoke_details.error:
+        return operation.chained_invoke_details.error
+    if operation.context_details and operation.context_details.error:
+        return operation.context_details.error
+    return None
+
+
 @dataclass(frozen=True)
 class OperationInfo:
     operation_id: str
@@ -37,6 +65,33 @@ class OperationInfo:
     start_time: datetime.datetime | None
     is_replayed: bool
     status: OperationStatus
+    end_time: datetime.datetime | None = field(default=None, kw_only=True)
+    result: str | None = field(default=None, kw_only=True)
+    error: ErrorObject | None = field(default=None, kw_only=True)
+    attempt: int | None = field(default=None, kw_only=True)
+
+    @staticmethod
+    def from_operation(
+        operation: Operation,
+        *,
+        is_replayed: bool = False,
+    ) -> OperationInfo:
+        return OperationInfo(
+            operation_id=operation.operation_id,
+            operation_type=operation.operation_type,
+            sub_type=operation.sub_type,
+            name=operation.name,
+            parent_id=operation.parent_id,
+            start_time=operation.start_timestamp,
+            end_time=operation.end_timestamp,
+            result=_extract_result(operation),
+            error=_extract_error(operation),
+            attempt=(
+                operation.step_details.attempt if operation.step_details else None
+            ),
+            is_replayed=is_replayed,
+            status=operation.status,
+        )
 
 
 @dataclass(frozen=True)
@@ -46,8 +101,15 @@ class OperationStartInfo(OperationInfo):
 
 @dataclass(frozen=True)
 class OperationEndInfo(OperationInfo):
-    end_time: datetime.datetime | None
-    error: ErrorObject | None
+    pass
+
+
+@dataclass(frozen=True)
+class OperationChangeInfo:
+    request_id: str | None
+    execution_arn: str | None
+    updated_operations: dict[str, OperationInfo]
+    operations: dict[str, OperationInfo]
 
 
 class UserFunctionOutcome(Enum):
@@ -66,9 +128,6 @@ class UserFunctionStartInfo(OperationInfo):
     is_replay_children: bool = (
         False  # True if user function is called to replay children (MAP/PARALLEL)
     )
-    attempt: int | None = (
-        None  # None for user function called more than once in CONTEXT
-    )
 
 
 @dataclass(frozen=True)
@@ -76,10 +135,7 @@ class UserFunctionEndInfo(OperationInfo):
     is_replay_children: (
         bool  # True if user function is called to replay children (MAP/PARALLEL)
     )
-    attempt: int | None  # None for user function called more than once in CONTEXT
     outcome: UserFunctionOutcome
-    end_time: datetime.datetime | None
-    error: ErrorObject | None
 
     @classmethod
     def from_start_info(
@@ -178,6 +234,16 @@ class DurableInstrumentationPlugin:
         """
         pass
 
+    def on_operation_change(self, info: OperationChangeInfo) -> None:
+        """
+        Called when checkpointed operations change after a checkpoint response is merged.
+        This is called NOT within the thread that runs operation.
+
+        Args:
+            info: Updated operations and the full operation map for the invocation.
+        """
+        pass
+
     def on_user_function_start(self, info: UserFunctionStartInfo) -> None:
         """Called when an operation starts to execute user provided function. This is called within the thread that runs user provided function.
 
@@ -229,6 +295,8 @@ class PluginExecutor:
                     plugin.on_operation_start(info)
                 case OperationEndInfo():
                     plugin.on_operation_end(info)
+                case OperationChangeInfo():
+                    plugin.on_operation_change(info)
                 case UserFunctionStartInfo():
                     plugin.on_user_function_start(info)
                 case UserFunctionEndInfo():
@@ -362,15 +430,26 @@ class PluginExecutor:
                     parent_id=operation.parent_id,
                     start_time=operation.start_timestamp,
                     end_time=operation.end_timestamp,
+                    result=_extract_result(operation),
                     status=operation.status,
                     error=self._extract_error(operation),
+                    attempt=(
+                        operation.step_details.attempt
+                        if operation.step_details
+                        else None
+                    ),
                     is_replayed=True,
                 ),
                 sync=True,
             )
 
-    def on_operation_update(self, operation: Operation | None):
-        """Execute any registered plugins for a given operation when it receives an update
+    def on_operation_update(
+        self,
+        operation_or_operations: Operation | Sequence[Operation] | None,
+        operations: Mapping[str, Operation] | None = None,
+        previous_operations: Mapping[str, Operation] | None = None,
+    ):
+        """Execute any registered plugins for operation updates.
 
         Updates such as STARTED might be omitted because START and completion action (e.g. SUCCEED/FAIL) may be
         checkpointed in batch and the backend returns only the terminal status (e.g. SUCCEEDED/PENDING/FAILED).
@@ -378,36 +457,77 @@ class PluginExecutor:
         Note: the operation may not be up-to-date if the checkpoint is called asynchronously.
 
         Args:
-            operation: the operation is just checkpointed
+            operation_or_operations: operation or operations that were just checkpointed.
+            operations: full operation map after the update, when available.
+            previous_operations: operation map before the update, when available.
         """
-        if operation and self._is_terminal_status(operation.status):
-            self.execute_plugins(
-                OperationEndInfo(
-                    operation_id=operation.operation_id,
-                    operation_type=operation.operation_type,
-                    sub_type=operation.sub_type,
-                    name=operation.name,
-                    parent_id=operation.parent_id,
-                    start_time=operation.start_timestamp,
-                    end_time=operation.end_timestamp,
-                    status=operation.status,
-                    error=self._extract_error(operation),
-                    is_replayed=False,
-                ),
-                sync=True,
-            )
+        if operation_or_operations is None:
+            return
+
+        updated_operations: list[Operation] = (
+            cast(list[Operation], list(operation_or_operations))
+            if isinstance(operation_or_operations, list | tuple)
+            else [cast(Operation, operation_or_operations)]
+        )
+        for operation in updated_operations:
+            if self._is_terminal_status(operation.status):
+                self.execute_plugins(
+                    OperationEndInfo(
+                        operation_id=operation.operation_id,
+                        operation_type=operation.operation_type,
+                        sub_type=operation.sub_type,
+                        name=operation.name,
+                        parent_id=operation.parent_id,
+                        start_time=operation.start_timestamp,
+                        end_time=operation.end_timestamp,
+                        result=_extract_result(operation),
+                        status=operation.status,
+                        error=self._extract_error(operation),
+                        attempt=(
+                            operation.step_details.attempt
+                            if operation.step_details
+                            else None
+                        ),
+                        is_replayed=False,
+                    ),
+                    sync=True,
+                )
+
+        if (
+            operations is None
+            or previous_operations is None
+            or self._invocation_status is None
+        ):
+            return
+
+        changed_operations = [
+            operation
+            for operation in updated_operations
+            if previous_operations.get(operation.operation_id) is None
+            or previous_operations[operation.operation_id].status != operation.status
+        ]
+        if not changed_operations:
+            return
+
+        self.execute_plugins(
+            OperationChangeInfo(
+                request_id=self._invocation_status.request_id,
+                execution_arn=self._invocation_status.execution_arn,
+                updated_operations={
+                    operation.operation_id: OperationInfo.from_operation(operation)
+                    for operation in changed_operations
+                },
+                operations={
+                    operation_id: OperationInfo.from_operation(operation)
+                    for operation_id, operation in operations.items()
+                },
+            ),
+            sync=True,
+        )
 
     @staticmethod
     def _extract_error(operation: Operation):
-        if operation.step_details and operation.step_details.error:
-            return operation.step_details.error
-        if operation.callback_details and operation.callback_details.error:
-            return operation.callback_details.error
-        if operation.chained_invoke_details and operation.chained_invoke_details.error:
-            return operation.chained_invoke_details.error
-        if operation.context_details and operation.context_details.error:
-            return operation.context_details.error
-        return None
+        return _extract_error(operation)
 
     @staticmethod
     def _is_terminal_status(status):

--- a/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/plugin.py
+++ b/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/plugin.py
@@ -106,7 +106,6 @@ class OperationEndInfo(OperationInfo):
 
 @dataclass(frozen=True)
 class OperationChangeInfo:
-    request_id: str | None
     execution_arn: str | None
     updated_operations: dict[str, OperationInfo]
     operations: dict[str, OperationInfo]
@@ -511,7 +510,6 @@ class PluginExecutor:
 
         self.execute_plugins(
             OperationChangeInfo(
-                request_id=self._invocation_status.request_id,
                 execution_arn=self._invocation_status.execution_arn,
                 updated_operations={
                     operation.operation_id: OperationInfo.from_operation(operation)

--- a/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/state.py
+++ b/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/state.py
@@ -744,18 +744,22 @@ class ExecutionState:
                     # Update local token for next iteration
                     current_checkpoint_token = output.checkpoint_token
 
+                    previous_operations = self.operations
+
                     # Fetch new operations from the API before unblocking sync waiters
                     updated_operations = self.fetch_paginated_operations(
                         output.new_execution_state.operations,
                         output.checkpoint_token,
                         output.new_execution_state.next_marker,
                     )
-
                     for update in updates:
                         self._plugin_executor.on_operation_action(update)
 
-                    for operation in updated_operations:
-                        self._plugin_executor.on_operation_update(operation)
+                    self._plugin_executor.on_operation_update(
+                        updated_operations,
+                        self.operations,
+                        previous_operations,
+                    )
 
                     # Signal completion for any synchronous operations
                     for queued_op in batch:

--- a/packages/aws-durable-execution-sdk-python/tests/plugin_test.py
+++ b/packages/aws-durable-execution-sdk-python/tests/plugin_test.py
@@ -60,7 +60,6 @@ OPERATION_END_INFO = OperationEndInfo(
     error=ERROR,
 )
 OPERATION_CHANGE_INFO = OperationChangeInfo(
-    request_id="req-1",
     execution_arn="arn:test",
     updated_operations={"op-1": OPERATION_END_INFO},
     operations={"op-1": OPERATION_END_INFO},
@@ -706,7 +705,6 @@ class TestPluginExecutorOnOperationChange(unittest.TestCase):
             )
 
         self.assertIn("operation_change:op-1", self.plugin.calls)
-        self.assertEqual(captured[0].request_id, "req-1")
         self.assertEqual(captured[0].execution_arn, "arn:exec")
         self.assertEqual(set(captured[0].updated_operations), {"op-1"})
         self.assertEqual(set(captured[0].operations), {"op-1", "op-2"})

--- a/packages/aws-durable-execution-sdk-python/tests/plugin_test.py
+++ b/packages/aws-durable-execution-sdk-python/tests/plugin_test.py
@@ -7,16 +7,20 @@ from aws_durable_execution_sdk_python.lambda_service import (
     DurableExecutionInvocationOutput,
     ErrorObject,
     InvocationStatus,
+    Operation,
     OperationAction,
     OperationStatus,
     OperationSubType,
     OperationType,
+    StepDetails,
 )
 from aws_durable_execution_sdk_python.plugin import (
     DurableInstrumentationPlugin,
     InvocationEndInfo,
     InvocationStartInfo,
+    OperationChangeInfo,
     OperationEndInfo,
+    OperationInfo,
     OperationStartInfo,
     PluginExecutor,
     UserFunctionEndInfo,
@@ -54,6 +58,12 @@ OPERATION_END_INFO = OperationEndInfo(
     status=OperationStatus.FAILED,
     end_time=END_TS,
     error=ERROR,
+)
+OPERATION_CHANGE_INFO = OperationChangeInfo(
+    request_id="req-1",
+    execution_arn="arn:test",
+    updated_operations={"op-1": OPERATION_END_INFO},
+    operations={"op-1": OPERATION_END_INFO},
 )
 
 INVOCATION_START_INFO = InvocationStartInfo(
@@ -175,6 +185,7 @@ class TestDurableInstrumentationPlugin(unittest.TestCase):
         self.assertIsNone(plugin.on_invocation_end(INVOCATION_END_INFO))
         self.assertIsNone(plugin.on_operation_start(OPERATION_START_INFO))
         self.assertIsNone(plugin.on_operation_end(OPERATION_END_INFO))
+        self.assertIsNone(plugin.on_operation_change(OPERATION_CHANGE_INFO))
         self.assertIsNone(plugin.on_user_function_start(USER_FUNCTION_START_INFO))
         self.assertIsNone(plugin.on_user_function_end(USER_FUNCTION_END_INFO))
 
@@ -321,6 +332,11 @@ class TestPluginExecutorExecutePlugins(unittest.TestCase):
         with self.executor.run():
             self.executor.execute_plugins(OPERATION_START_INFO, sync=False)
         self.assertIn("operation_start:op-2", self.plugin.calls)
+
+    def test_dispatch_operation_change_info(self):
+        with self.executor.run():
+            self.executor.execute_plugins(OPERATION_CHANGE_INFO, sync=False)
+        self.assertIn("operation_change:op-1", self.plugin.calls)
 
     def test_dispatch_user_function_start_info(self):
         with self.executor.run():
@@ -637,6 +653,89 @@ class TestPluginExecutorOnOperationUpdate(unittest.TestCase):
         self.assertIn("operation_end:op-1", self.plugin.calls)
 
 
+class TestPluginExecutorOnOperationChange(unittest.TestCase):
+    """Tests for operation change notifications from on_operation_update."""
+
+    def setUp(self):
+        self.plugin = _TrackingPlugin()
+        self.executor = PluginExecutor(plugins=[self.plugin])
+
+    def test_operation_change_uses_invocation_and_operation_maps(self):
+        updated_operation = Operation(
+            operation_id="op-1",
+            operation_type=OperationType.STEP,
+            status=OperationStatus.SUCCEEDED,
+            name="my-step",
+            parent_id="parent-1",
+            start_timestamp=START_TS,
+            end_timestamp=END_TS,
+            sub_type=OperationSubType.STEP,
+            step_details=StepDetails(attempt=2, result='"done"', error=None),
+        )
+        other_operation = Operation(
+            operation_id="op-2",
+            operation_type=OperationType.WAIT,
+            status=OperationStatus.STARTED,
+            name="my-wait",
+            sub_type=OperationSubType.WAIT,
+        )
+        captured: list[OperationChangeInfo] = []
+
+        class _CapturingPlugin(_TrackingPlugin):
+            def on_operation_change(self, info: OperationChangeInfo) -> None:
+                super().on_operation_change(info)
+                captured.append(info)
+
+        self.plugin = _CapturingPlugin()
+        self.executor = PluginExecutor(plugins=[self.plugin])
+
+        with self.executor.run():
+            self.executor.on_invocation_start(
+                execution_arn="arn:exec",
+                lambda_context=LAMBDA_CTX,
+                execution_start_time=START_TS,
+                is_first_invocation=False,
+            )
+            self.executor.on_operation_update(
+                [updated_operation],
+                {
+                    "op-1": updated_operation,
+                    "op-2": other_operation,
+                },
+                previous_operations={},
+            )
+
+        self.assertIn("operation_change:op-1", self.plugin.calls)
+        self.assertEqual(captured[0].request_id, "req-1")
+        self.assertEqual(captured[0].execution_arn, "arn:exec")
+        self.assertEqual(set(captured[0].updated_operations), {"op-1"})
+        self.assertEqual(set(captured[0].operations), {"op-1", "op-2"})
+
+        updated_info = captured[0].updated_operations["op-1"]
+        self.assertIsInstance(updated_info, OperationInfo)
+        self.assertEqual(updated_info.status, OperationStatus.SUCCEEDED)
+        self.assertEqual(updated_info.result, '"done"')
+        self.assertEqual(updated_info.attempt, 2)
+        self.assertEqual(updated_info.end_time, END_TS)
+        self.assertFalse(updated_info.is_replayed)
+
+    def test_operation_change_without_invocation_start_is_noop(self):
+        operation = Operation(
+            operation_id="op-1",
+            operation_type=OperationType.STEP,
+            status=OperationStatus.STARTED,
+        )
+
+        with self.executor.run():
+            self.executor.on_operation_update(
+                [operation],
+                {"op-1": operation},
+                previous_operations={},
+            )
+
+        self.assertEqual(self.plugin.calls, [])
+
+
 class TestPluginExecutorExtractError(unittest.TestCase):
     """Tests for PluginExecutor._extract_error static method."""
 
@@ -766,6 +865,11 @@ class _TrackingPlugin(DurableInstrumentationPlugin):
     def on_operation_end(self, info: OperationEndInfo) -> None:
         self.calls.append(f"operation_end:{info.operation_id}")
 
+    def on_operation_change(self, info: OperationChangeInfo) -> None:
+        self.calls.append(
+            "operation_change:" + ",".join(sorted(info.updated_operations))
+        )
+
     def on_user_function_start(self, info: UserFunctionStartInfo) -> None:
         self.calls.append(f"user_function_start:{info.operation_id}")
 
@@ -792,6 +896,9 @@ class _FailingPlugin(DurableInstrumentationPlugin):
         raise RuntimeError("boom")
 
     def on_operation_end(self, info):
+        raise RuntimeError("boom")
+
+    def on_operation_change(self, info):
         raise RuntimeError("boom")
 
     def on_operation_attempt_start(self, info):

--- a/packages/aws-durable-execution-sdk-python/tests/state_test.py
+++ b/packages/aws-durable-execution-sdk-python/tests/state_test.py
@@ -3879,6 +3879,11 @@ class _RecordingPlugin(DurableInstrumentationPlugin):
     def on_operation_end(self, info):
         self.calls.append(f"operation_end:{info.operation_id}")
 
+    def on_operation_change(self, info):
+        self.calls.append(
+            "operation_change:" + ",".join(sorted(info.updated_operations))
+        )
+
     def on_user_function_start(self, info):
         self.calls.append(f"user_function_start:{info.operation_id}")
 
@@ -4126,6 +4131,74 @@ def test_plugin_executor_called_for_multiple_updates_in_batch():
     # Both terminal operations should have triggered on_operation_update
     assert "operation_end:step-1" in plugin.calls
     assert "operation_end:step-2" in plugin.calls
+
+
+def test_plugin_executor_on_operation_change_called_for_status_changes():
+    """Test that on_operation_change receives status-changed checkpoint responses."""
+    mock_client = create_autospec(spec=LambdaClient)
+
+    step_op = Operation(
+        operation_id="step-1",
+        operation_type=OperationType.STEP,
+        status=OperationStatus.SUCCEEDED,
+        step_details=StepDetails(attempt=1, result='"done"'),
+    )
+    unchanged_wait_op = Operation(
+        operation_id="wait-1",
+        operation_type=OperationType.WAIT,
+        status=OperationStatus.STARTED,
+        sub_type=OperationSubType.WAIT,
+    )
+    mock_client.checkpoint.return_value = CheckpointOutput(
+        checkpoint_token="new_token",  # noqa: S106
+        new_execution_state=CheckpointUpdatedExecutionState(
+            operations=[step_op, unchanged_wait_op],
+            next_marker=None,
+        ),
+    )
+
+    plugin = _RecordingPlugin()
+    plugin_executor = PluginExecutor(plugins=[plugin])
+    with plugin_executor.run():
+        plugin_executor.on_invocation_start(
+            execution_arn="test_arn",
+            is_first_invocation=False,
+            execution_start_time=None,
+            lambda_context=None,
+        )
+        state = ExecutionState(
+            durable_execution_arn="test_arn",
+            initial_checkpoint_token="token123",  # noqa: S106
+            operations={
+                "wait-1": Operation(
+                    operation_id="wait-1",
+                    operation_type=OperationType.WAIT,
+                    status=OperationStatus.STARTED,
+                    sub_type=OperationSubType.WAIT,
+                )
+            },
+            service_client=mock_client,
+            plugin_executor=plugin_executor,
+        )
+
+        executor = ThreadPoolExecutor(max_workers=1)
+        executor.submit(state.checkpoint_batches_forever)
+
+        try:
+            operation_update = OperationUpdate(
+                operation_id="step-1",
+                operation_type=OperationType.STEP,
+                action=OperationAction.SUCCEED,
+                name="my-step",
+                payload='"done"',
+            )
+            state.create_checkpoint(operation_update, is_sync=True)
+        finally:
+            state.stop_checkpointing()
+            executor.shutdown(wait=True)
+
+    assert "operation_change:step-1" in plugin.calls
+    assert "operation_change:wait-1" not in plugin.calls
 
 
 def test_plugin_executor_not_called_on_checkpoint_failure():


### PR DESCRIPTION
## Summary
- add OperationChangeInfo and on_operation_change to the Python plugin interface
- emit operation change hooks after checkpoint responses merge status changes
- enrich OperationInfo with result, error, attempt, and end_time for parity with the JS SDK
- add plugin executor and execution state coverage

## Verification
- hatch run dev-core:test packages/aws-durable-execution-sdk-python/tests/plugin_test.py packages/aws-durable-execution-sdk-python/tests/state_test.py -q
- hatch run dev-otel:test -q
- hatch run dev-core:typecheck
- hatch fmt --check
- hatch run test:all -q