### PR TITLE
fix: retry transient GetDurableExecution not found

### DIFF
--- a/packages/aws-durable-execution-sdk-python-testing/src/aws_durable_execution_sdk_python_testing/runner.py
+++ b/packages/aws-durable-execution-sdk-python-testing/src/aws_durable_execution_sdk_python_testing/runner.py
@@ -1054,6 +1054,17 @@ class DurableFunctionCloudTestRunner:
                     DurableExecutionArn=execution_arn
                 )
                 execution = GetDurableExecutionResponse.from_dict(execution_dict)
+            except ClientError as e:
+                error_code = e.response.get("Error", {}).get("Code")
+                # Retry while the asynchronous invoke's durable execution record is
+                # still becoming visible to GetDurableExecution.
+                if error_code == "ResourceNotFoundException":
+                    logger.info("Execution status not available yet; retrying")
+                    time.sleep(self.poll_interval)
+                    continue
+
+                msg = f"Failed to get execution status: {e}"
+                raise DurableFunctionsTestError(msg) from e
             except Exception as e:
                 msg = f"Failed to get execution status: {e}"
                 raise DurableFunctionsTestError(msg) from e

--- a/packages/aws-durable-execution-sdk-python-testing/tests/runner_test.py
+++ b/packages/aws-durable-execution-sdk-python-testing/tests/runner_test.py
@@ -1387,6 +1387,43 @@ def test_cloud_runner_run_missing_execution_arn(mock_boto3):
 
 
 @patch("aws_durable_execution_sdk_python_testing.runner.boto3")
+def test_cloud_runner_wait_for_completion_get_execution_resource_not_found_retries(
+    mock_boto3,
+):
+    """Test _wait_for_completion retries transient ResourceNotFoundException."""
+    from botocore.exceptions import ClientError  # type: ignore
+
+    from aws_durable_execution_sdk_python_testing.runner import (
+        DurableFunctionCloudTestRunner,
+    )
+
+    mock_client = Mock()
+    mock_boto3.client.return_value = mock_client
+    mock_client.get_durable_execution.side_effect = [
+        ClientError(
+            error_response={"Error": {"Code": "ResourceNotFoundException"}},
+            operation_name="GetDurableExecution",
+        ),
+        {
+            "DurableExecutionArn": "arn:aws:lambda:us-east-1:123456789012:function:test:execution:exec-1",
+            "DurableExecutionName": "test-execution",
+            "FunctionArn": "arn:aws:lambda:us-east-1:123456789012:function:test",
+            "Status": "SUCCEEDED",
+            "StartTimestamp": "2023-01-01T00:00:00Z",
+            "EndTimestamp": "2023-01-01T00:01:00Z",
+        },
+    ]
+
+    runner = DurableFunctionCloudTestRunner(
+        function_name="test-function", poll_interval=0
+    )
+    result = runner._wait_for_completion("test-arn", timeout=10)
+
+    assert result.status == "SUCCEEDED"
+    assert mock_client.get_durable_execution.call_count == 2
+
+
+@patch("aws_durable_execution_sdk_python_testing.runner.boto3")
 def test_cloud_runner_wait_for_completion_get_execution_failure(mock_boto3):
     """Test DurableFunctionCloudTestRunner._wait_for_completion with API failure."""
     from aws_durable_execution_sdk_python_testing.exceptions import (


### PR DESCRIPTION
## Summary
- retry cloud runner status polling when GetDurableExecution returns ResourceNotFoundException
- keep non-retryable ClientError behavior unchanged
- add a regression test for transient ResourceNotFoundException followed by success

## Why this is needed
The cloud runner can invoke a durable Lambda and immediately begin polling GetDurableExecution. That API is eventually consistent: right after invoke, the durable execution ARN may be returned before the execution record is visible to GetDurableExecution. In that short window the service can return ResourceNotFoundException even though the execution is valid and will become readable shortly.

Without retrying this transient error, cloud tests can fail before the workflow has a chance to start. Retrying within the existing polling loop matches the runner's wait semantics and the existing wait_for_callback behavior for GetDurableExecutionHistory.

## Verification
- hatch run dev-testing:test packages/aws-durable-execution-sdk-python-testing/tests/runner_test.py::test_cloud_runner_wait_for_completion_get_execution_resource_not_found_retries packages/aws-durable-execution-sdk-python-testing/tests/runner_test.py::test_cloud_runner_wait_for_completion_get_execution_failure
- hatch fmt --check