### PR TITLE
test: allow parallel branch observation ordering

### DIFF
--- a/packages/aws-durable-execution-sdk-python-examples/test/parallel/test_parallel_with_named_branches.py
+++ b/packages/aws-durable-execution-sdk-python-examples/test/parallel/test_parallel_with_named_branches.py
@@ -38,18 +38,15 @@ def test_parallel_with_named_branches(durable_runner):
     # Verify branch names: named branches have custom names, unnamed use defaults
     assert len(parallel_op.child_operations) == 5
 
-    child_names = [op.name for op in parallel_op.child_operations]
+    child_names = {op.name for op in parallel_op.child_operations}
 
-    # 1. Named ParallelBranch
-    assert child_names[0] == "fetch-user-data"
-    # 2. Named decorator
-    assert child_names[1] == "fetch-orders"
-    # 3. Unnamed decorator (None name falls back to index-based default)
-    assert child_names[2] == "parallel-branch-2"
-    # 4. Unnamed ParallelBranch (None name falls back to index-based default)
-    assert child_names[3] == "parallel-branch-3"
-    # 5. Raw callable (no ParallelBranch wrapper, index-based default)
-    assert child_names[4] == "parallel-branch-4"
+    assert child_names == {
+        "fetch-user-data",  # Named ParallelBranch
+        "fetch-orders",  # Named decorator
+        "parallel-branch-2",  # Unnamed decorator
+        "parallel-branch-3",  # Unnamed ParallelBranch
+        "parallel-branch-4",  # Raw callable
+    }
 
     # Verify all children succeeded
     for child in parallel_op.child_operations:


### PR DESCRIPTION
## Summary
- make the parallel named branches example test assert the full set of child branch names
- stop depending on child operation list order for parallel branches

## Why this is needed
The first attempt of PR #512 failed in the Python 3.12 CI job because test_parallel_with_named_branches expected the first child operation to be fetch-user-data, but the observed first child was fetch-orders.

The example runs branches with ParallelConfig max_concurrency set to 3, so child operations can be recorded or surfaced in execution/checkpoint observation order rather than declaration order. The test only needs to verify that named branches and default branch names are present, not that parallel child operations appear in a stable order.

## Verification
- hatch run dev-examples:test packages/aws-durable-execution-sdk-python-examples/test/parallel/test_parallel_with_named_branches.py
- hatch fmt --check

issue: #405 