### PR TITLE
ci: prevent script injection in commit lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,10 @@ jobs:
       with:
         python-version: "3.12"
     - name: Lint commit messages
-      run: python .github/scripts/lintcommit.py --range "origin/${{ github.event.pull_request.base.ref }}..${{ github.event.pull_request.head.sha }}"
+      env:
+        PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      run: python .github/scripts/lintcommit.py --range "${PR_BASE_SHA}..${PR_HEAD_SHA}"
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- move pull request values out of the generated shell script and into step environment variables
- use immutable base and head commit SHAs for the lint range
- quote both environment variables when constructing the range argument

This backports the GitHub Actions script injection remediation to the `v1.5` maintenance branch.

## Validation
- `git diff --check`
- parsed `.github/workflows/ci.yml` with Ruby YAML
- confirmed no `github.event` expression remains directly embedded in a `run:` command