### PR TITLE
feat(errors): typed per-operation error hierarchy

### DIFF
--- a/packages/aws-durable-execution-sdk-python-examples/examples-catalog.json
+++ b/packages/aws-durable-execution-sdk-python-examples/examples-catalog.json
@@ -763,6 +763,17 @@
         "FILESYSTEM_MOUNT_PATH": "/mnt/s3"
       },
       "path": "./src/filesystem_serdes/filesystem_serdes_preview.py"
+    },
+    {
+      "name": "Catch Typed Step Error",
+      "description": "Catch a typed StepError raised by a failed step",
+      "handler": "catch_typed_step_error.handler",
+      "integration": true,
+      "durableConfig": {
+        "RetentionPeriodInDays": 7,
+        "ExecutionTimeout": 300
+      },
+      "path": "./src/error_handling/catch_typed_step_error.py"
     }
   ]
 }

--- a/packages/aws-durable-execution-sdk-python-examples/src/error_handling/catch_typed_step_error.py
+++ b/packages/aws-durable-execution-sdk-python-examples/src/error_handling/catch_typed_step_error.py
@@ -1,0 +1,59 @@
+"""Demonstrates catching a typed StepError raised by a failed step.
+
+A failure inside a durable operation surfaces as a typed
+DurableOperationError subclass (StepError, InvokeError, ChildContextError,
+WaitForConditionError) rather than a single catch-all error, so callers can
+handle each operation's failure distinctly.
+
+The handler also crosses a wait/replay boundary after catching the error. This
+shows the typed StepError is deterministic across replay: on the resume
+invocation the handler replays from the top, the failed step is reconstructed
+from its checkpoint (its body is NOT re-executed), and it surfaces the identical
+StepError, which the same ``except`` catches again.
+"""
+
+from typing import Any
+
+from aws_durable_execution_sdk_python import StepError
+from aws_durable_execution_sdk_python.config import Duration, StepConfig
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+from aws_durable_execution_sdk_python.retries import (
+    RetryStrategyConfig,
+    create_retry_strategy,
+)
+from aws_durable_execution_sdk_python.types import StepContext
+
+
+@durable_execution
+def handler(_event: Any, context: DurableContext) -> dict[str, Any]:
+    """Run a step that fails, catch the typed StepError, then replay across a wait."""
+
+    def failing_step(_step_context: StepContext) -> None:
+        raise ValueError("payment declined")
+
+    # A single attempt so the step fails without scheduling retries.
+    config = StepConfig(
+        retry_strategy=create_retry_strategy(RetryStrategyConfig(max_attempts=1))
+    )
+
+    outcome: dict[str, Any] = {"handled": False}
+    try:
+        context.step(failing_step, name="charge-card", config=config)
+    except StepError as error:
+        # The class identifies the operation kind (StepError); error_type carries
+        # the original failure type (ValueError).
+        outcome = {
+            "handled": True,
+            "caught": type(error).__name__,
+            "error_type": error.error_type,
+            "message": error.message,
+        }
+
+    # Replay boundary: the execution suspends here and resumes as a new
+    # invocation that replays from the top. On resume, the failed step above is
+    # reconstructed from its checkpoint and raises the same StepError, which the
+    # except catches again — so `outcome` is identical on first run and replay.
+    context.wait(duration=Duration.from_seconds(1), name="post-failure-cooldown")
+
+    return outcome

--- a/packages/aws-durable-execution-sdk-python-examples/test/error_handling/test_catch_typed_step_error.py
+++ b/packages/aws-durable-execution-sdk-python-examples/test/error_handling/test_catch_typed_step_error.py
@@ -1,0 +1,62 @@
+"""Tests for catch_typed_step_error."""
+
+import pytest
+from aws_durable_execution_sdk_python.execution import InvocationStatus
+from aws_durable_execution_sdk_python.lambda_service import (
+    OperationStatus,
+    OperationType,
+)
+
+from src.error_handling import catch_typed_step_error
+from test.conftest import deserialize_operation_payload
+
+
+@pytest.mark.example
+@pytest.mark.durable_execution(
+    handler=catch_typed_step_error.handler,
+    lambda_function_name="Catch Typed Step Error",
+)
+def test_catch_typed_step_error(durable_runner):
+    """A failed step surfaces as a catchable StepError, identical across replay.
+
+    The handler catches the StepError and then crosses a wait/replay boundary, so
+    the returned ``outcome`` is produced on the resume (replay) invocation, while
+    the STEP FAILED checkpoint was written on the first invocation. Asserting the
+    surfaced error matches the persisted checkpoint error shows the typed error is
+    reconstructed identically across replays.
+    """
+    with durable_runner:
+        result = durable_runner.run(input=None, timeout=10)
+
+    assert result.status is InvocationStatus.SUCCEEDED
+
+    # The error caught on the replay pass (returned as the execution result).
+    result_data = deserialize_operation_payload(result.result)
+    assert result_data == {
+        "handled": True,
+        "caught": "StepError",
+        "error_type": "ValueError",
+        "message": "payment declined",
+    }
+
+    # A WAIT operation proves the execution suspended and replayed after the
+    # error was caught, so the result above reflects the replay invocation.
+    wait_ops = [
+        op for op in result.operations if op.operation_type == OperationType.WAIT
+    ]
+    assert len(wait_ops) >= 1
+
+    # The step's own checkpoint (written on the first run) is FAILED and records
+    # the raw escaping error type.
+    step_ops = [
+        op for op in result.operations if op.operation_type == OperationType.STEP
+    ]
+    assert len(step_ops) == 1
+    checkpoint_error = step_ops[0].error
+    assert step_ops[0].status is OperationStatus.FAILED
+    assert checkpoint_error is not None
+
+    # Cross-replay identity: the error surfaced on the replay pass (result_data)
+    # matches the error persisted on the first run (the checkpoint).
+    assert result_data["error_type"] == checkpoint_error.type == "ValueError"
+    assert result_data["message"] == checkpoint_error.message == "payment declined"

--- a/packages/aws-durable-execution-sdk-python-examples/test/wait_for_callback/test_wait_for_callback_failure.py
+++ b/packages/aws-durable-execution-sdk-python-examples/test/wait_for_callback/test_wait_for_callback_failure.py
@@ -21,7 +21,11 @@ def test_wait_for_callback_failure(durable_runner):
 
     assert result.status is InvocationStatus.FAILED
     assert isinstance(result.error, ErrorObject)
+    # The callback failure raises CallbackError inside the child context that
+    # wait_for_callback runs in; it is wrapped as ChildContextError so first run
+    # and replay surface an identical type. The original CallbackError type is
+    # preserved on the error's error_type/__cause__.
     assert result.error.to_dict() == {
         "ErrorMessage": "my callback error",
-        "ErrorType": "CallableRuntimeError",
+        "ErrorType": "ChildContextError",
     }

--- a/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/__init__.py
+++ b/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/__init__.py
@@ -18,9 +18,15 @@ from aws_durable_execution_sdk_python.context import (
 
 # Most common exceptions - users need to handle these exceptions
 from aws_durable_execution_sdk_python.exceptions import (
+    ChildContextError,
     DurableExecutionsError,
+    DurableOperationError,
+    ExecutionError,
     InvocationError,
+    InvokeError,
+    StepError,
     ValidationError,
+    WaitForConditionError,
 )
 
 # Core decorator - used in every durable function
@@ -33,12 +39,18 @@ from aws_durable_execution_sdk_python.types import StepContext
 
 __all__ = [
     "BatchResult",
+    "ChildContextError",
     "DurableContext",
     "DurableExecutionsError",
+    "DurableOperationError",
+    "ExecutionError",
     "InvocationError",
+    "InvokeError",
     "ParallelBranch",
     "StepContext",
+    "StepError",
     "ValidationError",
+    "WaitForConditionError",
     "WithRetryConfig",
     "__version__",
     "durable_execution",

--- a/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/concurrency/executor.py
+++ b/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/concurrency/executor.py
@@ -25,6 +25,7 @@ from aws_durable_execution_sdk_python.config import (
     NestingType,
 )
 from aws_durable_execution_sdk_python.exceptions import (
+    DurableOperationError,
     OrphanedChildException,
     SuspendExecution,
     TimedSuspendExecution,
@@ -418,11 +419,26 @@ class ConcurrentExecutor(ABC, Generic[CallableType, ResultType]):
                         )
                     )
                 case BranchStatus.FAILED:
+                    err = executable.error
+                    # Record the raw escaping type so first-run matches the
+                    # branch's FAIL checkpoint that replay reads back;
+                    # from_exception on the ChildContextError wrapper would
+                    # instead record the wrapper class name.
+                    error_object = (
+                        ErrorObject(
+                            message=err.message,
+                            type=err.error_type,
+                            data=err.data,
+                            stack_trace=err.stack_trace,
+                        )
+                        if isinstance(err, DurableOperationError)
+                        else ErrorObject.from_exception(err)
+                    )
                     batch_items.append(
                         BatchItem(
                             executable.index,
                             BatchItemStatus.FAILED,
-                            error=ErrorObject.from_exception(executable.error),
+                            error=error_object,
                         )
                     )
                 case (

--- a/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/concurrency/models.py
+++ b/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/concurrency/models.py
@@ -11,6 +11,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Generic, TypeVar
 
 from aws_durable_execution_sdk_python.exceptions import (
+    ChildContextError,
     InvalidStateError,
     SuspendExecution,
 )
@@ -260,8 +261,12 @@ class BatchResult(Generic[R], BatchResultProtocol[R]):  # noqa: PYI059
             (item.error for item in self.all if item.status is BatchItemStatus.FAILED),
             None,
         )
-        if first_error:
-            raise first_error.to_callable_runtime_error()
+        if first_error is not None:
+            # Each item runs in a child context, so a failed item surfaces as a
+            # ChildContextError wrapping the escaping error (reconstructed as its
+            # typed form where possible, with __cause__ set). Remaining errors
+            # stay in get_errors().
+            first_error.raise_as_operation_error(ChildContextError)
 
     def get_results(self) -> list[R]:
         return [

--- a/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/exceptions.py
+++ b/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/exceptions.py
@@ -6,7 +6,6 @@ Avoid any non-stdlib references in this module, it is at the bottom of the depen
 from __future__ import annotations
 
 import time
-from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, Self, TypedDict
 
@@ -266,25 +265,88 @@ class InvalidStateError(DurableExecutionsError):
     """Raised when an operation is attempted on an object in an invalid state."""
 
 
-class UserlandError(DurableExecutionsError):
-    """Failure in user-land - i.e code passed into durable executions from the caller."""
+class DurableOperationError(DurableExecutionsError):
+    """Base class for typed, per-operation failures.
 
+    Wraps a failure that escaped a Durable Function operation (step, invoke,
+    child context, wait_for_condition). The concrete class identifies the
+    operation kind (so callers can ``except StepError``); the escaping error is
+    preserved as ``__cause__`` on the first run and reconstructed on replay.
 
-class CallableRuntimeError(UserlandError):
-    """This error wraps any failure from inside the callable code that you pass to a Durable Function operation."""
+    Attributes:
+        message: Human-readable failure message.
+        error_type: Type name of the error that escaped the operation (the
+            original/inner error, e.g. ``"ValueError"``), not the operation
+            class. Defaults to the class name only when no escaping error is
+            known.
+        data: Optional serialized error payload, preserved across operation
+            boundaries.
+        stack_trace: Optional stack trace lines captured from the origin.
+    """
 
     def __init__(
         self,
-        message: str | None,
-        error_type: str | None,
-        data: str | None,
-        stack_trace: list[str] | None,
+        message: str | None = None,
+        error_type: str | None = None,
+        data: str | None = None,
+        stack_trace: list[str] | None = None,
     ) -> None:
         super().__init__(message)
-        self.message = message
-        self.error_type = error_type
-        self.data = data
-        self.stack_trace = stack_trace
+        self.message: str | None = message
+        self.error_type: str = error_type or type(self).__name__
+        self.data: str | None = data
+        self.stack_trace: list[str] | None = stack_trace
+
+    @classmethod
+    def from_error_fields(
+        cls,
+        error_type: str | None,
+        message: str | None,
+        data: str | None,
+        stack_trace: list[str] | None,
+    ) -> DurableOperationError:
+        """Rebuild the correct subclass from serialized checkpoint error fields.
+
+        Looks the discriminator up in the reconstruction registry, falling back
+        to the base :class:`DurableOperationError` when ``error_type`` is unknown
+        (e.g. a downstream error surfaced by an async invoke/callback checkpoint).
+        """
+        target_cls: type[DurableOperationError] = _DURABLE_OPERATION_ERROR_REGISTRY.get(
+            error_type or "", DurableOperationError
+        )
+        return target_cls(
+            message=message,
+            error_type=error_type,
+            data=data,
+            stack_trace=stack_trace,
+        )
+
+
+class StepError(DurableOperationError):
+    """Raised when a step operation fails."""
+
+
+class InvokeError(DurableOperationError):
+    """Raised when a durable invoke operation fails."""
+
+
+class ChildContextError(DurableOperationError):
+    """Raised when a child context (run_in_child_context, map, parallel) fails."""
+
+
+class WaitForConditionError(DurableOperationError):
+    """Raised when a wait_for_condition operation fails."""
+
+
+# Reconstruction registry for replay: only the SDK's own operation-error types.
+# Any other discriminator falls back to DurableOperationError in
+# from_error_fields, so we never call a constructor the SDK doesn't control.
+_DURABLE_OPERATION_ERROR_REGISTRY: dict[str, type[DurableOperationError]] = {
+    "StepError": StepError,
+    "InvokeError": InvokeError,
+    "ChildContextError": ChildContextError,
+    "WaitForConditionError": WaitForConditionError,
+}
 
 
 class StepInterruptedError(InvocationError):
@@ -395,37 +457,6 @@ class OrderedLockError(DurableExecutionsError):
         )
         super().__init__(msg)
         self.source_exception: Exception | None = source_exception
-
-
-@dataclass(frozen=True)
-class CallableRuntimeErrorSerializableDetails:
-    """Serializable error details."""
-
-    type: str
-    message: str
-
-    @classmethod
-    def from_exception(
-        cls, exception: Exception
-    ) -> CallableRuntimeErrorSerializableDetails:
-        """Create an instance from an Exception, using its type and message.
-
-        Args:
-            exception: An Exception instance
-
-        Returns:
-            A CallableRuntimeErrorDetails instance with the exception's type name and message
-        """
-        return cls(type=exception.__class__.__name__, message=str(exception))
-
-    def __str__(self) -> str:
-        """
-        Return a string representation of the object.
-
-        Returns:
-            A string in the format "type: message"
-        """
-        return f"{self.type}: {self.message}"
 
 
 class SerDesError(DurableExecutionsError):

--- a/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/lambda_service.py
+++ b/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/lambda_service.py
@@ -1,20 +1,21 @@
 from __future__ import annotations
 
+import builtins
 import copy
 import datetime
 import logging
 from collections.abc import MutableMapping
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Protocol, TypeAlias, cast
+from typing import TYPE_CHECKING, Any, NoReturn, Protocol, TypeAlias, cast
 
 import boto3
 from botocore.config import Config
 
 from aws_durable_execution_sdk_python.__about__ import __version__
 from aws_durable_execution_sdk_python.exceptions import (
-    CallableRuntimeError,
     CheckpointError,
+    DurableOperationError,
     GetExecutionStateError,
 )
 
@@ -235,6 +236,17 @@ class ErrorObject:
 
     @classmethod
     def from_exception(cls, exception: Exception) -> ErrorObject:
+        # The wire ErrorType is always the class name (the discriminant): a raw
+        # error records its own type; a typed wrapper records its operation kind.
+        # For a DurableOperationError also preserve its own data and stack_trace
+        # so the inner info survives across a single operation boundary.
+        if isinstance(exception, DurableOperationError):
+            return cls(
+                message=exception.message,
+                type=type(exception).__name__,
+                data=exception.data,
+                stack_trace=exception.stack_trace,
+            )
         return cls(
             message=str(exception),
             type=type(exception).__name__,
@@ -263,13 +275,38 @@ class ErrorObject:
             result["StackTrace"] = self.stack_trace
         return result
 
-    def to_callable_runtime_error(self) -> CallableRuntimeError:
-        return CallableRuntimeError(
+    def to_durable_operation_error(self) -> DurableOperationError:
+        return DurableOperationError.from_error_fields(
+            error_type=self.type,
+            message=self.message,
+            data=self.data,
+            stack_trace=self.stack_trace,
+        )
+
+    def raise_as_operation_error(
+        self, operation_error_cls: builtins.type[DurableOperationError]
+    ) -> NoReturn:
+        """Raise the operation's typed error reconstructed from this ErrorObject.
+
+        Used by both the first-run terminal-failure path and replay, so the
+        surfaced error is identical (a durable-execution determinism guarantee):
+        the wrapper is ``operation_error_cls`` carrying this object's
+        ``error_type``/``data``/``stack_trace``, and ``__cause__`` is the escaping
+        error rebuilt via the registry (a typed subclass when known, else the
+        base ``DurableOperationError``).
+        """
+        cause: DurableOperationError = DurableOperationError.from_error_fields(
+            error_type=self.type,
+            message=self.message,
+            data=self.data,
+            stack_trace=self.stack_trace,
+        )
+        raise operation_error_cls(
             message=self.message,
             error_type=self.type,
             data=self.data,
             stack_trace=self.stack_trace,
-        )
+        ) from cause
 
 
 @dataclass(frozen=True)

--- a/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/operation/child.py
+++ b/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/operation/child.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, TypeVar
 
 from aws_durable_execution_sdk_python.config import ChildConfig
 from aws_durable_execution_sdk_python.exceptions import (
+    ChildContextError,
     InvocationError,
     SuspendExecution,
 )
@@ -78,7 +79,7 @@ class ChildOperationExecutor(OperationExecutor[T]):
             CheckResult indicating the next action to take
 
         Raises:
-            CallableRuntimeError: For FAILED operations
+            ChildContextError: For FAILED operations
         """
         checkpointed_result: CheckpointedResult = self.state.get_checkpoint_result(
             self.operation_identifier.operation_id
@@ -114,7 +115,7 @@ class ChildOperationExecutor(OperationExecutor[T]):
 
         # Terminal failure
         if checkpointed_result.is_failed():
-            checkpointed_result.raise_callable_error()
+            checkpointed_result.raise_operation_error(ChildContextError)
 
         # Create START checkpoint if not exists
         if not checkpointed_result.is_existent() and not self.is_virtual:
@@ -145,7 +146,7 @@ class ChildOperationExecutor(OperationExecutor[T]):
         Raises:
             SuspendExecution: Re-raised without checkpointing
             InvocationError: Re-raised after checkpointing FAIL
-            CallableRuntimeError: Raised for other exceptions after checkpointing FAIL
+            ChildContextError: Raised for other exceptions after checkpointing FAIL
         """
         logger.debug(
             "▶️ Executing child context for id: %s, name: %s",
@@ -239,6 +240,13 @@ class ChildOperationExecutor(OperationExecutor[T]):
             # Don't checkpoint SuspendExecution - let it bubble up
             raise
         except Exception as e:
+            # Retryable InvocationError: re-raise with no FAIL checkpoint so the
+            # backend retry re-runs. Non-retryable falls through to FAIL + wrap.
+            if isinstance(e, InvocationError) and e.is_retryable():
+                raise
+
+            # Any other error is terminal: persist FAIL, then surface as
+            # ChildContextError (original type kept on error_type/__cause__).
             error_object = ErrorObject.from_exception(e)
             # Virtual deliberately does not write checkpoints, but exception still propagates below
             if not self.is_virtual:
@@ -252,14 +260,9 @@ class ChildOperationExecutor(OperationExecutor[T]):
                 # This guarantees the error is durable and child operations won't be re-executed on replay.
                 self.state.create_checkpoint(operation_update=fail_operation)
 
-            # InvocationError and its derivatives can be retried.
-            # When we encounter an invocation error (in all of its forms), we
-            # bubble that error upwards (with the checkpoint in place for
-            # non-virtual) such that we reach the execution handler at the
-            # very top, which will then make the backend retry.
-            if isinstance(e, InvocationError):
-                raise
-            raise error_object.to_callable_runtime_error() from e
+            # Reconstruct from the checkpointed error (same path as replay) so
+            # first run and replay surface an identical ChildContextError.
+            error_object.raise_as_operation_error(ChildContextError)
 
 
 def child_handler(

--- a/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/operation/invoke.py
+++ b/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/operation/invoke.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, TypeVar
 
-from aws_durable_execution_sdk_python.exceptions import ExecutionError
+from aws_durable_execution_sdk_python.exceptions import ExecutionError, InvokeError
 from aws_durable_execution_sdk_python.lambda_service import (
     ChainedInvokeOptions,
     OperationUpdate,
@@ -81,7 +81,7 @@ class InvokeOperationExecutor(OperationExecutor[R]):
             CheckResult indicating the next action to take
 
         Raises:
-            CallableRuntimeError: For FAILED, TIMED_OUT, or STOPPED operations
+            InvokeError: For FAILED, TIMED_OUT, or STOPPED operations
             SuspendExecution: For STARTED operations waiting for completion
         """
         checkpointed_result: CheckpointedResult = self.state.get_checkpoint_result(
@@ -107,7 +107,7 @@ class InvokeOperationExecutor(OperationExecutor[R]):
             or checkpointed_result.is_timed_out()
             or checkpointed_result.is_stopped()
         ):
-            checkpointed_result.raise_callable_error()
+            checkpointed_result.raise_operation_error(InvokeError)
 
         # Still running - ready to suspend
         if checkpointed_result.is_started():

--- a/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/operation/step.py
+++ b/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/operation/step.py
@@ -12,6 +12,7 @@ from aws_durable_execution_sdk_python.config import (
 from aws_durable_execution_sdk_python.exceptions import (
     ExecutionError,
     InvalidStateError,
+    StepError,
     StepInterruptedError,
 )
 from aws_durable_execution_sdk_python.lambda_service import (
@@ -86,7 +87,7 @@ class StepOperationExecutor(OperationExecutor[T]):
             CheckResult indicating the next action to take
 
         Raises:
-            CallableRuntimeError: For FAILED operations
+            StepError: For FAILED operations
             StepInterruptedError: For interrupted AT_MOST_ONCE operations
             SuspendExecution: For PENDING operations waiting for retry
         """
@@ -115,7 +116,7 @@ class StepOperationExecutor(OperationExecutor[T]):
         # Terminal failure
         if checkpointed_result.is_failed():
             # Have to throw the exact same error on replay as the checkpointed failure
-            checkpointed_result.raise_callable_error()
+            checkpointed_result.raise_operation_error(StepError)
 
         # Pending retry
         if checkpointed_result.is_pending():
@@ -143,7 +144,7 @@ class StepOperationExecutor(OperationExecutor[T]):
             # Step was previously interrupted in a prior invocation - handle retry
             msg: str = f"Step operation_id={self.operation_identifier.operation_id} name={self.operation_identifier.name} was previously interrupted"
             self.retry_handler(StepInterruptedError(msg), checkpointed_result)
-            checkpointed_result.raise_callable_error()
+            checkpointed_result.raise_operation_error(StepError)
 
         # Ready to execute if STARTED + AT_LEAST_ONCE
         if (
@@ -297,9 +298,12 @@ class StepOperationExecutor(OperationExecutor[T]):
 
         Raises:
             SuspendExecution: If retry is scheduled
-            StepInterruptedError: If the error is a StepInterruptedError
-            CallableRuntimeError: If retry is exhausted or error is not retryable
+            StepError: If retry is exhausted or the error is not retryable
+                (including an exhausted StepInterruptedError)
         """
+        # Checkpoint the raw escaping error (records its own type, e.g.
+        # "ValueError"); the StepError wrapper is what we raise, and it is
+        # recorded one level up by whoever catches it.
         error_object = ErrorObject.from_exception(error)
 
         retry_strategy = self.config.retry_strategy or RetryPresets.default()
@@ -371,7 +375,8 @@ class StepOperationExecutor(OperationExecutor[T]):
         # This guarantees the error is durable and the step won't be retried on replay.
         self.state.create_checkpoint(operation_update=fail_operation)
 
-        if isinstance(error, StepInterruptedError):
-            raise error
-
-        raise error_object.to_callable_runtime_error()
+        # Surface as a StepError reconstructed from the checkpointed error, the
+        # same path replay uses, so first run and replay are identical. (An
+        # exhausted StepInterruptedError surfaces the same way as any other
+        # step failure.)
+        error_object.raise_as_operation_error(StepError)

--- a/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/operation/wait_for_condition.py
+++ b/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/operation/wait_for_condition.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING, TypeVar
 
 from aws_durable_execution_sdk_python.exceptions import (
     ExecutionError,
+    InvocationError,
+    WaitForConditionError,
 )
 from aws_durable_execution_sdk_python.lambda_service import (
     ErrorObject,
@@ -84,7 +86,7 @@ class WaitForConditionOperationExecutor(OperationExecutor[T]):
             CheckResult indicating the next action to take
 
         Raises:
-            CallableRuntimeError: For FAILED operations
+            WaitForConditionError: For FAILED operations
             SuspendExecution: For PENDING operations waiting for retry
         """
         checkpointed_result = self.state.get_checkpoint_result(
@@ -110,7 +112,7 @@ class WaitForConditionOperationExecutor(OperationExecutor[T]):
 
         # Terminal failure
         if checkpointed_result.is_failed():
-            checkpointed_result.raise_callable_error()
+            checkpointed_result.raise_operation_error(WaitForConditionError)
 
         # Pending retry
         if checkpointed_result.is_pending():
@@ -266,23 +268,30 @@ class WaitForConditionOperationExecutor(OperationExecutor[T]):
             )
 
         except Exception as e:
-            # Mark as failed - waitForCondition doesn't have its own retry logic for errors
-            # If the check function throws, it's considered a failure
+            # Retryable InvocationError: re-raise with no FAIL checkpoint so the
+            # backend retry re-runs. Non-retryable falls through to FAIL + wrap.
+            if isinstance(e, InvocationError) and e.is_retryable():
+                logger.warning(
+                    "wait_for_condition invocation error for id: %s, name: %s; re-raising for retry",
+                    self.operation_identifier.operation_id,
+                    self.operation_identifier.name,
+                )
+                raise
+
+            # Any other error is terminal: persist FAIL, then surface as
+            # WaitForConditionError (original type kept on error_type/__cause__).
             logger.exception(
                 "❌ wait_for_condition failed for id: %s, name: %s",
                 self.operation_identifier.operation_id,
                 self.operation_identifier.name,
             )
-
+            error_object = ErrorObject.from_exception(e)
             fail_operation = OperationUpdate.create_wait_for_condition_fail(
                 identifier=self.operation_identifier,
-                error=ErrorObject.from_exception(e),
+                error=error_object,
             )
-            # Checkpoint FAIL operation with blocking (is_sync=True, default).
-            # Must ensure the failure state is persisted before raising the exception.
-            # This guarantees the error is durable and the condition won't be re-evaluated on replay.
             self.state.create_checkpoint(operation_update=fail_operation)
-            raise
+            error_object.raise_as_operation_error(WaitForConditionError)
 
         msg: str = (
             "wait_for_condition should never reach this point"  # pragma: no cover

--- a/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/retries.py
+++ b/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/retries.py
@@ -296,8 +296,8 @@ class WithRetryConfig(Generic[T]):
             (RetryStrategyConfig defaults) is used.
         wrap_with_run_in_child_context: Whether to wrap the retry loop in
             a child context for isolation. Default True. When True, final
-            failure is rethrown as CallableRuntimeError with the original
-            exception on `cause`. When False, the original error is
+            failure is rethrown as ChildContextError with the original
+            exception on `__cause__`. When False, the original error is
             rethrown unchanged.
         child_context_config: Optional ChildConfig forwarded to
             run_in_child_context when wrapping is enabled. Ignored when
@@ -344,8 +344,8 @@ def with_retry(
         exhausted or the retry strategy returns should_retry=False.
         When wrap_with_run_in_child_context is True (default),
         ChildOperationExecutor.process wraps non-InvocationError /
-        SuspendExecution exceptions as CallableRuntimeError with the
-        original error in cause.
+        SuspendExecution exceptions as ChildContextError with the
+        original error in __cause__.
         When wrap_with_run_in_child_context is False, the original
         exception propagates unchanged.
         SuspendExecution: Re-raised immediately (SDK control flow).

--- a/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/state.py
+++ b/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/state.py
@@ -11,12 +11,12 @@ import time
 from dataclasses import dataclass
 from enum import Enum
 from threading import Lock
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, Callable, NoReturn
 
 from aws_durable_execution_sdk_python.exceptions import (
     BackgroundThreadError,
-    CallableRuntimeError,
     DurableExecutionsError,
+    DurableOperationError,
     GetExecutionStateError,
     OrphanedChildException,
     SuspendExecution,
@@ -222,20 +222,29 @@ class CheckpointedResult:
             return False
         return op.context_details.replay_children if op.context_details else False
 
-    def raise_callable_error(self, msg: str | None = None) -> None:
+    def raise_operation_error(
+        self,
+        operation_error_cls: type[DurableOperationError],
+        msg: str | None = None,
+    ) -> NoReturn:
+        """Reconstruct and raise the typed operation error for a FAILED checkpoint.
+
+        The concrete error type is dictated by the operation being replayed and
+        supplied by the calling executor (e.g. ``StepError`` for a step). This
+        ensures async operations whose checkpoint carries a downstream error type
+        (invoke/callback) still surface as the correct per-operation error.
+        """
         if self.error is None:
-            err_msg = (
+            err_msg: str = (
                 msg
                 or "Unknown error. No ErrorObject exists on the Checkpoint Operation."
             )
-            raise CallableRuntimeError(
-                message=err_msg,
-                error_type=None,
-                data=None,
-                stack_trace=None,
-            )
+            raise operation_error_cls(message=err_msg)
 
-        raise self.error.to_callable_runtime_error()
+        # Reconstruct from the checkpointed ErrorObject. This is the same path the
+        # handlers use on the first-run failure, so first run and replay surface
+        # an identical error.
+        self.error.raise_as_operation_error(operation_error_cls)
 
     def get_next_attempt_timestamp(self) -> datetime.datetime | None:
         if self.operation and self.operation.step_details:

--- a/packages/aws-durable-execution-sdk-python/tests/concurrency_test.py
+++ b/packages/aws-durable-execution-sdk-python/tests/concurrency_test.py
@@ -36,7 +36,7 @@ from aws_durable_execution_sdk_python.context import (
     ExecutionContext,
 )
 from aws_durable_execution_sdk_python.exceptions import (
-    CallableRuntimeError,
+    ChildContextError,
     InvalidStateError,
     SuspendExecution,
     TimedSuspendExecution,
@@ -221,12 +221,12 @@ def test_batch_result_throw_if_error():
     result = BatchResult(items, CompletionReason.ALL_COMPLETED)
     result.throw_if_error()  # Should not raise
 
-    # Has error
-    error = ErrorObject("test message", "TestError", None, None)
+    # Has error - reconstructs the typed operation error from its discriminator
+    error = ErrorObject("test message", "ChildContextError", None, None)
     items = [BatchItem(0, BatchItemStatus.FAILED, error=error)]
     result = BatchResult(items, CompletionReason.ALL_COMPLETED)
 
-    with pytest.raises(CallableRuntimeError):
+    with pytest.raises(ChildContextError, match="test message"):
         result.throw_if_error()
 
 
@@ -1795,6 +1795,68 @@ def test_concurrent_executor_create_result_with_failed_status():
     assert result.all[0].status == BatchItemStatus.FAILED
     assert result.all[0].error is not None
     assert result.all[0].error.message == "Test error"
+
+
+def test_failed_branch_error_type_matches_across_execute_and_replay():
+    """A failed branch's error_type must be identical on first run and replay.
+
+    First run builds the item error in _create_result; replay reads the branch's
+    FAIL checkpoint (which records the raw escaping type). Both must surface the
+    raw type ("ValueError"), not the ChildContextError wrapper class name.
+    """
+
+    class TestExecutor(ConcurrentExecutor):
+        def execute_item(self, child_context, executable):
+            msg = "Test error"
+            raise ValueError(msg)
+
+    completion_config = CompletionConfig(
+        min_successful=1,
+        tolerated_failure_count=0,
+        tolerated_failure_percentage=None,
+    )
+
+    def make_executor():
+        return TestExecutor(
+            executables=[Executable(0, lambda: "test")],
+            max_concurrency=1,
+            completion_config=completion_config,
+            sub_type_top="TOP",
+            sub_type_iteration="ITER",
+            name_prefix="test_",
+            serdes=None,
+        )
+
+    # First run: execute() runs the branch and builds the result live.
+    execution_state = Mock()
+    execution_state.create_checkpoint = Mock()
+    executor_context = Mock()
+    executor_context._create_step_id_for_logical_step = lambda *args: "1"  # noqa: SLF001
+    child_context = Mock()
+    child_context.state.wrap_user_function = lambda func, *args, **kwargs: func
+    executor_context.create_child_context = lambda *args, **kwargs: child_context
+
+    live_error = make_executor().execute(execution_state, executor_context).all[0].error
+    assert live_error is not None
+
+    # Replay: replay() reads the child's FAIL checkpoint, which stored the raw type.
+    failed_checkpoint = Mock()
+    failed_checkpoint.is_succeeded.return_value = False
+    failed_checkpoint.is_failed.return_value = True
+    failed_checkpoint.error = ErrorObject(
+        message="Test error", type="ValueError", data=None, stack_trace=None
+    )
+    replay_state = Mock()
+    replay_state.get_checkpoint_result = Mock(return_value=failed_checkpoint)
+    replay_context = Mock()
+    replay_context._create_step_id_for_logical_step = lambda *args: "1"  # noqa: SLF001
+
+    replay_error = make_executor().replay(replay_state, replay_context).all[0].error
+    assert replay_error is not None
+
+    # Both paths must carry the same raw error_type.
+    assert replay_error.type == "ValueError"
+    assert live_error.type == replay_error.type
 
 
 def test_timer_scheduler_can_resume_false():

--- a/packages/aws-durable-execution-sdk-python/tests/e2e/checkpoint_response_int_test.py
+++ b/packages/aws-durable-execution-sdk-python/tests/e2e/checkpoint_response_int_test.py
@@ -643,7 +643,7 @@ def test_end_to_end_child_context_error_handling():
     """Test end-to-end child context error handling.
 
     Verifies that child context that raises exception creates FAIL checkpoint
-    and error is wrapped as CallableRuntimeError.
+    and error is wrapped as a typed DurableOperationError (e.g. StepError).
     """
 
     def child_function_that_fails(ctx: DurableContext) -> str:
@@ -705,11 +705,7 @@ def test_end_to_end_child_context_error_handling():
 
 
 def test_end_to_end_child_context_invocation_error_reraised():
-    """Test end-to-end child context InvocationError re-raising.
-
-    Verifies that child context that raises InvocationError creates FAIL checkpoint
-    and re-raises InvocationError (not wrapped) to enable retry at execution handler level.
-    """
+    """Child context InvocationError re-raises unchanged and writes no FAIL checkpoint."""
 
     def child_function_with_invocation_error(ctx: DurableContext) -> str:
         msg = "Invocation failed in child"
@@ -758,11 +754,11 @@ def test_end_to_end_child_context_invocation_error_reraised():
         with pytest.raises(InvocationError, match="Invocation failed in child"):
             my_handler(event, lambda_context)
 
-        # Verify FAIL checkpoint was created before re-raising
+        # No FAIL checkpoint - the operation stays non-terminal for retry.
         all_operations = [op for batch in checkpoint_calls for op in batch]
         fail_updates = [
             op
             for op in all_operations
             if hasattr(op, "action") and op.action.value == "FAIL"
         ]
-        assert len(fail_updates) == 1
+        assert len(fail_updates) == 0

--- a/packages/aws-durable-execution-sdk-python/tests/e2e/error_hierarchy_int_test.py
+++ b/packages/aws-durable-execution-sdk-python/tests/e2e/error_hierarchy_int_test.py
@@ -1,0 +1,176 @@
+"""Integration tests for the typed per-operation error hierarchy.
+
+These exercise the full handler flow end-to-end (rather than mocking the
+executor seams) to cover the two directions unit tests mock away:
+
+- serialization: a failing operation checkpoints a FAIL carrying the typed
+  discriminator, and the invocation result surfaces the typed error.
+- reconstruction: a pre-seeded FAILED checkpoint resurfaces as the typed error
+  on replay without re-executing the operation.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import Mock, patch
+
+from aws_durable_execution_sdk_python.config import StepConfig
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import (
+    InvocationStatus,
+    durable_execution,
+)
+from aws_durable_execution_sdk_python.retries import (
+    RetryStrategyConfig,
+    create_retry_strategy,
+)
+from tests.e2e.checkpoint_response_int_test import (
+    create_mock_checkpoint_with_operations,
+)
+from tests.test_helpers import operation_id_sequence
+
+if TYPE_CHECKING:
+    from aws_durable_execution_sdk_python.types import StepContext
+
+
+def _lambda_context() -> Mock:
+    lambda_context = Mock()
+    lambda_context.aws_request_id = "test-request-id"
+    lambda_context.client_context = None
+    lambda_context.identity = None
+    lambda_context._epoch_deadline_time_in_ms = 0  # noqa: SLF001
+    lambda_context.invoked_function_arn = "test-arn"
+    lambda_context.tenant_id = None
+    return lambda_context
+
+
+def test_step_failure_surfaces_typed_step_error():
+    """A failing step records the raw error at its own level and surfaces a
+    typed StepError to the caller (serialization path).
+
+    The step's FAIL checkpoint records the raw escaping error ("ValueError");
+    the StepError wrapper is recorded one level up (the execution result).
+    """
+
+    def failing_step(_step_context: StepContext) -> str:
+        msg = "step boom"
+        raise ValueError(msg)
+
+    @durable_execution
+    def my_handler(event, context: DurableContext) -> str:
+        # Single attempt so the step fails without scheduling retries.
+        config = StepConfig(
+            retry_strategy=create_retry_strategy(RetryStrategyConfig(max_attempts=1))
+        )
+        return context.step(failing_step, name="charge", config=config)
+
+    with patch(
+        "aws_durable_execution_sdk_python.execution.LambdaClient"
+    ) as mock_client_class:
+        mock_client = Mock()
+        mock_client_class.initialize_client.return_value = mock_client
+
+        mock_checkpoint, checkpoint_calls = create_mock_checkpoint_with_operations()
+        mock_client.checkpoint = mock_checkpoint
+
+        event = {
+            "DurableExecutionArn": "test-arn/execution-1",
+            "CheckpointToken": "test-token",
+            "InitialExecutionState": {
+                "Operations": [
+                    {
+                        "Id": "execution-1",
+                        "Type": "EXECUTION",
+                        "Status": "STARTED",
+                        "ExecutionDetails": {"InputPayload": "{}"},
+                    }
+                ],
+                "NextMarker": "",
+            },
+            "LocalRunner": True,
+        }
+
+        result = my_handler(event, _lambda_context())
+
+        # Execution failed; the result (one level up from the step) carries the
+        # StepError wrapper, and StepError.error_type is the original error type.
+        assert result["Status"] == InvocationStatus.FAILED.value
+        assert result["Error"]["ErrorType"] == "StepError"
+        assert result["Error"]["ErrorMessage"] == "step boom"
+
+        # The step's own FAIL checkpoint records the raw escaping error type.
+        all_operations = [op for batch in checkpoint_calls for op in batch]
+        fail_updates = [
+            op
+            for op in all_operations
+            if hasattr(op, "action") and op.action.value == "FAIL"
+        ]
+        assert len(fail_updates) == 1
+        assert fail_updates[0].error is not None
+        assert fail_updates[0].error.type == "ValueError"
+
+
+def test_failed_step_reconstructs_step_error_on_replay():
+    """A pre-seeded FAILED step checkpoint resurfaces as a typed StepError on
+    replay without re-executing the step (reconstruction path)."""
+    executed = {"count": 0}
+
+    def maybe_step(_step_context: StepContext) -> str:
+        executed["count"] += 1
+        return "should-not-run"
+
+    @durable_execution
+    def my_handler(event, context: DurableContext) -> str:
+        return context.step(maybe_step, name="charge")
+
+    # The id the first top-level step will look up on replay.
+    step_id = next(operation_id_sequence())
+
+    with patch(
+        "aws_durable_execution_sdk_python.execution.LambdaClient"
+    ) as mock_client_class:
+        mock_client = Mock()
+        mock_client_class.initialize_client.return_value = mock_client
+
+        mock_checkpoint, _checkpoint_calls = create_mock_checkpoint_with_operations()
+        mock_client.checkpoint = mock_checkpoint
+
+        event = {
+            "DurableExecutionArn": "test-arn/execution-1",
+            "CheckpointToken": "test-token",
+            "InitialExecutionState": {
+                "Operations": [
+                    {
+                        "Id": "execution-1",
+                        "Type": "EXECUTION",
+                        "Status": "STARTED",
+                        "ExecutionDetails": {"InputPayload": "{}"},
+                    },
+                    {
+                        "Id": step_id,
+                        "Type": "STEP",
+                        "Status": "FAILED",
+                        "SubType": "Step",
+                        "ParentId": "execution-1",
+                        # A failed step records the raw escaping error type.
+                        "StepDetails": {
+                            "Error": {
+                                "ErrorType": "ValueError",
+                                "ErrorMessage": "prior boom",
+                            }
+                        },
+                    },
+                ],
+                "NextMarker": "",
+            },
+            "LocalRunner": True,
+        }
+
+        result = my_handler(event, _lambda_context())
+
+        # Reconstructed as a StepError with the checkpointed message; the step
+        # body is never re-executed.
+        assert result["Status"] == InvocationStatus.FAILED.value
+        assert result["Error"]["ErrorType"] == "StepError"
+        assert result["Error"]["ErrorMessage"] == "prior boom"
+        assert executed["count"] == 0

--- a/packages/aws-durable-execution-sdk-python/tests/exceptions_test.py
+++ b/packages/aws-durable-execution-sdk-python/tests/exceptions_test.py
@@ -7,25 +7,28 @@ import pytest
 from botocore.exceptions import ClientError  # type: ignore[import-untyped]
 
 from aws_durable_execution_sdk_python.exceptions import (
+    _DURABLE_OPERATION_ERROR_REGISTRY,
     BotoClientError,
-    CallableRuntimeError,
-    CallableRuntimeErrorSerializableDetails,
+    ChildContextError,
     CheckpointError,
     CheckpointErrorCategory,
     DurableApiErrorCategory,
     DurableExecutionsError,
+    DurableOperationError,
     ExecutionError,
     GetExecutionStateError,
     InvocationError,
+    InvokeError,
     OrderedLockError,
     OrphanedChildException,
+    StepError,
     StepInterruptedError,
     SuspendExecution,
     TerminationReason,
     TimedSuspendExecution,
     UnrecoverableError,
-    UserlandError,
     ValidationError,
+    WaitForConditionError,
 )
 
 
@@ -207,31 +210,102 @@ def test_validation_error():
     assert isinstance(error, DurableExecutionsError)
 
 
-def test_userland_error():
-    """Test UserlandError exception."""
-    error = UserlandError("userland error")
-    assert str(error) == "userland error"
+def test_durable_operation_error_defaults_error_type_to_class_name():
+    """Base DurableOperationError defaults error_type to its class name."""
+    error = DurableOperationError("boom")
+    assert str(error) == "boom"
+    assert error.message == "boom"
+    assert error.error_type == "DurableOperationError"
+    assert error.data is None
+    assert error.stack_trace is None
     assert isinstance(error, DurableExecutionsError)
 
 
-def test_callable_runtime_error():
-    """Test CallableRuntimeError exception."""
-    error = CallableRuntimeError(
+def test_durable_operation_error_explicit_fields():
+    """DurableOperationError preserves explicitly provided fields."""
+    error = DurableOperationError(
         "runtime error", "ValueError", "error data", ["line1", "line2"]
     )
-    assert str(error) == "runtime error"
     assert error.message == "runtime error"
     assert error.error_type == "ValueError"
     assert error.data == "error data"
-    assert isinstance(error, UserlandError)
+    assert error.stack_trace == ["line1", "line2"]
 
 
-def test_callable_runtime_error_with_none_values():
-    """Test CallableRuntimeError with None values."""
-    error = CallableRuntimeError(None, None, None, None)
+def test_durable_operation_error_with_none_message():
+    """DurableOperationError tolerates a None message."""
+    error = DurableOperationError(None)
     assert error.message is None
-    assert error.error_type is None
+    assert error.error_type == "DurableOperationError"
     assert error.data is None
+
+
+@pytest.mark.parametrize(
+    "error_cls",
+    [StepError, InvokeError, ChildContextError, WaitForConditionError],
+)
+def test_operation_error_subclasses(error_cls):
+    """Each per-operation subclass derives from DurableOperationError and self-types."""
+    error = error_cls("failed")
+    assert isinstance(error, DurableOperationError)
+    assert isinstance(error, DurableExecutionsError)
+    assert error.error_type == error_cls.__name__
+    assert error.message == "failed"
+
+
+def test_operation_error_registry_contains_all_subclasses():
+    """The reconstruction registry is keyed by class name for every subclass."""
+    assert _DURABLE_OPERATION_ERROR_REGISTRY["StepError"] is StepError
+    assert _DURABLE_OPERATION_ERROR_REGISTRY["InvokeError"] is InvokeError
+    assert _DURABLE_OPERATION_ERROR_REGISTRY["ChildContextError"] is ChildContextError
+    assert (
+        _DURABLE_OPERATION_ERROR_REGISTRY["WaitForConditionError"]
+        is WaitForConditionError
+    )
+
+
+def test_from_error_fields_user_subclass_falls_back_without_typeerror():
+    """A user subclass with an incompatible __init__ must not be reconstructed.
+
+    Only the SDK's own operation-error types are in the registry, so an unknown
+    discriminator (including a user subclass) falls back to the base
+    DurableOperationError instead of calling a constructor the SDK doesn't control.
+    """
+
+    class CustomError(StepError):
+        def __init__(self, my_arg: str):
+            super().__init__(f"arb: {my_arg}")
+
+    # The user subclass is not registered, so reconstruction never calls its __init__.
+    assert "CustomError" not in _DURABLE_OPERATION_ERROR_REGISTRY
+    reconstructed = DurableOperationError.from_error_fields(
+        error_type="CustomError",
+        message="boom",
+        data=None,
+        stack_trace=None,
+    )
+    assert type(reconstructed) is DurableOperationError
+    assert reconstructed.error_type == "CustomError"
+    assert reconstructed.message == "boom"
+
+
+def test_from_error_fields_by_name():
+    """from_error_fields rebuilds the correct subclass from its discriminator."""
+    error = DurableOperationError.from_error_fields(
+        "StepError", "step failed", "data", ["frame"]
+    )
+    assert isinstance(error, StepError)
+    assert error.error_type == "StepError"
+    assert error.message == "step failed"
+    assert error.data == "data"
+    assert error.stack_trace == ["frame"]
+
+
+def test_from_error_fields_unknown_falls_back_to_base():
+    """Unknown discriminators fall back to the base DurableOperationError."""
+    error = DurableOperationError.from_error_fields("ValueError", "boom", None, None)
+    assert type(error) is DurableOperationError
+    assert error.error_type == "ValueError"
 
 
 def test_step_interrupted_error():
@@ -265,27 +339,6 @@ def test_ordered_lock_error_with_source():
     error = OrderedLockError("lock error", source)
     assert str(error) == "lock error ValueError: source error"
     assert error.source_exception is source
-
-
-def test_callable_runtime_error_serializable_details_from_exception():
-    """Test CallableRuntimeErrorSerializableDetails.from_exception."""
-    exception = ValueError("test error")
-    details = CallableRuntimeErrorSerializableDetails.from_exception(exception)
-    assert details.type == "ValueError"
-    assert details.message == "test error"
-
-
-def test_callable_runtime_error_serializable_details_str():
-    """Test CallableRuntimeErrorSerializableDetails.__str__."""
-    details = CallableRuntimeErrorSerializableDetails("TypeError", "type error message")
-    assert str(details) == "TypeError: type error message"
-
-
-def test_callable_runtime_error_serializable_details_frozen():
-    """Test CallableRuntimeErrorSerializableDetails is frozen."""
-    details = CallableRuntimeErrorSerializableDetails("Error", "message")
-    with pytest.raises(AttributeError):
-        details.type = "NewError"
 
 
 def test_timed_suspend_execution():

--- a/packages/aws-durable-execution-sdk-python/tests/lambda_service_test.py
+++ b/packages/aws-durable-execution-sdk-python/tests/lambda_service_test.py
@@ -8,9 +8,10 @@ import pytest
 
 from aws_durable_execution_sdk_python.__about__ import __version__
 from aws_durable_execution_sdk_python.exceptions import (
-    CallableRuntimeError,
     CheckpointError,
+    DurableOperationError,
     GetExecutionStateError,
+    StepError,
 )
 from aws_durable_execution_sdk_python.identifier import OperationIdentifier
 from aws_durable_execution_sdk_python.lambda_service import (
@@ -228,20 +229,53 @@ def test_error_object_to_dict_all_none():
     assert result == {}
 
 
-def test_error_object_to_callable_runtime_error():
-    """Test ErrorObject.to_callable_runtime_error method."""
+def test_error_object_to_durable_operation_error_reconstructs_subclass():
+    """ErrorObject.to_durable_operation_error rebuilds the typed subclass by name."""
+    error = ErrorObject(
+        message="Test error",
+        type="StepError",
+        data="test_data",
+        stack_trace=["line1"],
+    )
+    operation_error = error.to_durable_operation_error()
+    assert isinstance(operation_error, StepError)
+    assert operation_error.message == "Test error"
+    assert operation_error.error_type == "StepError"
+    assert operation_error.data == "test_data"
+    assert operation_error.stack_trace == ["line1"]
+
+
+def test_error_object_to_durable_operation_error_unknown_type_falls_back():
+    """An unknown discriminator falls back to the base DurableOperationError."""
     error = ErrorObject(
         message="Test error",
         type="TestError",
         data="test_data",
         stack_trace=["line1"],
     )
-    runtime_error = error.to_callable_runtime_error()
-    assert isinstance(runtime_error, CallableRuntimeError)
-    assert runtime_error.message == "Test error"
-    assert runtime_error.error_type == "TestError"
-    assert runtime_error.data == "test_data"
-    assert runtime_error.stack_trace == ["line1"]
+    operation_error = error.to_durable_operation_error()
+    assert type(operation_error) is DurableOperationError
+    assert operation_error.error_type == "TestError"
+    assert operation_error.message == "Test error"
+
+
+def test_error_object_from_exception_preserves_operation_error_fields():
+    """from_exception keeps a DurableOperationError's typed discriminator/data."""
+    cause = ValueError("boom")
+    step_error = StepError(message="step failed", data="payload")
+    step_error.__cause__ = cause
+    error_object = ErrorObject.from_exception(step_error)
+    assert error_object.type == "StepError"
+    assert error_object.message == "step failed"
+    assert error_object.data == "payload"
+
+
+def test_error_object_from_exception_plain_exception():
+    """A non-operation exception still serializes its Python class name."""
+    error_object = ErrorObject.from_exception(ValueError("nope"))
+    assert error_object.type == "ValueError"
+    assert error_object.message == "nope"
+    assert error_object.data is None
 
 
 def test_step_details_from_dict():

--- a/packages/aws-durable-execution-sdk-python/tests/operation/child_test.py
+++ b/packages/aws-durable-execution-sdk-python/tests/operation/child_test.py
@@ -10,7 +10,10 @@ import pytest
 
 from aws_durable_execution_sdk_python.config import ChildConfig
 from aws_durable_execution_sdk_python.exceptions import (
-    CallableRuntimeError,
+    BotoClientError,
+    ChildContextError,
+    DurableApiErrorCategory,
+    ExecutionError,
     InvocationError,
 )
 from aws_durable_execution_sdk_python.identifier import OperationIdentifier
@@ -173,13 +176,13 @@ def test_child_handler_already_failed():
     mock_result = Mock()
     mock_result.is_succeeded.return_value = False
     mock_result.is_failed.return_value = True
-    mock_result.raise_callable_error.side_effect = CallableRuntimeError(
-        "Previous failure", "TestError", None, None
+    mock_result.raise_operation_error.side_effect = ChildContextError(
+        "Previous failure"
     )
     mock_state.get_checkpoint_result.return_value = mock_result
     mock_callable = Mock()
 
-    with pytest.raises(CallableRuntimeError, match="Previous failure"):
+    with pytest.raises(ChildContextError, match="Previous failure"):
         child_handler(
             mock_callable,
             mock_state,
@@ -287,7 +290,7 @@ def test_child_handler_callable_exception(
     mock_callable = Mock(side_effect=ValueError("Test error"))
     mock_state.wrap_user_function.return_value = mock_callable
 
-    with pytest.raises(CallableRuntimeError):
+    with pytest.raises(ChildContextError):
         child_handler(
             mock_callable,
             mock_state,
@@ -322,14 +325,18 @@ def test_child_handler_callable_exception(
     assert fail_operation.operation_type is OperationType.CONTEXT
     assert fail_operation.sub_type is expected_sub_type
     assert fail_operation.action is OperationAction.FAIL
-    assert fail_operation.error == ErrorObject.from_exception(ValueError("Test error"))
+    # The checkpoint records the escaping error as-is (its own type); the
+    # ChildContextError wrapper is raised and recorded one level up.
+    assert fail_operation.error == ErrorObject(
+        message="Test error", type="ValueError", data=None, stack_trace=None
+    )
 
 
 def test_child_handler_error_wrapped():
-    """Test child_handler wraps regular errors as CallableRuntimeError.
+    """Test child_handler wraps regular errors as ChildContextError.
 
     Verifies:
-    - Regular exceptions are wrapped as CallableRuntimeError
+    - Regular exceptions are wrapped as ChildContextError
     - FAIL checkpoint is created
     """
     mock_state = Mock(spec=ExecutionState)
@@ -344,7 +351,7 @@ def test_child_handler_error_wrapped():
     mock_callable = Mock(side_effect=test_error)
     mock_state.wrap_user_function.return_value = mock_callable
 
-    with pytest.raises(CallableRuntimeError):
+    with pytest.raises(ChildContextError):
         child_handler(
             mock_callable,
             mock_state,
@@ -359,14 +366,7 @@ def test_child_handler_error_wrapped():
 
 
 def test_child_handler_invocation_error_reraised():
-    """Test child_handler re-raises InvocationError after checkpointing FAIL.
-
-    Verifies:
-    - InvocationError: checkpoints FAIL and re-raises (for retry)
-    - FAIL checkpoint is created
-    - Original InvocationError is re-raised (not wrapped)
-    """
-
+    """InvocationError propagates unchanged and writes no FAIL checkpoint."""
     mock_state = Mock(spec=ExecutionState)
     mock_state.durable_execution_arn = "test_arn"
     mock_result = Mock()
@@ -379,6 +379,7 @@ def test_child_handler_invocation_error_reraised():
     mock_callable = Mock(side_effect=test_error)
     mock_state.wrap_user_function.return_value = mock_callable
 
+    # Raises the original InvocationError, NOT ChildContextError.
     with pytest.raises(InvocationError, match="Invocation failed"):
         child_handler(
             mock_callable,
@@ -389,10 +390,83 @@ def test_child_handler_invocation_error_reraised():
             None,
         )
 
+    # Only the async START checkpoint is written - no FAIL.
+    assert mock_state.create_checkpoint.call_count == 1  # start only
+    actions = [
+        call.kwargs["operation_update"].action
+        for call in mock_state.create_checkpoint.call_args_list
+    ]
+    assert OperationAction.FAIL not in actions
+
+
+def test_child_handler_execution_error_wrapped():
+    """ExecutionError is wrapped as ChildContextError (replay-safe), not raised raw."""
+    mock_state = Mock(spec=ExecutionState)
+    mock_state.durable_execution_arn = "test_arn"
+    mock_result = Mock()
+    mock_result.is_succeeded.return_value = False
+    mock_result.is_failed.return_value = False
+    mock_result.is_started.return_value = False
+    mock_result.is_existent.return_value = False
+    mock_state.get_checkpoint_result.return_value = mock_result
+    test_error = ExecutionError("execution failed")
+    mock_callable = Mock(side_effect=test_error)
+    mock_state.wrap_user_function.return_value = mock_callable
+
+    with pytest.raises(ChildContextError) as exc_info:
+        child_handler(
+            mock_callable,
+            mock_state,
+            OperationIdentifier(
+                "op7c", OperationSubType.RUN_IN_CHILD_CONTEXT, None, "test_name"
+            ),
+            None,
+        )
+
+    # Not the raw ExecutionError; the original type survives on error_type.
+    assert not isinstance(exc_info.value, ExecutionError)
+    assert exc_info.value.error_type == "ExecutionError"
+
     # Verify FAIL checkpoint was created
     assert mock_state.create_checkpoint.call_count == 2  # start and fail
+    fail_call = mock_state.create_checkpoint.call_args_list[1]
+    fail_operation = fail_call[1]["operation_update"]
+    assert fail_operation.action is OperationAction.FAIL
 
-    # Verify fail checkpoint
+
+def test_child_handler_non_retryable_invocation_error_wrapped():
+    """Non-retryable InvocationError is terminal: writes FAIL and wraps as ChildContextError."""
+    mock_state = Mock(spec=ExecutionState)
+    mock_state.durable_execution_arn = "test_arn"
+    mock_result = Mock()
+    mock_result.is_succeeded.return_value = False
+    mock_result.is_failed.return_value = False
+    mock_result.is_started.return_value = False
+    mock_result.is_existent.return_value = False
+    mock_state.get_checkpoint_result.return_value = mock_result
+    test_error = BotoClientError(
+        "boto failure", error_category=DurableApiErrorCategory.EXECUTION
+    )
+    assert test_error.is_retryable() is False
+    mock_callable = Mock(side_effect=test_error)
+    mock_state.wrap_user_function.return_value = mock_callable
+
+    with pytest.raises(ChildContextError) as exc_info:
+        child_handler(
+            mock_callable,
+            mock_state,
+            OperationIdentifier(
+                "op7d", OperationSubType.RUN_IN_CHILD_CONTEXT, None, "test_name"
+            ),
+            None,
+        )
+
+    # Not re-raised raw; the escaping type survives on error_type.
+    assert not isinstance(exc_info.value, InvocationError)
+    assert exc_info.value.error_type == "BotoClientError"
+
+    # FAIL checkpoint IS written so the op is not left STARTED in a FAILED execution.
+    assert mock_state.create_checkpoint.call_count == 2  # start and fail
     fail_call = mock_state.create_checkpoint.call_args_list[1]
     fail_operation = fail_call[1]["operation_update"]
     assert fail_operation.action is OperationAction.FAIL
@@ -881,7 +955,7 @@ def test_child_handler_is_virtual_with_exception():
     A virtual branch emits no lifecycle entries in the execution
     history, so a failure inside the branch does not get its own FAIL
     checkpoint. The exception still propagates (wrapped as
-    CallableRuntimeError for non-InvocationError exceptions) so the
+    ChildContextError for non-InvocationError exceptions) so the
     concurrency executor records the failure in the BatchResult and
     its completion-tolerance logic still applies.
     """
@@ -899,7 +973,7 @@ def test_child_handler_is_virtual_with_exception():
 
     config = ChildConfig(is_virtual=True)
 
-    with pytest.raises(CallableRuntimeError):
+    with pytest.raises(ChildContextError):
         child_handler(
             mock_callable,
             mock_state,
@@ -931,7 +1005,7 @@ def test_child_handler_not_is_virtual_with_exception():
 
     config = ChildConfig(is_virtual=False)
 
-    with pytest.raises(CallableRuntimeError):
+    with pytest.raises(ChildContextError):
         child_handler(
             mock_callable,
             mock_state,

--- a/packages/aws-durable-execution-sdk-python/tests/operation/invoke_test.py
+++ b/packages/aws-durable-execution-sdk-python/tests/operation/invoke_test.py
@@ -9,8 +9,8 @@ import pytest
 
 from aws_durable_execution_sdk_python.config import InvokeConfig
 from aws_durable_execution_sdk_python.exceptions import (
-    CallableRuntimeError,
     ExecutionError,
+    InvokeError,
     SuspendExecution,
     TimedSuspendExecution,
 )
@@ -147,7 +147,7 @@ def test_invoke_handler_already_terminated(kind: OperationStatus):
     mock_result = CheckpointedResult.create_from_operation(operation)
     mock_state.get_checkpoint_result.return_value = mock_result
 
-    with pytest.raises(CallableRuntimeError):
+    with pytest.raises(InvokeError):
         invoke_handler(
             function_name="test_function",
             payload="test_input",
@@ -176,7 +176,7 @@ def test_invoke_handler_already_timed_out():
     mock_result = CheckpointedResult.create_from_operation(operation)
     mock_state.get_checkpoint_result.return_value = mock_result
 
-    with pytest.raises(CallableRuntimeError):
+    with pytest.raises(InvokeError):
         invoke_handler(
             function_name="test_function",
             payload="test_input",
@@ -914,7 +914,7 @@ def test_invoke_immediate_response_immediate_failure(status: OperationStatus):
     mock_state.get_checkpoint_result.side_effect = [not_found, failed]
 
     # Verify error is raised without suspend
-    with pytest.raises(CallableRuntimeError):
+    with pytest.raises(InvokeError):
         invoke_handler(
             function_name="test_function",
             payload="test_input",

--- a/packages/aws-durable-execution-sdk-python/tests/operation/step_test.py
+++ b/packages/aws-durable-execution-sdk-python/tests/operation/step_test.py
@@ -13,8 +13,9 @@ from aws_durable_execution_sdk_python.config import (
     StepSemantics,
 )
 from aws_durable_execution_sdk_python.exceptions import (
-    CallableRuntimeError,
+    DurableOperationError,
     ExecutionError,
+    StepError,
     StepInterruptedError,
     SuspendExecution,
 )
@@ -132,7 +133,7 @@ def test_step_handler_already_failed():
     mock_callable = Mock()
     mock_logger = Mock(spec=Logger)
 
-    with pytest.raises(CallableRuntimeError):
+    with pytest.raises(StepError):
         step_handler(
             mock_callable,
             mock_state,
@@ -424,7 +425,7 @@ def test_step_handler_retry_exhausted():
     mock_logger = Mock(spec=Logger)
     mock_logger.with_log_info.return_value = mock_logger
 
-    with pytest.raises(CallableRuntimeError):
+    with pytest.raises(StepError):
         step_handler(
             mock_callable,
             mock_state,
@@ -450,10 +451,14 @@ def test_step_handler_retry_exhausted():
     assert fail_operation.operation_type is OperationType.STEP
     assert fail_operation.sub_type is OperationSubType.STEP
     assert fail_operation.action is OperationAction.FAIL
+    # The checkpoint records the raw escaping error's type; the StepError wrapper
+    # is surfaced to the caller and recorded one level up.
+    assert fail_operation.error is not None
+    assert fail_operation.error.type == "RuntimeError"
 
 
 def test_step_handler_retry_interrupted_error():
-    """Test step_handler with StepInterruptedError in retry."""
+    """A StepInterruptedError that exhausts retries surfaces as a StepError."""
     mock_state = Mock(spec=ExecutionState)
     mock_result = CheckpointedResult.create_not_found()
     mock_state.get_checkpoint_result.return_value = mock_result
@@ -469,7 +474,7 @@ def test_step_handler_retry_interrupted_error():
     mock_logger = Mock(spec=Logger)
     mock_logger.with_log_info.return_value = mock_logger
 
-    with pytest.raises(StepInterruptedError, match="Step interrupted"):
+    with pytest.raises(StepError, match="Step interrupted") as exc_info:
         step_handler(
             mock_callable,
             mock_state,
@@ -477,6 +482,13 @@ def test_step_handler_retry_interrupted_error():
             config,
             mock_logger,
         )
+
+    # First run and replay both reconstruct from the checkpointed error, so the
+    # surfaced StepError carries the interrupted error's type/message and a
+    # reconstructed (stand-in) cause rather than the live object.
+    assert exc_info.value.error_type == "StepInterruptedError"
+    assert isinstance(exc_info.value.__cause__, DurableOperationError)
+    assert exc_info.value.__cause__.error_type == "StepInterruptedError"
 
 
 def test_step_handler_retry_with_existing_attempts():
@@ -1024,7 +1036,7 @@ def test_step_immediate_response_immediate_failure():
     )
 
     # Verify operation raises error after executing step function
-    with pytest.raises(CallableRuntimeError, match="Step execution error"):
+    with pytest.raises(StepError, match="Step execution error"):
         step_handler(
             mock_callable,
             mock_state,

--- a/packages/aws-durable-execution-sdk-python/tests/operation/wait_for_condition_test.py
+++ b/packages/aws-durable-execution-sdk-python/tests/operation/wait_for_condition_test.py
@@ -8,14 +8,19 @@ import pytest
 
 from aws_durable_execution_sdk_python.config import Duration
 from aws_durable_execution_sdk_python.exceptions import (
-    CallableRuntimeError,
+    BotoClientError,
+    DurableApiErrorCategory,
+    DurableOperationError,
+    ExecutionError,
     InvocationError,
     SuspendExecution,
+    WaitForConditionError,
 )
 from aws_durable_execution_sdk_python.identifier import OperationIdentifier
 from aws_durable_execution_sdk_python.lambda_service import (
     ErrorObject,
     Operation,
+    OperationAction,
     OperationStatus,
     OperationType,
     StepDetails,
@@ -232,7 +237,7 @@ def test_wait_for_condition_already_failed():
         wait_strategy=lambda s, a: WaitForConditionDecision.stop_polling(),
     )
 
-    with pytest.raises(CallableRuntimeError):
+    with pytest.raises(WaitForConditionError):
         wait_for_condition_handler(
             state=mock_state,
             operation_identifier=op_id,
@@ -392,7 +397,10 @@ def test_wait_for_condition_check_function_exception():
         wait_strategy=lambda s, a: WaitForConditionDecision.stop_polling(),
     )
 
-    with pytest.raises(ValueError, match="Test error"):
+    # A check-function failure surfaces as the typed WaitForConditionError. First
+    # run and replay both reconstruct from the checkpointed error, so error_type
+    # is the original type and __cause__ is a reconstructed stand-in.
+    with pytest.raises(WaitForConditionError, match="Test error") as exc_info:
         wait_for_condition_handler(
             state=mock_state,
             operation_identifier=op_id,
@@ -401,7 +409,140 @@ def test_wait_for_condition_check_function_exception():
             context_logger=mock_logger,
         )
 
+    assert exc_info.value.error_type == "ValueError"
+    assert isinstance(exc_info.value.__cause__, DurableOperationError)
+    assert exc_info.value.__cause__.error_type == "ValueError"
     assert mock_state.create_checkpoint.call_count == 2  # START and FAIL
+
+
+def test_wait_for_condition_invocation_error_not_wrapped():
+    """InvocationError propagates unchanged and writes no FAIL checkpoint."""
+    mock_state = Mock(spec=ExecutionState)
+    mock_state.durable_execution_arn = "arn:aws:test"
+    mock_state.get_checkpoint_result.return_value = (
+        CheckpointedResult.create_not_found()
+    )
+
+    mock_logger = Mock(spec=Logger)
+    mock_logger.with_log_info.return_value = mock_logger
+
+    op_id = OperationIdentifier(
+        "op1", OperationSubType.WAIT_FOR_CONDITION, None, "test_wait"
+    )
+
+    def check_func(state, context):
+        raise InvocationError("control-flow failure")
+
+    mock_state.wrap_user_function.return_value = check_func
+
+    config = WaitForConditionConfig(
+        initial_state=5,
+        wait_strategy=lambda s, a: WaitForConditionDecision.stop_polling(),
+    )
+
+    # Not wrapped in WaitForConditionError - propagates with its own type.
+    with pytest.raises(InvocationError, match="control-flow failure"):
+        wait_for_condition_handler(
+            state=mock_state,
+            operation_identifier=op_id,
+            check=check_func,
+            config=config,
+            context_logger=mock_logger,
+        )
+
+    # Only the async START checkpoint is written - no FAIL.
+    assert mock_state.create_checkpoint.call_count == 1  # START only
+    actions = [
+        call.kwargs["operation_update"].action
+        for call in mock_state.create_checkpoint.call_args_list
+    ]
+    assert OperationAction.FAIL not in actions
+
+
+def test_wait_for_condition_execution_error_wrapped():
+    """ExecutionError from the check function is wrapped as WaitForConditionError (replay-safe)."""
+    mock_state = Mock(spec=ExecutionState)
+    mock_state.durable_execution_arn = "arn:aws:test"
+    mock_state.get_checkpoint_result.return_value = (
+        CheckpointedResult.create_not_found()
+    )
+
+    mock_logger = Mock(spec=Logger)
+    mock_logger.with_log_info.return_value = mock_logger
+
+    op_id = OperationIdentifier(
+        "op1", OperationSubType.WAIT_FOR_CONDITION, None, "test_wait"
+    )
+
+    def check_func(state, context):
+        raise ExecutionError("execution failure")
+
+    mock_state.wrap_user_function.return_value = check_func
+
+    config = WaitForConditionConfig(
+        initial_state=5,
+        wait_strategy=lambda s, a: WaitForConditionDecision.stop_polling(),
+    )
+
+    with pytest.raises(WaitForConditionError, match="execution failure") as exc_info:
+        wait_for_condition_handler(
+            state=mock_state,
+            operation_identifier=op_id,
+            check=check_func,
+            config=config,
+            context_logger=mock_logger,
+        )
+
+    # Not the raw ExecutionError; the original type survives on error_type.
+    assert not isinstance(exc_info.value, ExecutionError)
+    assert exc_info.value.error_type == "ExecutionError"
+    assert mock_state.create_checkpoint.call_count == 2  # START and FAIL
+
+
+def test_wait_for_condition_non_retryable_invocation_error_wrapped():
+    """Non-retryable InvocationError is terminal: writes FAIL and wraps as WaitForConditionError."""
+    mock_state = Mock(spec=ExecutionState)
+    mock_state.durable_execution_arn = "arn:aws:test"
+    mock_state.get_checkpoint_result.return_value = (
+        CheckpointedResult.create_not_found()
+    )
+
+    mock_logger = Mock(spec=Logger)
+    mock_logger.with_log_info.return_value = mock_logger
+
+    op_id = OperationIdentifier(
+        "op1", OperationSubType.WAIT_FOR_CONDITION, None, "test_wait"
+    )
+
+    test_error = BotoClientError(
+        "boto failure", error_category=DurableApiErrorCategory.EXECUTION
+    )
+    assert test_error.is_retryable() is False
+
+    def check_func(state, context):
+        raise test_error
+
+    mock_state.wrap_user_function.return_value = check_func
+
+    config = WaitForConditionConfig(
+        initial_state=5,
+        wait_strategy=lambda s, a: WaitForConditionDecision.stop_polling(),
+    )
+
+    with pytest.raises(WaitForConditionError) as exc_info:
+        wait_for_condition_handler(
+            state=mock_state,
+            operation_identifier=op_id,
+            check=check_func,
+            config=config,
+            context_logger=mock_logger,
+        )
+
+    # Not re-raised raw; the escaping type survives on error_type.
+    assert not isinstance(exc_info.value, InvocationError)
+    assert exc_info.value.error_type == "BotoClientError"
+    # FAIL checkpoint IS written (START + FAIL).
+    assert mock_state.create_checkpoint.call_count == 2
 
 
 def test_wait_for_condition_check_context():
@@ -1234,7 +1375,7 @@ def test_wait_for_condition_immediate_failure_without_executing_check():
     )
 
     # Verify error raised without executing check function
-    with pytest.raises(CallableRuntimeError):
+    with pytest.raises(WaitForConditionError):
         wait_for_condition_handler(
             state=mock_state,
             operation_identifier=op_id,

--- a/packages/aws-durable-execution-sdk-python/tests/state_test.py
+++ b/packages/aws-durable-execution-sdk-python/tests/state_test.py
@@ -15,10 +15,10 @@ import pytest
 
 from aws_durable_execution_sdk_python.exceptions import (
     BackgroundThreadError,
-    CallableRuntimeError,
     DurableApiErrorCategory,
     GetExecutionStateError,
     OrphanedChildException,
+    StepError,
     TimedSuspendExecution,
 )
 from aws_durable_execution_sdk_python.identifier import OperationIdentifier
@@ -368,32 +368,39 @@ def test_checkpointed_result_is_started():
     assert result_no_op.is_started() is False
 
 
-def test_checkpointed_result_raise_callable_error():
-    """Test CheckpointedResult.raise_callable_error method."""
-    error = Mock(spec=ErrorObject)
-    error.to_callable_runtime_error.return_value = RuntimeError("Test error")
+def test_checkpointed_result_raise_operation_error():
+    """raise_operation_error wraps the checkpoint error in the given operation type."""
+    error = ErrorObject(
+        message="Test error", type="ValueError", data="d", stack_trace=["l"]
+    )
     result = CheckpointedResult(error=error)
 
-    with pytest.raises(RuntimeError, match="Test error"):
-        result.raise_callable_error()
+    with pytest.raises(StepError, match="Test error") as exc_info:
+        result.raise_operation_error(StepError)
 
-    error.to_callable_runtime_error.assert_called_once()
+    # error_type carries the escaping/original error type from the checkpoint,
+    # and a typed __cause__ is reattached so replay matches the first run.
+    assert exc_info.value.error_type == "ValueError"
+    assert exc_info.value.data == "d"
+    assert exc_info.value.stack_trace == ["l"]
+    assert exc_info.value.__cause__ is not None
+    assert str(exc_info.value.__cause__) == "Test error"
 
 
-def test_checkpointed_result_raise_callable_error_no_error():
-    """Test CheckpointedResult.raise_callable_error with no error."""
+def test_checkpointed_result_raise_operation_error_no_error():
+    """raise_operation_error with no error raises the operation type with a default message."""
     result = CheckpointedResult()
 
-    with pytest.raises(CallableRuntimeError, match="Unknown error"):
-        result.raise_callable_error()
+    with pytest.raises(StepError, match="Unknown error"):
+        result.raise_operation_error(StepError)
 
 
-def test_checkpointed_result_raise_callable_error_no_error_with_message():
-    """Test CheckpointedResult.raise_callable_error with no error and custom message."""
+def test_checkpointed_result_raise_operation_error_no_error_with_message():
+    """raise_operation_error with no error uses the provided custom message."""
     result = CheckpointedResult()
 
-    with pytest.raises(CallableRuntimeError, match="Custom error message"):
-        result.raise_callable_error("Custom error message")
+    with pytest.raises(StepError, match="Custom error message"):
+        result.raise_operation_error(StepError, "Custom error message")
 
 
 def test_checkpointed_result_immutable():


### PR DESCRIPTION
*Issue #, if available:* 
https://github.com/aws/aws-durable-execution-sdk-python/issues/120
https://github.com/aws/aws-durable-execution-sdk-python/issues/546

*Description of changes:*

Replaces the single catch-all `CallableRuntimeError` with a typed, per-operation error hierarchy. A failed step, invoke, child context, or wait_for_condition now surfaces as a distinct, catchable exception type. It also lands the `from_exception`/`throw_if_error` changes those types require. The `CallbackError` rework and the nested-boundary regression test are intentionally deferred to follow-up PRs.

#### Public API

- Exports the typed operation errors and their base from the package root: `StepError`, `InvokeError`, `ChildContextError`, `WaitForConditionError`, and `DurableOperationError`, plus `ExecutionError`. Users can now `from aws_durable_execution_sdk_python import StepError` (etc.) and catch on the specific type. `CallbackError` and `SerDesError` are intentionally not exported yet (see follow-ups).

#### Breaking changes

- Operation failures now raise the typed subclasses (StepError, InvokeError, ChildContextError, WaitForConditionError) instead of CallableRuntimeError (removed).
- Catch on the exception class to identify the operation. The error_type attribute carries the original Python exception name (e.g. "ValueError"); the original message is on .message, and the original error is attached as __cause__ (the live exception on first run, a reconstructed stand-in on replay). At the wire/checkpoint level, an escaping wrapper is recorded under its class-name discriminator (e.g. "StepError") one level up, while the operation's own FAIL checkpoint records the raw error type.
- wait_for_condition check failures are now wrapped in WaitForConditionError rather than re-raised raw.
- wait_for_callback/callback failures now surface as CallbackError (previously CallableRuntimeError); CallbackError remains in the termination tree until the follow-up.
- An exhausted interrupted step fails immediately as StepError rather than round-tripping through a Lambda retry.

#### Fixes #546 - non-retryable failures no longer leave a STARTED op in a FAILED execution

- In child context and wait_for_condition, a non-retryable `InvocationError` (e.g. a `BotoClientError` classified EXECUTION) now falls through to the FAIL checkpoint before being wrapped, so the operation isn't left STARTED inside a FAILED execution. A retryable `InvocationError` still re-raises so the backend can retry, matching the JS and Java SDKs (which resolve retry/suspend before the branch boundary and terminally FAIL everything else).

#### Testing

- Updated/added unit tests across exceptions, lambda_service, state, concurrency, and the four operation handlers.
- Added coverage for: registry + from_error_fields (including fallback to the base DurableOperationError for unknown/user discriminators), from_exception field preservation across a single operation boundary, raise_operation_error, wait_for_condition control-flow errors propagating unwrapped, non-retryable InvocationError wrapping in child and wait_for_condition (#546), and the execution result recording the StepError discriminator while the step's own FAIL checkpoint records the raw error type.
- Added an integration test and an example; the example also verifies the caught error is identical across a wait/replay boundary.

#### Follow-ups

- Move `CallbackError` under `DurableOperationError` with graded subclasses (`CallbackExternalError`, `CallbackTimeoutError`, `CallbackSubmitterError`) and drop `CALLBACK_ERROR` metadata.
- Regression test for `data` surviving ≥2 nested `run_in_child_context` boundaries

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
