### PR TITLE
fix(otel): fix continuation span start time

### DIFF
--- a/packages/aws-durable-execution-sdk-python-otel/src/aws_durable_execution_sdk_python_otel/plugin.py
+++ b/packages/aws-durable-execution-sdk-python-otel/src/aws_durable_execution_sdk_python_otel/plugin.py
@@ -393,7 +393,7 @@ class OtelPlugin(DurableInstrumentationPlugin):
                 operation_id=info.operation_id,
                 name=info.name or info.operation_id,
                 attributes=attributes,
-                start_time=datetime.datetime.now(datetime.UTC),
+                start_time=info.start_time,
                 parent_span=parent_span,
                 existed=True,
             )

--- a/packages/aws-durable-execution-sdk-python-otel/tests/test_plugin.py
+++ b/packages/aws-durable-execution-sdk-python-otel/tests/test_plugin.py
@@ -247,6 +247,35 @@ def test_operation_end_without_start_emits_continuation_span_with_link():
     )
 
 
+def test_continuation_span_uses_recorded_start_and_end_times():
+    """Continuation spans use the recorded operation start/end times."""
+    plugin, exporter = _create_plugin()
+    plugin.on_invocation_start(_invocation_start_info())
+
+    plugin.on_operation_end(
+        OperationEndInfo(
+            operation_id="fast-step",
+            operation_type=OperationType.STEP,
+            sub_type=None,
+            name="fast-step",
+            parent_id=None,
+            start_time=START_TIME,
+            is_replayed=False,
+            status=OperationStatus.SUCCEEDED,
+            end_time=END_TIME,
+            error=None,
+        )
+    )
+
+    span = exporter.get_finished_spans()[0]
+    expected_start = int(START_TIME.timestamp() * 1_000_000_000)
+    expected_end = int(END_TIME.timestamp() * 1_000_000_000)
+    assert span.start_time == expected_start
+    assert span.end_time == expected_end
+    # Duration must be non-negative.
+    assert span.end_time >= span.start_time
+
+
 def test_replayed_operation_start_emits_continuation_span_with_link():
     """Replayed operation spans should not reuse the original deterministic span ID."""
     plugin, exporter = _create_plugin()


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Update the continuation span's start time to use the operation's start time.

Current behaviour:

When `on_operation_end` continues a span from a previous invocation, it creates a span with `start_time` = `datetime.now()`. But the span's end time is set to the `end_time` recorded in the operation info.

If an operation quickly finishes before the span is started, `end_time` will be before the `datetime.now()` call, resulting in a negative span duration.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
