### PR TITLE
fix(step): Return round-tripped result on first run

### DIFF
--- a/packages/aws-durable-execution-sdk-python-examples/examples-catalog.json
+++ b/packages/aws-durable-execution-sdk-python-examples/examples-catalog.json
@@ -46,6 +46,17 @@
       "path": "./src/step/step_with_retry.py"
     },
     {
+      "name": "Step with Custom SerDes",
+      "description": "Step with a non-identity custom SerDes; the step returns the canonical round-tripped value, consistent across first run and replay",
+      "handler": "step_with_custom_serdes.handler",
+      "integration": true,
+      "durableConfig": {
+        "RetentionPeriodInDays": 7,
+        "ExecutionTimeout": 300
+      },
+      "path": "./src/step/step_with_custom_serdes.py"
+    },
+    {
       "name": "Wait State",
       "description": "Basic usage of context.wait() to pause execution",
       "handler": "wait.handler",

--- a/packages/aws-durable-execution-sdk-python-examples/src/step/step_with_custom_serdes.py
+++ b/packages/aws-durable-execution-sdk-python-examples/src/step/step_with_custom_serdes.py
@@ -1,0 +1,65 @@
+"""Step with a custom (non-identity) SerDes.
+
+Demonstrates that a step returns the *canonical, round-tripped* value — the
+value produced by ``serialize`` then ``deserialize`` — rather than the raw
+in-memory object the step function returned. Because a step's result is
+deserialized from the checkpoint on replay, returning the round-tripped value
+on the first run keeps the result identical across the first run and every
+replay.
+
+Here the custom SerDes normalizes the order on the way to the checkpoint: it
+persists only the canonical fields, sorts the tags, and drops a transient,
+non-persisted field. The handler uses the step result immediately, so the value
+observed on the first run is already the canonical form (sorted tags, transient
+field dropped) — the same value a replay would deserialize from the checkpoint.
+"""
+
+import json
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import StepConfig
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+from aws_durable_execution_sdk_python.serdes import SerDes, SerDesContext
+
+
+class OrderSerDes(SerDes[dict[str, Any]]):
+    """Persist a canonical order: keep stable fields, sort tags, drop transients.
+
+    ``deserialize(serialize(order))`` is intentionally not the identity — the
+    transient field is dropped and the tags are sorted — so the difference
+    between the raw result and the round-tripped result is observable.
+    """
+
+    def serialize(self, value: dict[str, Any], _: SerDesContext) -> str:
+        canonical: dict[str, Any] = {
+            "order_id": value["order_id"],
+            "tags": sorted(value["tags"]),
+        }
+        return json.dumps(canonical)
+
+    def deserialize(self, data: str, _: SerDesContext) -> dict[str, Any]:
+        return json.loads(data)
+
+
+@durable_execution
+def handler(_event: Any, context: DurableContext) -> dict[str, Any]:
+    """Build an order in a step and use its round-tripped result immediately."""
+    order = context.step(
+        lambda _: {
+            "order_id": "ORD-42",
+            "tags": ["priority", "gift", "fragile"],  # unsorted on purpose
+            "transient_score": 0.99,  # not persisted by OrderSerDes
+        },
+        name="build_order",
+        config=StepConfig(serdes=OrderSerDes()),
+    )
+
+    # `order` is the canonical, round-tripped value even on the first run:
+    # tags are sorted and the transient field is gone. A replay would produce
+    # the exact same value by deserializing the checkpoint.
+    return {
+        "order_id": order["order_id"],
+        "tags": order["tags"],  # canonical: sorted
+        "has_transient": "transient_score" in order,  # False after round-trip
+    }

--- a/packages/aws-durable-execution-sdk-python-examples/test/step/test_step_with_custom_serdes.py
+++ b/packages/aws-durable-execution-sdk-python-examples/test/step/test_step_with_custom_serdes.py
@@ -1,0 +1,44 @@
+"""Tests for the step-with-custom-serdes example."""
+
+import pytest
+from aws_durable_execution_sdk_python.execution import InvocationStatus
+
+from src.step import step_with_custom_serdes
+from src.step.step_with_custom_serdes import OrderSerDes
+from test.conftest import deserialize_operation_payload
+
+
+@pytest.mark.example
+@pytest.mark.durable_execution(
+    handler=step_with_custom_serdes.handler,
+    lambda_function_name="Step with Custom SerDes",
+)
+def test_step_with_custom_serdes(durable_runner):
+    """The handler returns the canonical, round-tripped step result.
+
+    Even on the first run the step returns the value produced by
+    OrderSerDes.serialize then OrderSerDes.deserialize, so the result reflects
+    the canonical form (sorted tags, transient field dropped) rather than the
+    raw value the step function produced. This is the same value a replay would
+    deserialize from the checkpoint.
+    """
+    with durable_runner:
+        result = durable_runner.run(input="test", timeout=10)
+
+    assert result.status is InvocationStatus.SUCCEEDED
+
+    result_data = deserialize_operation_payload(result.result)
+    assert result_data == {
+        "order_id": "ORD-42",
+        "tags": ["fragile", "gift", "priority"],  # sorted by the serdes
+        "has_transient": False,  # transient field dropped on serialize
+    }
+
+    # The step checkpoint stores the canonical payload, and deserializing it
+    # yields exactly what the handler returned for the order fields.
+    step_result = result.get_step("build_order")
+    canonical = deserialize_operation_payload(step_result.result, OrderSerDes())
+    assert canonical == {
+        "order_id": "ORD-42",
+        "tags": ["fragile", "gift", "priority"],
+    }

--- a/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/operation/step.py
+++ b/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/operation/step.py
@@ -249,7 +249,17 @@ class StepOperationExecutor(OperationExecutor[T]):
                 self.operation_identifier.operation_id,
                 self.operation_identifier.name,
             )
-            return raw_result  # noqa: TRY300
+            # Return the round-tripped value so the first run matches replay,
+            # which reconstructs the result by deserializing the checkpoint.
+            # A None payload is returned as-is, mirroring the replay path.
+            if serialized_result is None:
+                return None  # type: ignore[return-value]
+            return deserialize(  # noqa: TRY300
+                serdes=self.config.serdes,
+                data=serialized_result,
+                operation_id=self.operation_identifier.operation_id,
+                durable_execution_arn=self.state.durable_execution_arn,
+            )
         except Exception as e:
             if isinstance(e, ExecutionError):
                 # No retry on fatal - e.g checkpoint exception

--- a/packages/aws-durable-execution-sdk-python/tests/e2e/custom_serdes_roundtrip_int_test.py
+++ b/packages/aws-durable-execution-sdk-python/tests/e2e/custom_serdes_roundtrip_int_test.py
@@ -1,0 +1,189 @@
+"""Integration tests for the first-run/replay result equality guarantee.
+
+With a non-identity custom ``SerDes`` (serialize/deserialize is not a round-trip
+identity), a step must return the *round-tripped* value on the first run so that
+it matches the value returned on replay, where the result is deserialized from
+the checkpoint. Returning the raw in-memory result on the first run would make
+the first-run and replay results diverge.
+
+The serdes used here strips a marker key on ``serialize`` and re-adds it on
+``deserialize`` so that ``deserialize(serialize(x)) != x``. That makes the bug
+observable end-to-end through a full ``durable_execution`` invocation.
+"""
+
+import json
+from typing import Any
+from unittest.mock import Mock, patch
+
+from aws_durable_execution_sdk_python.config import StepConfig
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import (
+    InvocationStatus,
+    durable_execution,
+)
+from aws_durable_execution_sdk_python.lambda_service import (
+    CheckpointOutput,
+    CheckpointUpdatedExecutionState,
+    OperationAction,
+)
+from aws_durable_execution_sdk_python.serdes import SerDes, SerDesContext
+
+
+class MarkerSerDes(SerDes[Any]):
+    """Non-identity serdes: deserialize() re-adds a marker serialize() strips.
+
+    ``deserialize(serialize(value)) == {**value, "round_tripped": True}`` which
+    differs from ``value`` whenever ``value`` lacks the marker. This makes any
+    first-run vs replay divergence observable.
+    """
+
+    def serialize(self, value: Any, _: SerDesContext) -> str:
+        payload = {k: v for k, v in dict(value).items() if k != "round_tripped"}
+        return json.dumps(payload)
+
+    def deserialize(self, data: str, _: SerDesContext) -> dict[str, Any]:
+        parsed = json.loads(data)
+        return {**parsed, "round_tripped": True}
+
+
+def _create_lambda_context():
+    """Create a mock Lambda context."""
+    ctx = Mock()
+    ctx.aws_request_id = "test-request-id"
+    ctx.client_context = None
+    ctx.identity = None
+    ctx._epoch_deadline_time_in_ms = 0  # noqa: SLF001
+    ctx.invoked_function_arn = "test-arn"
+    ctx.tenant_id = None
+    return ctx
+
+
+def _create_initial_event(input_payload: str = "{}"):
+    """Create a fresh execution event (first invocation)."""
+    return {
+        "DurableExecutionArn": "arn:aws:lambda:us-east-1:123456789012:function:test-func:1/durable-execution/exec-001/inv-001",
+        "CheckpointToken": "test-token",
+        "InitialExecutionState": {
+            "Operations": [
+                {
+                    "Id": "execution-1",
+                    "Type": "EXECUTION",
+                    "Status": "STARTED",
+                    "ExecutionDetails": {"InputPayload": input_payload},
+                }
+            ],
+            "NextMarker": "",
+        },
+        "LocalRunner": True,
+    }
+
+
+def _create_replay_event(operations: list[dict], input_payload: str = "{}"):
+    """Create a replay event with pre-existing operations."""
+    base_ops = [
+        {
+            "Id": "execution-1",
+            "Type": "EXECUTION",
+            "Status": "STARTED",
+            "ExecutionDetails": {"InputPayload": input_payload},
+        }
+    ]
+    return {
+        "DurableExecutionArn": "arn:aws:lambda:us-east-1:123456789012:function:test-func:1/durable-execution/exec-001/inv-001",
+        "CheckpointToken": "test-token",
+        "InitialExecutionState": {
+            "Operations": base_ops + operations,
+            "NextMarker": "",
+        },
+        "LocalRunner": True,
+    }
+
+
+def _patched_client():
+    """Patch LambdaClient and record checkpoint batches."""
+    checkpoint_calls: list = []
+
+    def mock_checkpoint(
+        durable_execution_arn,
+        checkpoint_token,
+        updates,
+        client_token="token",  # noqa: S107
+    ):
+        checkpoint_calls.append(updates)
+        return CheckpointOutput(
+            checkpoint_token="new_token",  # noqa: S106
+            new_execution_state=CheckpointUpdatedExecutionState(),
+        )
+
+    return checkpoint_calls, mock_checkpoint
+
+
+def test_step_first_run_matches_replay_with_non_identity_serdes():
+    """First-run result equals replay result for a non-identity serdes."""
+
+    @durable_execution
+    def handler(event, context: DurableContext) -> dict[str, Any]:
+        return context.step(
+            lambda _: {"order_id": "ORD-123"},
+            name="process_order",
+            config=StepConfig(serdes=MarkerSerDes()),
+        )
+
+    # --- First invocation ---
+    checkpoint_calls, mock_checkpoint = _patched_client()
+    with patch(
+        "aws_durable_execution_sdk_python.execution.LambdaClient"
+    ) as mock_client_class:
+        mock_client = Mock()
+        mock_client_class.initialize_client.return_value = mock_client
+        mock_client.checkpoint = mock_checkpoint
+
+        first_result = handler(_create_initial_event(), _create_lambda_context())
+
+    assert first_result["Status"] == InvocationStatus.SUCCEEDED.value
+    first_data = json.loads(first_result["Result"])
+
+    # The step's SUCCEED payload is the *serialized* value (marker stripped).
+    all_operations = [op for batch in checkpoint_calls for op in batch]
+    step_succeed_ops = [
+        op
+        for op in all_operations
+        if op.action == OperationAction.SUCCEED and op.operation_id != "execution-1"
+    ]
+    assert len(step_succeed_ops) == 1
+    step_payload = step_succeed_ops[0].payload
+    assert json.loads(step_payload) == {"order_id": "ORD-123"}  # no marker
+
+    # --- Replay: rebuild the execution with the step already SUCCEEDED ---
+    from tests.test_helpers import operation_id_sequence
+
+    step_id = next(operation_id_sequence())
+
+    checkpoint_calls_replay, mock_checkpoint_replay = _patched_client()
+    with patch(
+        "aws_durable_execution_sdk_python.execution.LambdaClient"
+    ) as mock_client_class:
+        mock_client = Mock()
+        mock_client_class.initialize_client.return_value = mock_client
+        mock_client.checkpoint = mock_checkpoint_replay
+
+        replay_event = _create_replay_event(
+            [
+                {
+                    "Id": step_id,
+                    "Type": "STEP",
+                    "Status": "SUCCEEDED",
+                    "ParentId": "execution-1",
+                    "StepDetails": {"Result": step_payload},
+                }
+            ]
+        )
+        replay_result = handler(replay_event, _create_lambda_context())
+
+    assert replay_result["Status"] == InvocationStatus.SUCCEEDED.value
+    replay_data = json.loads(replay_result["Result"])
+
+    # The core invariant: first-run output equals replay output, and both carry
+    # the marker added by deserialize() (i.e. the round-tripped value, not raw).
+    assert first_data == replay_data
+    assert first_data == {"order_id": "ORD-123", "round_tripped": True}

--- a/packages/aws-durable-execution-sdk-python/tests/operation/step_test.py
+++ b/packages/aws-durable-execution-sdk-python/tests/operation/step_test.py
@@ -2,6 +2,7 @@
 
 import datetime
 import json
+from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
@@ -30,6 +31,7 @@ from aws_durable_execution_sdk_python.lambda_service import (
 from aws_durable_execution_sdk_python.logger import Logger
 from aws_durable_execution_sdk_python.operation.step import StepOperationExecutor
 from aws_durable_execution_sdk_python.retries import RetryDecision
+from aws_durable_execution_sdk_python.serdes import SerDes, SerDesContext
 from aws_durable_execution_sdk_python.state import CheckpointedResult, ExecutionState
 from tests.serdes_test import CustomDictSerDes
 
@@ -603,6 +605,126 @@ def test_step_handler_custom_serdes_already_succeeded():
     )
 
     assert result == {"key": "value", "number": 42, "list": [1, 2, 3]}
+
+
+def test_step_handler_first_run_returns_round_tripped_result():
+    """First-run result must match the replay (deserialized-from-checkpoint) result.
+
+    With a non-identity SerDes whose serialize/deserialize is not a round-trip
+    identity, returning the raw in-memory result on the first run diverges from
+    the value returned on replay. The first run must return the value obtained by
+    serializing then deserializing, so both runs agree.
+    """
+
+    class NonIdentitySerDes(SerDes[Any]):
+        """deserialize() adds a marker that serialize() never removes."""
+
+        def serialize(self, value: Any, _: SerDesContext) -> str:
+            payload = dict(value)
+            payload.pop("deserialized", None)
+            return json.dumps(payload)
+
+        def deserialize(self, data: str, _: SerDesContext) -> dict[str, Any]:
+            parsed = json.loads(data)
+            return {**parsed, "deserialized": True}
+
+    serdes = NonIdentitySerDes()
+    raw_result = {"key": "value"}
+
+    # --- First run ---
+    first_run_state = Mock(spec=ExecutionState)
+    first_run_state.get_checkpoint_result.return_value = (
+        CheckpointedResult.create_not_found()
+    )
+    first_run_state.durable_execution_arn = "test_arn"
+    mock_callable = Mock(return_value=raw_result)
+    first_run_state.wrap_user_function.return_value = mock_callable
+    mock_logger = Mock(spec=Logger)
+    mock_logger.with_log_info.return_value = mock_logger
+
+    config = StepConfig(
+        step_semantics=StepSemantics.AT_LEAST_ONCE_PER_RETRY, serdes=serdes
+    )
+    first_run_result = step_handler(
+        mock_callable,
+        first_run_state,
+        OperationIdentifier("step_rt", OperationSubType.STEP, None, "test_step"),
+        config,
+        mock_logger,
+    )
+
+    # Grab the payload that was actually checkpointed.
+    success_call = first_run_state.create_checkpoint.call_args_list[1]
+    checkpointed_payload = success_call[1]["operation_update"].payload
+
+    # --- Replay: checkpoint already SUCCEEDED with the serialized payload ---
+    replay_state = Mock(spec=ExecutionState)
+    replay_state.durable_execution_arn = "test_arn"
+    succeeded_op = Operation(
+        operation_id="step_rt",
+        operation_type=OperationType.STEP,
+        status=OperationStatus.SUCCEEDED,
+        step_details=StepDetails(result=checkpointed_payload),
+    )
+    replay_state.get_checkpoint_result.return_value = (
+        CheckpointedResult.create_from_operation(succeeded_op)
+    )
+    replay_result = step_handler(
+        Mock(return_value="should_not_call"),
+        replay_state,
+        OperationIdentifier("step_rt", OperationSubType.STEP, None, "test_step"),
+        config,
+        Mock(spec=Logger),
+    )
+
+    # First run must return the round-tripped value, which equals the replay value,
+    # and must NOT equal the raw in-memory result.
+    assert first_run_result == {"key": "value", "deserialized": True}
+    assert first_run_result == replay_result
+    assert first_run_result != raw_result
+
+
+def test_step_handler_first_run_none_payload_skips_deserialize():
+    """A None serialized payload is returned as-is without deserializing.
+
+    This mirrors the replay path, which returns None without calling deserialize
+    when the checkpointed result is None. A serdes whose serialize returns None
+    must therefore see its deserialize skipped on the first run too.
+    """
+
+    class NonePayloadSerDes(SerDes[Any]):
+        """serialize() yields None; deserialize() must never be called for None."""
+
+        def serialize(self, _value: Any, _ctx: SerDesContext) -> str:
+            return None  # type: ignore[return-value]
+
+        def deserialize(self, _data: str, _ctx: SerDesContext) -> Any:
+            msg = "deserialize should not be called for a None payload"
+            raise AssertionError(msg)
+
+    mock_state = Mock(spec=ExecutionState)
+    mock_state.get_checkpoint_result.return_value = (
+        CheckpointedResult.create_not_found()
+    )
+    mock_state.durable_execution_arn = "test_arn"
+    mock_callable = Mock(return_value={"key": "value"})
+    mock_state.wrap_user_function.return_value = mock_callable
+    mock_logger = Mock(spec=Logger)
+    mock_logger.with_log_info.return_value = mock_logger
+
+    config = StepConfig(
+        step_semantics=StepSemantics.AT_LEAST_ONCE_PER_RETRY,
+        serdes=NonePayloadSerDes(),
+    )
+    result = step_handler(
+        mock_callable,
+        mock_state,
+        OperationIdentifier("step_none", OperationSubType.STEP, None, "test_step"),
+        config,
+        mock_logger,
+    )
+
+    assert result is None
 
 
 # Tests for immediate response handling


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-durable-execution-sdk-python/issues/407

*Description of changes:*
A step serialized its result for the checkpoint but returned the raw in-memory value on the first run, while replay returned the value deserialized from the checkpoint. With a non-identity custom SerDes the first-run and replay results diverged, breaking the durability guarantee that a step yields the same value on every run.

Serialize then deserialize the result before returning it on the first run so the value matches what replay produces.

Added unit, integration, and example coverage for the first-run/replay equality with a non-identity SerDes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
