### PR TITLE
fix(otel): align dependencies with ADOT layer

### DIFF
--- a/.github/workflows/cloud-tests.yml
+++ b/.github/workflows/cloud-tests.yml
@@ -89,14 +89,38 @@ jobs:
         PYTHON_RUNTIME: python${{ matrix.python-version }}
         STACK_NAME: ${{ matrix.python-prefix }}-python-examples
         FUNCTION_NAME_PREFIX: ${{ matrix.python-prefix }}-
+        GH_TOKEN: ${{ github.token }}
       run: |
         echo "Building SAM application"
         sam build --template-file packages/aws-durable-execution-sdk-python-examples/template.generated.json
+
+        ADOT_LAYER_ARN=$(
+          gh api repos/aws-observability/aws-otel-python-instrumentation/releases/latest \
+            --jq .body |
+            awk -F '|' -v region="$AWS_REGION" '
+              $2 ~ "^[[:space:]]*" region "[[:space:]]*$" {
+                gsub(/^[[:space:]]+|[[:space:]]+$/, "", $3)
+                print $3
+                exit
+              }
+            '
+        )
+        if [ -z "$ADOT_LAYER_ARN" ]; then
+          echo "Could not resolve the latest ADOT Python layer for $AWS_REGION"
+          exit 1
+        fi
+        aws lambda get-layer-version-by-arn \
+          --arn "$ADOT_LAYER_ARN" \
+          --region "$AWS_REGION" \
+          --query LayerVersionArn \
+          --output text > /dev/null
+        echo "Using ADOT Python layer $ADOT_LAYER_ARN"
 
         PARAMETER_OVERRIDES=(
           PythonRuntime="$PYTHON_RUNTIME"
           FunctionNamePrefix="$FUNCTION_NAME_PREFIX"
           LambdaExecutionRoleArn="$LAMBDA_EXECUTION_ROLE_ARN"
+          AdotLayerArn="$ADOT_LAYER_ARN"
         )
         if [ -n "$LAMBDA_ENDPOINT_OVERRIDE" ]; then
           PARAMETER_OVERRIDES+=(LambdaEndpoint="$LAMBDA_ENDPOINT_OVERRIDE")

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,6 +96,18 @@ hatch build
 hatch run examples:build
 hatch run examples:generate-sam-template
 sam build --template-file packages/aws-durable-execution-sdk-python-examples/template.generated.json
+AWS_REGION=us-west-2
+ADOT_LAYER_ARN=$(
+  gh api repos/aws-observability/aws-otel-python-instrumentation/releases/latest \
+    --jq .body |
+    awk -F '|' -v region="$AWS_REGION" '
+      $2 ~ "^[[:space:]]*" region "[[:space:]]*$" {
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", $3)
+        print $3
+        exit
+      }
+    '
+)
 sam deploy \
   --template-file .aws-sam/build/template.yaml \
   --stack-name python-examples-dev \
@@ -105,7 +117,8 @@ sam deploy \
     PythonRuntime=python3.13 \
     FunctionNamePrefix=PythonDev- \
     LambdaEndpoint=https://lambda.us-west-2.amazonaws.com \
-    LambdaExecutionRoleArn=arn:aws:iam::123456789012:role/example-lambda-role
+    LambdaExecutionRoleArn=arn:aws:iam::123456789012:role/example-lambda-role \
+    AdotLayerArn="$ADOT_LAYER_ARN"
 ```
 
 After the stack is deployed, use [SAM remote execution commands](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-cli-command-reference-sam-remote-execution.html) to invoke examples, inspect durable executions, stop executions that go wrong, and manage reusable test events. Pass the generated CloudFormation logical ID from `template.generated.json`; for example, `hello_world.handler` is generated as `HelloWorld`.
@@ -379,6 +392,18 @@ hatch run examples:generate-sam-template
 
 # Build and deploy the full stack with SAM
 sam build --template-file packages/aws-durable-execution-sdk-python-examples/template.generated.json
+AWS_REGION=us-west-2
+ADOT_LAYER_ARN=$(
+  gh api repos/aws-observability/aws-otel-python-instrumentation/releases/latest \
+    --jq .body |
+    awk -F '|' -v region="$AWS_REGION" '
+      $2 ~ "^[[:space:]]*" region "[[:space:]]*$" {
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", $3)
+        print $3
+        exit
+      }
+    '
+)
 sam deploy \
   --template-file .aws-sam/build/template.yaml \
   --stack-name python-examples-dev \
@@ -388,7 +413,8 @@ sam deploy \
     PythonRuntime=python3.13 \
     FunctionNamePrefix=PythonDev- \
     LambdaEndpoint=https://lambda.us-west-2.amazonaws.com \
-    LambdaExecutionRoleArn=arn:aws:iam::123456789012:role/example-lambda-role
+    LambdaExecutionRoleArn=arn:aws:iam::123456789012:role/example-lambda-role \
+    AdotLayerArn="$ADOT_LAYER_ARN"
 
 # Invoke deployed examples, inspect executions, and manage saved test events
 # with SAM remote commands

--- a/packages/aws-durable-execution-sdk-python-examples/examples-catalog.json
+++ b/packages/aws-durable-execution-sdk-python-examples/examples-catalog.json
@@ -677,7 +677,9 @@
       },
       "tracing": "Active",
       "layers": [
-        "arn:aws:lambda:us-west-2:615299751070:layer:AWSOpenTelemetryDistroPython:32"
+        {
+          "Ref": "AdotLayerArn"
+        }
       ],
       "environment": {
         "AWS_LAMBDA_EXEC_WRAPPER": "/opt/otel-instrument"
@@ -699,7 +701,9 @@
       },
       "tracing": "Active",
       "layers": [
-        "arn:aws:lambda:us-west-2:615299751070:layer:AWSOpenTelemetryDistroPython:32"
+        {
+          "Ref": "AdotLayerArn"
+        }
       ],
       "environment": {
         "AWS_LAMBDA_EXEC_WRAPPER": "/opt/otel-instrument",

--- a/packages/aws-durable-execution-sdk-python-examples/scripts/generate_sam_template.py
+++ b/packages/aws-durable-execution-sdk-python-examples/scripts/generate_sam_template.py
@@ -63,6 +63,10 @@ def build_template(examples: list[dict[str, Any]]) -> dict[str, Any]:
                 "Type": "String",
                 "Description": "ARN of an existing IAM role for all example Lambda functions.",
             },
+            "AdotLayerArn": {
+                "Type": "String",
+                "Description": "ARN of the ADOT Python Lambda layer.",
+            },
         },
         "Resources": {},
     }

--- a/packages/aws-durable-execution-sdk-python-examples/test/README.md
+++ b/packages/aws-durable-execution-sdk-python-examples/test/README.md
@@ -34,6 +34,18 @@ Tests run against actual AWS Lambda functions using `DurableFunctionCloudTestRun
 hatch run examples:build
 hatch run examples:generate-sam-template
 sam build --template-file packages/aws-durable-execution-sdk-python-examples/template.generated.json
+AWS_REGION=us-west-2
+ADOT_LAYER_ARN=$(
+  gh api repos/aws-observability/aws-otel-python-instrumentation/releases/latest \
+    --jq .body |
+    awk -F '|' -v region="$AWS_REGION" '
+      $2 ~ "^[[:space:]]*" region "[[:space:]]*$" {
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", $3)
+        print $3
+        exit
+      }
+    '
+)
 sam deploy \
   --template-file .aws-sam/build/template.yaml \
   --stack-name python-examples-test \
@@ -43,7 +55,8 @@ sam deploy \
     PythonRuntime=python3.13 \
     FunctionNamePrefix=PythonTest- \
     LambdaEndpoint=https://lambda.us-west-2.amazonaws.com \
-    LambdaExecutionRoleArn=arn:aws:iam::123456789012:role/example-lambda-role
+    LambdaExecutionRoleArn=arn:aws:iam::123456789012:role/example-lambda-role \
+    AdotLayerArn="$ADOT_LAYER_ARN"
 
 # Optional: invoke a deployed example directly with SAM remote execution.
 # The logical ID comes from template.generated.json; hello_world.handler maps to HelloWorld.

--- a/packages/aws-durable-execution-sdk-python-examples/test/test_log_group_deployment.py
+++ b/packages/aws-durable-execution-sdk-python-examples/test/test_log_group_deployment.py
@@ -73,6 +73,26 @@ def test_build_template_preserves_existing_logging_config():
     }
 
 
+def test_build_template_references_adot_layer_parameter():
+    template = generate_sam_template.build_template(
+        [
+            {
+                "handler": "execution_with_otel.handler",
+                "description": "OTel example",
+                "layers": [{"Ref": "AdotLayerArn"}],
+            }
+        ]
+    )
+
+    assert template["Parameters"]["AdotLayerArn"] == {
+        "Type": "String",
+        "Description": "ARN of the ADOT Python Lambda layer.",
+    }
+    assert template["Resources"]["ExecutionWithOtel"]["Properties"]["Layers"] == [
+        {"Ref": "AdotLayerArn"}
+    ]
+
+
 def test_log_group_resources_match_generated_template_names(monkeypatch):
     monkeypatch.setattr(
         cleanup_unmanaged_log_groups,

--- a/packages/aws-durable-execution-sdk-python-otel/README.md
+++ b/packages/aws-durable-execution-sdk-python-otel/README.md
@@ -284,8 +284,9 @@ setups.
 
 - Python >= 3.11
 - `aws-durable-execution-sdk-python` >= 1.5.0
-- `opentelemetry-api` >= 1.20.0
-- `opentelemetry-sdk` >= 1.20.0
+- `opentelemetry-api` >= 1.20.0, <= 1.42.1
+- `opentelemetry-sdk` >= 1.20.0, <= 1.42.1
+- `opentelemetry-exporter-otlp` <= 1.42.1
 
 ## License
 

--- a/packages/aws-durable-execution-sdk-python-otel/pyproject.toml
+++ b/packages/aws-durable-execution-sdk-python-otel/pyproject.toml
@@ -23,9 +23,9 @@ classifiers = [
 ]
 dependencies = [
   "aws-durable-execution-sdk-python>=1.5.0",
-  "opentelemetry-api>=1.20.0",
-  "opentelemetry-sdk>=1.20.0",
-  "opentelemetry-exporter-otlp",
+  "opentelemetry-api>=1.20.0,<=1.42.1",
+  "opentelemetry-sdk>=1.20.0,<=1.42.1",
+  "opentelemetry-exporter-otlp<=1.42.1",
   "opentelemetry-propagator-aws-xray",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
   "pytest",
   "pytest-cov",
   "pytest-xdist",
-  "opentelemetry-sdk>=1.20.0",
+  "opentelemetry-sdk>=1.20.0,<=1.42.1",
   "aws-durable-execution-sdk-python-testing",
 ]
 
@@ -46,7 +46,7 @@ extra-dependencies = [
   "mypy>=1.0.0",
   "pytest",
   "boto3-stubs[lambda]",
-  "opentelemetry-sdk>=1.20.0",
+  "opentelemetry-sdk>=1.20.0,<=1.42.1",
 ]
 
 [tool.hatch.envs.types.scripts]
@@ -77,7 +77,7 @@ dependencies = [
   "pytest",
   "pytest-cov",
   "coverage[toml]",
-  "opentelemetry-sdk>=1.20.0",
+  "opentelemetry-sdk>=1.20.0,<=1.42.1",
   "mypy>=1.0.0",
 ]
 
@@ -121,7 +121,7 @@ test = "pytest packages/aws-durable-execution-sdk-python-examples/test {args}"
 [tool.hatch.envs.test-pypi-otel]
 dependencies = [
   "aws-durable-execution-sdk-python",
-  "opentelemetry-sdk>=1.20.0",
+  "opentelemetry-sdk>=1.20.0,<=1.42.1",
   "pytest",
   "pytest-cov",
   "coverage[toml]",


### PR DESCRIPTION
**Summary**
- Resolve and validate the latest regional ADOT Python Lambda layer before cloud deployment.
- Pass the layer ARN into the generated SAM template instead of pinning a regional layer version in the examples catalog.
- Cap `opentelemetry-api`, `opentelemetry-sdk`, and `opentelemetry-exporter-otlp` at `1.42.1`, matching the stable OTel family bundled by ADOT `0.18.0` / layer `:33`.
- Document the temporary compatibility ceiling.

**Root cause**
OpenTelemetry `1.44.0` removed the deprecated Events API. ADOT still imports `opentelemetry._events`; when the function bundle supplies OTel `1.44.0` ahead of the Lambda layer on `sys.path`, ADOT initialization fails while importing `_OTEL_PYTHON_EVENT_LOGGER_PROVIDER`. Lambda continues with a proxy tracer provider, so spans are non-recording and never reach X-Ray.

Updating only the layer to `:33` still reproduced both X-Ray failures because that ADOT release predates OTel `1.44.0`. The dependency ceiling keeps the application and layer on the compatible `1.42.1` / `0.63b1` family.

**Testing**
- `hatch run dev-otel:test` (`53 passed`)
- `hatch run dev-examples:test` (`79 passed`, `2 skipped` cloud-only X-Ray tests)
- `hatch run examples:build` resolves OTel API, SDK, exporters, and proto to `1.42.1`, with semantic conventions `0.63b1`
- `hatch fmt --check`
- Cloud example-test matrix passes on Python 3.11, 3.12, 3.13, and 3.14, including both X-Ray span assertions