### PR TITLE
ci: pin GitHub Actions to commits

### DIFF
--- a/.github/workflows/cloud-tests.yml
+++ b/.github/workflows/cloud-tests.yml
@@ -42,16 +42,16 @@ jobs:
           - python-version: "3.14"
             python-prefix: Py314
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Setup Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Configure AWS credentials
       if: github.event_name != 'workflow_dispatch' || github.actor != 'nektos/act'
-      uses: aws-actions/configure-aws-credentials@v6
+      uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
       with:
         role-to-assume: "${{ secrets.TEST_ROLE_ARN }}"
         role-session-name: pythonTestingLibraryGitHubIntegrationTest
@@ -73,7 +73,7 @@ jobs:
       run: pip install hatch
 
     - name: Setup SAM CLI
-      uses: aws-actions/setup-sam@v3
+      uses: aws-actions/setup-sam@89ddb14d60e682855e3fea4be85b3c56485de310 # v3
 
     - name: Build examples
       run: |

--- a/.github/workflows/ecr-release.yml
+++ b/.github/workflows/ecr-release.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Set up QEMU for multi-platform builds
         if: matrix.arch == 'arm64'
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
         with:
           platforms: arm64
 
@@ -60,14 +60,14 @@ jobs:
           echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
         with:
           role-to-assume: ${{ secrets.ECR_UPLOAD_IAM_ROLE_ARN }}
           aws-region: ${{ env.aws_region }}
 
       - name: Login to Amazon ECR
         id: login-ecr-public
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6
         with:
           registry-type: public
 
@@ -89,13 +89,13 @@ jobs:
     needs: [build-and-upload-image-to-ecr]
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
         with:
           role-to-assume: ${{ secrets.ECR_UPLOAD_IAM_ROLE_ARN }}
           aws-region: ${{ env.aws_region }}
 
       - name: Login to Amazon ECR
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6
         with:
           registry-type: public
 


### PR DESCRIPTION
## Summary

- pin all nine remaining mutable GitHub Action tags to full commit SHAs
- retain version comments for Dependabot updates and reviewer context
- cover the cloud test and testing SDK image release workflows

## Validation

- parsed every workflow YAML file
- verified every external action reference uses a full 40-character commit SHA
- ran `git diff --check`
- ran `hatch run python .github/scripts/lintcommit.py`

Closes #445