### PR TITLE
test: retry incomplete X-Ray traces

### DIFF
--- a/packages/aws-durable-execution-sdk-python-examples/test/conftest.py
+++ b/packages/aws-durable-execution-sdk-python-examples/test/conftest.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import sys
+import time
 from datetime import datetime
 from enum import StrEnum
 from pathlib import Path
@@ -305,28 +306,14 @@ class XRaySpanFetcher:
     def _query_trace_summaries(
         self, start_time: datetime, end_time: datetime
     ) -> list[dict]:
-        """Query trace summaries in a window, retrying for consistency."""
-        import time
-
-        for attempt in range(_XRAY_QUERY_RETRIES):
-            response = self._client.get_trace_summaries(
-                StartTime=start_time,
-                EndTime=end_time,
-                TimeRangeType="Event",
-                Sampling=False,
-            )
-            summaries = response.get("TraceSummaries", [])
-            if summaries:
-                return summaries
-
-            logger.info(
-                "X-Ray query returned 0 traces, retrying in %ss (attempt %d/%d)",
-                _XRAY_RETRY_DELAY_SECONDS,
-                attempt + 1,
-                _XRAY_QUERY_RETRIES,
-            )
-            time.sleep(_XRAY_RETRY_DELAY_SECONDS)
-        return []
+        """Query trace summaries in a window."""
+        response = self._client.get_trace_summaries(
+            StartTime=start_time,
+            EndTime=end_time,
+            TimeRangeType="Event",
+            Sampling=False,
+        )
+        return response.get("TraceSummaries", [])
 
     def fetch_trace_with_span(
         self,
@@ -348,25 +335,40 @@ class XRaySpanFetcher:
         Returns:
             A tuple of (trace_id, concatenated segment-document JSON text).
         """
-        summaries = self._query_trace_summaries(start_time, end_time)
-        assert summaries, "Expected at least one trace in X-Ray after execution"
+        seen_trace_ids: set[str] = set()
+        for attempt in range(_XRAY_QUERY_RETRIES):
+            summaries = self._query_trace_summaries(start_time, end_time)
+            trace_ids = [summary["Id"] for summary in summaries]
+            seen_trace_ids.update(trace_ids)
 
-        trace_ids = [s["Id"] for s in summaries]
+            for i in range(0, len(trace_ids), 5):
+                batch = trace_ids[i : i + 5]
+                result = self._client.batch_get_traces(TraceIds=batch)
+                for trace in result.get("Traces", []):
+                    documents = [
+                        segment.get("Document", "")
+                        for segment in trace.get("Segments", [])
+                    ]
+                    segment_text = "\n".join(documents)
+                    if marker_span in segment_text:
+                        return trace["Id"], segment_text
 
-        for i in range(0, len(trace_ids), 5):
-            batch = trace_ids[i : i + 5]
-            result = self._client.batch_get_traces(TraceIds=batch)
-            for trace in result.get("Traces", []):
-                documents = [
-                    seg.get("Document", "") for seg in trace.get("Segments", [])
-                ]
-                segment_text = "\n".join(documents)
-                if marker_span in segment_text:
-                    return trace["Id"], segment_text
+            if attempt < _XRAY_QUERY_RETRIES - 1:
+                logger.info(
+                    "X-Ray traces do not yet contain span '%s', retrying in %ss "
+                    "(attempt %d/%d)",
+                    marker_span,
+                    _XRAY_RETRY_DELAY_SECONDS,
+                    attempt + 1,
+                    _XRAY_QUERY_RETRIES,
+                )
+                time.sleep(_XRAY_RETRY_DELAY_SECONDS)
+
+        assert seen_trace_ids, "Expected at least one trace in X-Ray after execution"
 
         pytest.fail(
             f"Did not find a trace containing span '{marker_span}' in the time "
-            f"window across {len(trace_ids)} trace(s)"
+            f"window across {len(seen_trace_ids)} trace(s)"
         )
 
 

--- a/packages/aws-durable-execution-sdk-python-examples/test/test_xray_span_fetcher.py
+++ b/packages/aws-durable-execution-sdk-python-examples/test/test_xray_span_fetcher.py
@@ -1,0 +1,71 @@
+"""Tests for X-Ray span retrieval."""
+
+from datetime import UTC, datetime
+from unittest.mock import Mock, patch
+
+from test.conftest import XRaySpanFetcher
+
+
+START_TIME = datetime(2026, 7, 17, 20, 0, tzinfo=UTC)
+END_TIME = datetime(2026, 7, 17, 20, 1, tzinfo=UTC)
+TRACE_ID = "1-test"
+TRACE_SUMMARIES = {"TraceSummaries": [{"Id": TRACE_ID}]}
+INCOMPLETE_TRACE = {
+    "Traces": [
+        {
+            "Id": TRACE_ID,
+            "Segments": [{"Document": '{"name":"invocation"}'}],
+        }
+    ]
+}
+COMPLETE_TRACE = {
+    "Traces": [
+        {
+            "Id": TRACE_ID,
+            "Segments": [{"Document": '{"name":"top-greet"}'}],
+        }
+    ]
+}
+
+
+def test_fetch_trace_with_span_retries_incomplete_trace():
+    client = Mock()
+    client.get_trace_summaries.return_value = TRACE_SUMMARIES
+    client.batch_get_traces.side_effect = [INCOMPLETE_TRACE, COMPLETE_TRACE]
+    fetcher = XRaySpanFetcher(client)
+
+    with patch("test.conftest.time.sleep") as sleep:
+        trace_id, segment_text = fetcher.fetch_trace_with_span(
+            START_TIME,
+            END_TIME,
+            marker_span="top-greet",
+        )
+
+    assert trace_id == TRACE_ID
+    assert "top-greet" in segment_text
+    assert client.get_trace_summaries.call_count == 2
+    assert client.batch_get_traces.call_count == 2
+    sleep.assert_called_once_with(10)
+
+
+def test_fetch_trace_with_span_retries_missing_summary():
+    client = Mock()
+    client.get_trace_summaries.side_effect = [
+        {"TraceSummaries": []},
+        TRACE_SUMMARIES,
+    ]
+    client.batch_get_traces.return_value = COMPLETE_TRACE
+    fetcher = XRaySpanFetcher(client)
+
+    with patch("test.conftest.time.sleep") as sleep:
+        trace_id, segment_text = fetcher.fetch_trace_with_span(
+            START_TIME,
+            END_TIME,
+            marker_span="top-greet",
+        )
+
+    assert trace_id == TRACE_ID
+    assert "top-greet" in segment_text
+    assert client.get_trace_summaries.call_count == 2
+    assert client.batch_get_traces.call_count == 1
+    sleep.assert_called_once_with(10)


### PR DESCRIPTION
## Summary

- retry the complete X-Ray summary and trace lookup while the marker span is still being indexed
- preserve bounded retries when no trace summary is available yet
- add regression tests for delayed summaries and delayed trace segments

## Context

Follow-up to the Python 3.14 cloud test failure observed in #547: https://github.com/aws/aws-durable-execution-sdk-python/actions/runs/29609352593/job/87980091433?pr=547

## Validation

- `hatch run dev-examples:test` (81 passed, 2 cloud-only tests skipped)
- `hatch fmt --check` in the examples package
- `git diff --check`