### PR TITLE
feat: expose operation attempt in contexts

### DIFF
--- a/packages/aws-durable-execution-sdk-python-examples/src/step/step_with_retry.py
+++ b/packages/aws-durable-execution-sdk-python-examples/src/step/step_with_retry.py
@@ -1,4 +1,3 @@
-from itertools import count
 from typing import Any
 
 from aws_durable_execution_sdk_python.config import StepConfig
@@ -14,19 +13,13 @@ from aws_durable_execution_sdk_python.retries import (
 )
 
 
-# Counter for deterministic behavior across retries
-_attempts = count(1)  # starts from 1
-
-
 @durable_step
 def unreliable_operation(
-    _step_context: StepContext,
+    step_context: StepContext,
 ) -> str:
-    # Use counter for deterministic behavior
-    # Will fail on first attempt, succeed on second
-    attempt = next(_attempts)
-    if attempt < 2:
-        msg = f"Attempt {attempt} failed"
+    # Fail on the first durable attempt and succeed on the retry.
+    if step_context.attempt == 1:
+        msg = f"Attempt {step_context.attempt} failed"
         raise RuntimeError(msg)
     return "Operation succeeded"
 

--- a/packages/aws-durable-execution-sdk-python-examples/src/step/steps_with_retry.py
+++ b/packages/aws-durable-execution-sdk-python-examples/src/step/steps_with_retry.py
@@ -1,6 +1,5 @@
 """Example demonstrating multiple steps with retry logic."""
 
-from itertools import count
 from typing import Any
 
 from aws_durable_execution_sdk_python.config import Duration, StepConfig
@@ -12,25 +11,19 @@ from aws_durable_execution_sdk_python.retries import (
 )
 
 
-# Counter for deterministic behavior across retries
-_attempts = count(1)  # starts from 1
-
-
-def simulated_get_item(_step_context: StepContext, name: str) -> dict[str, Any] | None:
-    """Simulate getting an item with deterministic counter-based behavior."""
-    # Use counter for deterministic behavior
-    attempt = next(_attempts)
-
-    # Fail on first attempt
-    if attempt == 1:
+def simulated_get_item(
+    step_context: StepContext, name: str, poll_count: int
+) -> dict[str, Any] | None:
+    """Simulate getting an item with deterministic attempt-based behavior."""
+    # Poll 1 fails once, then returns no item on its retry.
+    if poll_count == 1 and step_context.attempt == 1:
         msg = "Random failure"
         raise RuntimeError(msg)
 
-    # Return None on second attempt (poll 1)
-    if attempt == 2:
+    if poll_count == 1:
         return None
 
-    # Return item on third attempt (poll 2, after retry)
+    # Poll 2 returns the item on its first attempt.
     return {"id": name, "data": "item data"}
 
 
@@ -57,7 +50,9 @@ def handler(event: Any, context: DurableContext) -> dict[str, Any]:
 
             # Try to get the item with retry
             get_response = context.step(
-                lambda _, n=name: simulated_get_item(_, n),
+                lambda step_context, n=name, p=poll_count: simulated_get_item(
+                    step_context, n, p
+                ),
                 name=f"get_item_poll_{poll_count}",
                 config=step_config,
             )

--- a/packages/aws-durable-execution-sdk-python-examples/src/step/steps_with_retry.py
+++ b/packages/aws-durable-execution-sdk-python-examples/src/step/steps_with_retry.py
@@ -12,18 +12,16 @@ from aws_durable_execution_sdk_python.retries import (
 
 
 def simulated_get_item(
-    step_context: StepContext, name: str, poll_count: int
+    step_context: StepContext, name: str, item_available: bool
 ) -> dict[str, Any] | None:
     """Simulate getting an item with deterministic attempt-based behavior."""
-    # Poll 1 fails once, then returns no item on its retry.
-    if poll_count == 1 and step_context.attempt == 1:
+    if not item_available and step_context.attempt == 1:
         msg = "Random failure"
         raise RuntimeError(msg)
 
-    if poll_count == 1:
+    if not item_available:
         return None
 
-    # Poll 2 returns the item on its first attempt.
     return {"id": name, "data": "item data"}
 
 
@@ -48,10 +46,16 @@ def handler(event: Any, context: DurableContext) -> dict[str, Any]:
         while poll_count < max_polls:
             poll_count += 1
 
+            # Each poll is a new step whose attempt starts at 1. Availability
+            # models the external item state independently from retry attempts.
+            item_available: bool = poll_count > 1
+
             # Try to get the item with retry
             get_response = context.step(
-                lambda step_context, n=name, p=poll_count: simulated_get_item(
-                    step_context, n, p
+                lambda step_context,
+                n=name,
+                available=item_available: simulated_get_item(
+                    step_context, n, available
                 ),
                 name=f"get_item_poll_{poll_count}",
                 config=step_config,

--- a/packages/aws-durable-execution-sdk-python-examples/test/step/test_step_with_retry.py
+++ b/packages/aws-durable-execution-sdk-python-examples/test/step/test_step_with_retry.py
@@ -1,10 +1,28 @@
 """Tests for step_with_retry example."""
 
+from unittest.mock import Mock
+
 import pytest
+from aws_durable_execution_sdk_python.context import StepContext
 from aws_durable_execution_sdk_python.execution import InvocationStatus
 from aws_durable_execution_sdk_python.lambda_service import OperationType
 from src.step import step_with_retry
 from test.conftest import deserialize_operation_payload
+
+
+def test_unreliable_operation_uses_durable_attempt():
+    """Retry behavior is independent of process-level state."""
+    operation = step_with_retry.unreliable_operation()
+    first_attempt = StepContext(logger=Mock(), attempt=1)
+    second_attempt = StepContext(logger=Mock(), attempt=2)
+
+    with pytest.raises(RuntimeError, match="Attempt 1 failed"):
+        operation(first_attempt)
+
+    assert operation(second_attempt) == "Operation succeeded"
+
+    with pytest.raises(RuntimeError, match="Attempt 1 failed"):
+        operation(first_attempt)
 
 
 @pytest.mark.example
@@ -15,16 +33,16 @@ from test.conftest import deserialize_operation_payload
 def test_step_with_retry(durable_runner):
     """Test step with retry configuration.
 
-    With counter-based deterministic behavior:
-    - Attempt 1: counter = 1 < 2 → raises RuntimeError ❌
-    - Attempt 2: counter = 2 >= 2 → succeeds ✓
+    With durable-attempt-based deterministic behavior:
+    - Attempt 1: step context attempt = 1, so the operation raises RuntimeError.
+    - Attempt 2: step context attempt = 2, so the operation succeeds.
 
     The function deterministically fails once then succeeds on the second attempt.
     """
     with durable_runner:
         result = durable_runner.run(input="test", timeout=30)
 
-    # With counter-based deterministic behavior, succeeds on attempt 2
+    # With durable-attempt-based deterministic behavior, succeeds on attempt 2
     assert result.status is InvocationStatus.SUCCEEDED
     assert deserialize_operation_payload(result.result) == "Operation succeeded"
 

--- a/packages/aws-durable-execution-sdk-python-examples/test/step/test_steps_with_retry.py
+++ b/packages/aws-durable-execution-sdk-python-examples/test/step/test_steps_with_retry.py
@@ -1,10 +1,31 @@
 """Tests for steps_with_retry."""
 
+from unittest.mock import Mock
+
 import pytest
+from aws_durable_execution_sdk_python.context import StepContext
 from aws_durable_execution_sdk_python.execution import InvocationStatus
 from aws_durable_execution_sdk_python.lambda_service import OperationType
 from src.step import steps_with_retry
 from test.conftest import deserialize_operation_payload
+
+
+def test_simulated_get_item_uses_poll_and_durable_attempt():
+    """Polling behavior is independent of process-level state."""
+    first_attempt = StepContext(logger=Mock(), attempt=1)
+    second_attempt = StepContext(logger=Mock(), attempt=2)
+
+    with pytest.raises(RuntimeError, match="Random failure"):
+        steps_with_retry.simulated_get_item(first_attempt, "test-item", 1)
+
+    assert steps_with_retry.simulated_get_item(second_attempt, "test-item", 1) is None
+    assert steps_with_retry.simulated_get_item(first_attempt, "test-item", 2) == {
+        "id": "test-item",
+        "data": "item data",
+    }
+
+    with pytest.raises(RuntimeError, match="Random failure"):
+        steps_with_retry.simulated_get_item(first_attempt, "test-item", 1)
 
 
 @pytest.mark.example
@@ -15,10 +36,10 @@ from test.conftest import deserialize_operation_payload
 def test_steps_with_retry(durable_runner):
     """Test steps_with_retry pattern.
 
-    With counter-based deterministic behavior:
-    - Poll 1, Attempt 1: counter = 1 → raises RuntimeError ❌
-    - Poll 1, Attempt 2: counter = 2 → returns None
-    - Poll 2, Attempt 1: counter = 3 → returns item ✓
+    With poll- and durable-attempt-based deterministic behavior:
+    - Poll 1, Attempt 1: raises RuntimeError.
+    - Poll 1, Attempt 2: returns None.
+    - Poll 2, Attempt 1: returns the item.
 
     The function finds the item on poll 2 after 1 retry on poll 1.
     """
@@ -27,7 +48,7 @@ def test_steps_with_retry(durable_runner):
 
     assert result.status is InvocationStatus.SUCCEEDED
 
-    # With counter-based deterministic behavior, finds item on poll 2
+    # With poll- and durable-attempt-based deterministic behavior, finds item on poll 2
     result_data = deserialize_operation_payload(result.result)
     assert isinstance(result_data, dict)
     assert result_data.get("success") is True

--- a/packages/aws-durable-execution-sdk-python-examples/test/step/test_steps_with_retry.py
+++ b/packages/aws-durable-execution-sdk-python-examples/test/step/test_steps_with_retry.py
@@ -10,22 +10,24 @@ from src.step import steps_with_retry
 from test.conftest import deserialize_operation_payload
 
 
-def test_simulated_get_item_uses_poll_and_durable_attempt():
+def test_simulated_get_item_uses_availability_and_durable_attempt():
     """Polling behavior is independent of process-level state."""
     first_attempt = StepContext(logger=Mock(), attempt=1)
     second_attempt = StepContext(logger=Mock(), attempt=2)
 
     with pytest.raises(RuntimeError, match="Random failure"):
-        steps_with_retry.simulated_get_item(first_attempt, "test-item", 1)
+        steps_with_retry.simulated_get_item(first_attempt, "test-item", False)
 
-    assert steps_with_retry.simulated_get_item(second_attempt, "test-item", 1) is None
-    assert steps_with_retry.simulated_get_item(first_attempt, "test-item", 2) == {
+    assert (
+        steps_with_retry.simulated_get_item(second_attempt, "test-item", False) is None
+    )
+    assert steps_with_retry.simulated_get_item(first_attempt, "test-item", True) == {
         "id": "test-item",
         "data": "item data",
     }
 
     with pytest.raises(RuntimeError, match="Random failure"):
-        steps_with_retry.simulated_get_item(first_attempt, "test-item", 1)
+        steps_with_retry.simulated_get_item(first_attempt, "test-item", False)
 
 
 @pytest.mark.example

--- a/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/operation/step.py
+++ b/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/operation/step.py
@@ -214,7 +214,8 @@ class StepOperationExecutor(OperationExecutor[T]):
                     op_id=self.operation_identifier,
                     attempt=attempt,
                 )
-            )
+            ),
+            attempt=attempt,
         )
 
         try:

--- a/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/operation/wait_for_condition.py
+++ b/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/operation/wait_for_condition.py
@@ -185,7 +185,8 @@ class WaitForConditionOperationExecutor(OperationExecutor[T]):
                         op_id=self.operation_identifier,
                         attempt=attempt,
                     )
-                )
+                ),
+                attempt=attempt,
             )
 
             wrapped_user_func = self.state.wrap_user_function(

--- a/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/types.py
+++ b/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/types.py
@@ -57,7 +57,13 @@ class OperationContext:
 
 @dataclass(frozen=True)
 class StepContext(OperationContext):
-    pass
+    """Context provided to step functions.
+
+    Attributes:
+        attempt: Current attempt number, starting at 1 for the first execution.
+    """
+
+    attempt: int
 
 
 @dataclass(frozen=True)
@@ -67,7 +73,13 @@ class WaitForCallbackContext(OperationContext):
 
 @dataclass(frozen=True)
 class WaitForConditionCheckContext(OperationContext):
-    pass
+    """Context provided to wait_for_condition check functions.
+
+    Attributes:
+        attempt: Current attempt number, starting at 1 for the first check.
+    """
+
+    attempt: int
 
 
 class Callback(Protocol, Generic[C_co]):

--- a/packages/aws-durable-execution-sdk-python/tests/operation/step_test.py
+++ b/packages/aws-durable-execution-sdk-python/tests/operation/step_test.py
@@ -31,6 +31,7 @@ from aws_durable_execution_sdk_python.logger import Logger
 from aws_durable_execution_sdk_python.operation.step import StepOperationExecutor
 from aws_durable_execution_sdk_python.retries import RetryDecision
 from aws_durable_execution_sdk_python.state import CheckpointedResult, ExecutionState
+from aws_durable_execution_sdk_python.types import StepContext
 from tests.serdes_test import CustomDictSerDes
 
 
@@ -235,6 +236,52 @@ def test_step_handler_success_at_least_once():
     assert success_operation.operation_type is OperationType.STEP
     assert success_operation.sub_type is OperationSubType.STEP
     assert success_operation.action is OperationAction.SUCCEED
+
+
+@pytest.mark.parametrize(
+    ("checkpointed_attempts", "expected_attempt"),
+    [(None, 1), (2, 3)],
+)
+def test_step_context_exposes_current_attempt(
+    checkpointed_attempts: int | None, expected_attempt: int
+) -> None:
+    """Step context exposes the 1-based current attempt."""
+    mock_state = Mock(spec=ExecutionState)
+    mock_state.durable_execution_arn = "test_arn"
+    if checkpointed_attempts is None:
+        checkpointed_result: CheckpointedResult = CheckpointedResult.create_not_found()
+    else:
+        operation: Operation = Operation(
+            operation_id="step-attempt",
+            operation_type=OperationType.STEP,
+            status=OperationStatus.STARTED,
+            step_details=StepDetails(attempt=checkpointed_attempts),
+        )
+        checkpointed_result = CheckpointedResult.create_from_operation(operation)
+    mock_state.get_checkpoint_result.return_value = checkpointed_result
+
+    captured_context: StepContext | None = None
+
+    def step_func(context: StepContext) -> str:
+        nonlocal captured_context
+        captured_context = context
+        return "success_result"
+
+    mock_state.wrap_user_function.return_value = step_func
+    mock_logger = Mock(spec=Logger)
+    mock_logger.with_log_info.return_value = mock_logger
+
+    result: str = step_handler(
+        step_func,
+        mock_state,
+        OperationIdentifier("step-attempt", OperationSubType.STEP, None, "test_step"),
+        StepConfig(step_semantics=StepSemantics.AT_LEAST_ONCE_PER_RETRY),
+        mock_logger,
+    )
+
+    assert result == "success_result"
+    assert isinstance(captured_context, StepContext)
+    assert captured_context.attempt == expected_attempt
 
 
 def test_step_handler_success_at_most_once():

--- a/packages/aws-durable-execution-sdk-python/tests/operation/wait_for_condition_test.py
+++ b/packages/aws-durable-execution-sdk-python/tests/operation/wait_for_condition_test.py
@@ -443,6 +443,7 @@ def test_wait_for_condition_check_context():
 
     assert isinstance(captured_context, WaitForConditionCheckContext)
     assert captured_context.logger is mock_logger
+    assert captured_context.attempt == 1
 
 
 def test_wait_for_condition_delay_seconds_none():
@@ -619,7 +620,7 @@ def test_wait_for_condition_attempt_number_passed_to_strategy():
     """Test that attempt number is correctly passed to wait strategy."""
     mock_state = Mock(spec=ExecutionState)
     mock_state.durable_execution_arn = "arn:aws:test"
-    operation = Operation(
+    operation: Operation = Operation(
         operation_id="op1",
         operation_type=OperationType.STEP,
         status=OperationStatus.STARTED,
@@ -658,6 +659,49 @@ def test_wait_for_condition_attempt_number_passed_to_strategy():
     )
 
     assert captured_attempt == 4
+
+
+def test_wait_for_condition_context_exposes_current_attempt():
+    """Check context exposes the 1-based current attempt."""
+    mock_state = Mock(spec=ExecutionState)
+    mock_state.durable_execution_arn = "arn:aws:test"
+    operation = Operation(
+        operation_id="op1",
+        operation_type=OperationType.STEP,
+        status=OperationStatus.STARTED,
+        step_details=StepDetails(result=json.dumps(10), attempt=3),
+    )
+    mock_state.get_checkpoint_result.return_value = (
+        CheckpointedResult.create_from_operation(operation)
+    )
+
+    mock_logger = Mock(spec=Logger)
+    mock_logger.with_log_info.return_value = mock_logger
+    captured_context: WaitForConditionCheckContext | None = None
+
+    def check_func(state: int, context: WaitForConditionCheckContext) -> int:
+        nonlocal captured_context
+        captured_context = context
+        return state + 1
+
+    mock_state.wrap_user_function.return_value = check_func
+    config = WaitForConditionConfig(
+        initial_state=5,
+        wait_strategy=lambda s, a: WaitForConditionDecision.stop_polling(),
+    )
+
+    wait_for_condition_handler(
+        state=mock_state,
+        operation_identifier=OperationIdentifier(
+            "op1", OperationSubType.WAIT_FOR_CONDITION, None, "test_wait"
+        ),
+        check=check_func,
+        config=config,
+        context_logger=mock_logger,
+    )
+
+    assert isinstance(captured_context, WaitForConditionCheckContext)
+    assert captured_context.attempt == 4
 
 
 def test_wait_for_condition_attempt_sequence_is_monotonic():


### PR DESCRIPTION
## Summary

- expose the 1-based current attempt on `StepContext`
- expose the same attempt on `WaitForConditionCheckContext`
- replace process-global retry counters in the step retry examples with durable attempt-based behavior
- add regression coverage proving retry behavior is independent of warm Lambda process state

## Testing

- `hatch run test:all` (`2887 passed, 2 skipped`)
- `hatch run dev-examples:test` (`81 passed, 2 skipped`)
- affected retry example tests on the final rebased branch (`4 passed`)
- `hatch run types:check`
- `hatch fmt --check` (core and examples packages)

Closes #526
Closes #520