### PR TITLE
ci: scope OIDC permissions to jobs

### DIFF
--- a/.github/workflows/cloud-tests.yml
+++ b/.github/workflows/cloud-tests.yml
@@ -19,13 +19,15 @@ env:
   AWS_REGION: ${{ github.event.inputs.region || 'us-west-2' }}
 
 permissions:
-  id-token: write
   contents: read
 
 jobs:
   example-tests:
     name: example-tests (${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     concurrency:
       group: cloud-tests-${{ matrix.python-prefix }}
       cancel-in-progress: false

--- a/.github/workflows/ecr-release.yml
+++ b/.github/workflows/ecr-release.yml
@@ -6,7 +6,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 env:
   package_path: packages/aws-durable-execution-sdk-python-testing
@@ -16,6 +15,9 @@ env:
 jobs:
   build-and-upload-image-to-ecr:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     outputs:
       full_image_arm64: ${{ steps.build-publish.outputs.full_image_arm64 }}
       full_image_x86_64: ${{ steps.build-publish.outputs.full_image_x86_64 }}
@@ -86,6 +88,8 @@ jobs:
 
   create-ecr-manifest-per-arch:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     needs: [build-and-upload-image-to-ecr]
     steps:
       - name: Configure AWS Credentials


### PR DESCRIPTION
## Summary
- move `id-token: write` from workflow scope to the AWS-authenticating jobs
- retain `contents: read` only where checkout requires it
- keep workflow-level defaults read-only

## Validation
- `git diff --check`
- parsed both edited workflow files as YAML
- audited all workflow permission blocks to confirm OIDC grants are job-scoped

Fixes #170