### PR TITLE
feat: add Python conformance test package

### DIFF
--- a/.github/workflows/conformance-tests.yml
+++ b/.github/workflows/conformance-tests.yml
@@ -1,10 +1,8 @@
 name: Conformance Tests
 
-# Full-integration conformance run: builds the Python handlers against the local
-# monorepo SDK, installs the pinned language-agnostic runner from PyPI, then
-# deploys + invokes + validates one SAM stack per suite. Each suite runs as its
-# own parallel matrix job. To add a suite later, add its name to
-# `strategy.matrix.suite` (and ship its template_<suite>.yaml + handlers).
+# Full-integration conformance run: discovers suites from template_<suite>.yaml,
+# builds the Python handlers against the local monorepo SDK, and runs each suite
+# as its own parallel matrix job with the pinned language-agnostic runner.
 
 on:
   pull_request:
@@ -29,16 +27,32 @@ concurrency:
 
 permissions:
   contents: read
-  id-token: write # Required for AWS OIDC credentials
 
 jobs:
+  discover_suites:
+    name: discover conformance suites
+    runs-on: ubuntu-latest
+    outputs:
+      suites: ${{ steps.discover.outputs.suites }}
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+    - name: Discover suites from templates
+      id: discover
+      working-directory: packages/aws-durable-execution-sdk-python-conformance-tests
+      run: echo "suites=$(python3 scripts/discover_suites.py)" >> "$GITHUB_OUTPUT"
+
   conformance:
     name: conformance (${{ matrix.suite }})
+    needs: discover_suites
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # Required for AWS OIDC credentials
     strategy:
       fail-fast: false
       matrix:
-        suite: [step, wait]
+        suite: ${{ fromJSON(needs.discover_suites.outputs.suites) }}
     defaults:
       run:
         working-directory: packages/aws-durable-execution-sdk-python-conformance-tests
@@ -48,14 +62,11 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
-        # The conformance runner requires Python >= 3.14.
         python-version: "3.14"
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
       with:
-        # SAM-capable deploy role (CloudFormation/S3/IAM), the same role the
-        # cloud (example) integration tests assume.
         role-to-assume: "${{ secrets.TEST_ROLE_ARN }}"
         role-session-name: pythonConformanceTest
         aws-region: ${{ env.AWS_REGION }}
@@ -88,9 +99,6 @@ jobs:
           echo "TEST_LAMBDA_EXECUTION_ROLE_ARN not set; template will create its own role."
           exit 0
         fi
-        # Point every function at the pre-existing execution role and drop the
-        # self-created DurableFunctionRole. Mutates only the CI checkout; the
-        # checked-in template stays self-contained for local runs.
         python3 scripts/inject_execution_role.py \
           --template template_${{ matrix.suite }}.yaml \
           --role-arn "$ROLE_ARN"

--- a/.github/workflows/conformance-tests.yml
+++ b/.github/workflows/conformance-tests.yml
@@ -1,0 +1,118 @@
+name: Conformance Tests
+
+# Full-integration conformance run: builds the Python handlers against the local
+# monorepo SDK, installs the pinned language-agnostic runner from PyPI, then
+# deploys + invokes + validates one SAM stack per suite. Each suite runs as its
+# own parallel matrix job. To add a suite later, add its name to
+# `strategy.matrix.suite` (and ship its template_<suite>.yaml + handlers).
+
+on:
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "packages/aws-durable-execution-sdk-python-conformance-tests/**"
+      - ".github/workflows/conformance-tests.yml"
+  workflow_dispatch:
+    inputs:
+      region:
+        description: "AWS Region for deploying and running conformance tests"
+        required: false
+        default: us-west-2
+        type: string
+
+env:
+  AWS_REGION: ${{ github.event.inputs.region || 'us-west-2' }}
+
+concurrency:
+  group: ${{ github.head_ref || github.ref_name || github.run_id }}-conformance
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  id-token: write # Required for AWS OIDC credentials
+
+jobs:
+  conformance:
+    name: conformance (${{ matrix.suite }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        suite: [step, wait]
+    defaults:
+      run:
+        working-directory: packages/aws-durable-execution-sdk-python-conformance-tests
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+    - name: Setup Python
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+      with:
+        # The conformance runner requires Python >= 3.14.
+        python-version: "3.14"
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
+      with:
+        # SAM-capable deploy role (CloudFormation/S3/IAM), the same role the
+        # cloud (example) integration tests assume.
+        role-to-assume: "${{ secrets.TEST_ROLE_ARN }}"
+        role-session-name: pythonConformanceTest
+        aws-region: ${{ env.AWS_REGION }}
+
+    - name: Verify AWS test account
+      env:
+        TEST_ACCOUNT_ID: ${{ secrets.TEST_ACCOUNT_ID }}
+      run: |
+        ACTUAL_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+        if [ "$ACTUAL_ACCOUNT_ID" != "$TEST_ACCOUNT_ID" ]; then
+          echo "Expected AWS account $TEST_ACCOUNT_ID but assumed into $ACTUAL_ACCOUNT_ID"
+          exit 1
+        fi
+        echo "Using AWS test account $ACTUAL_ACCOUNT_ID"
+
+    - name: Setup SAM CLI
+      uses: aws-actions/setup-sam@89ddb14d60e682855e3fea4be85b3c56485de310 # v3
+
+    - name: Build conformance handlers
+      run: python3 scripts/build_examples.py
+
+    - name: Install conformance runner
+      run: pip install aws-durable-execution-conformance-tests==0.1.0
+
+    - name: Inject Lambda execution role into template
+      env:
+        ROLE_ARN: ${{ secrets.TEST_LAMBDA_EXECUTION_ROLE_ARN }}
+      run: |
+        if [ -z "$ROLE_ARN" ]; then
+          echo "TEST_LAMBDA_EXECUTION_ROLE_ARN not set; template will create its own role."
+          exit 0
+        fi
+        # Point every function at the pre-existing execution role and drop the
+        # self-created DurableFunctionRole. Mutates only the CI checkout; the
+        # checked-in template stays self-contained for local runs.
+        python3 scripts/inject_execution_role.py \
+          --template template_${{ matrix.suite }}.yaml \
+          --role-arn "$ROLE_ARN"
+
+    - name: Run conformance suite
+      run: |
+        python -m aws_durable_execution_conformance_tests.app \
+          --template template_${{ matrix.suite }}.yaml \
+          --language python \
+          --suite ${{ matrix.suite }} \
+          --name conf-py-${{ matrix.suite }}-${{ github.run_id }} \
+          --region ${{ env.AWS_REGION }} \
+          --history-dir history-${{ matrix.suite }} \
+          --report junit \
+          --report-file report-${{ matrix.suite }}
+
+    - name: Upload conformance report
+      if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: conformance-report-${{ matrix.suite }}
+        path: |
+          packages/aws-durable-execution-sdk-python-conformance-tests/report-${{ matrix.suite }}.xml
+          packages/aws-durable-execution-sdk-python-conformance-tests/history-${{ matrix.suite }}/
+        if-no-files-found: warn

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/.gitignore
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/.gitignore
@@ -1,0 +1,9 @@
+build/
+lambda-build/
+dist/
+.aws-sam/
+history-*/
+report-*.xml
+report-*.json
+__pycache__/
+*.pyc

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/README.md
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/README.md
@@ -17,19 +17,18 @@ wire them to requirement IDs.
 
 ```
 handlers/
-  step/                     # one .py handler per scenario (context.step)
-  wait/                     # one .py handler per scenario (context.wait)
-template_step.yaml          # SAM template: maps each handler -> requirement ID(s)
-template_wait.yaml
+  <suite>/                  # one .py handler per conformance scenario
+template_<suite>.yaml       # maps suite handlers to requirement IDs
 scripts/
   build_examples.py         # assembles lambda-build/ from the local monorepo SDK
   inject_execution_role.py  # CI: point functions at a pre-existing role
 tests/                      # unit tests for the scripts
 ```
 
-Each SAM template is a self-contained deployment for one **suite** (operation
-category). Suites are added incrementally; today this package ships `step`
-(requirements `1-1`..`1-20`) and `wait` (`2-1`..`2-5`).
+Each `template_<suite>.yaml` is a self-contained deployment for one conformance
+suite. The checked-in templates and the CI workflow matrix are the source of
+truth for supported suites; this README intentionally does not duplicate that
+list.
 
 ## How a handler maps to a requirement
 
@@ -37,13 +36,13 @@ The link is the `TestingMetadata.TestDescription` field on each function in the
 SAM template — a list of requirement IDs the handler satisfies:
 
 ```yaml
-StepBasic:
+RequirementCase:
   Type: AWS::Serverless::Function
   TestingMetadata:
-    TestDescription: ["1-1"]      # <- requirement ID(s) in the conformance repo
+    TestDescription: ["<requirement-id>"]
   Properties:
     CodeUri: lambda-build/
-    Handler: step.step_basic.handler   # <- lambda-build/step/step_basic.py, `handler`
+    Handler: <suite>.<handler_module>.handler
     Role: !GetAtt DurableFunctionRole.Arn
     DurableConfig:
       RetentionPeriodInDays: 7
@@ -72,17 +71,17 @@ This produces:
 ```
 lambda-build/
   aws_durable_execution_sdk_python/   # copied from the local SDK package
-  step/                               # from handlers/step
-  wait/                               # from handlers/wait
+  <suite>/                            # copied from handlers/<suite>
 ```
 
 ## Running a suite
 
-Prerequisites: Python ≥ 3.11, the AWS SAM CLI, and AWS credentials for an
+Prerequisites: Python ≥ 3.14, the AWS SAM CLI, and AWS credentials for an
 account where the Durable Execution service is available.
 
 ```bash
 cd packages/aws-durable-execution-sdk-python-conformance-tests
+SUITE=<suite>
 
 # 1. Assemble lambda-build/ from the local SDK
 python3 scripts/build_examples.py
@@ -90,22 +89,21 @@ python3 scripts/build_examples.py
 # 2. Install the pinned conformance runner
 pip install aws-durable-execution-conformance-tests==0.1.0
 
-# 3. Deploy + invoke + validate one suite (step or wait)
+# 3. Deploy + invoke + validate the selected suite
 python -m aws_durable_execution_conformance_tests.app \
-  --template template_step.yaml \
+  --template "template_${SUITE}.yaml" \
   --language python \
-  --suite step \
-  --name conformance-python-step-local \
+  --suite "$SUITE" \
+  --name "conformance-python-${SUITE}-local" \
   --region us-west-2 \
-  --history-dir history-step \
-  --report junit --report-file report-step
+  --history-dir "history-${SUITE}" \
+  --report junit --report-file "report-${SUITE}"
 ```
 
-Swap `template_step.yaml`/`--suite step` for `template_wait.yaml`/`--suite wait`
-to run the wait suite. The runner deploys the template via SAM, invokes each
-function once per requirement ID, and reports `PASSED` / `FAILED` / `UNCOVERED`
-per requirement. A non-zero exit means at least one requirement failed. Stacks
-are cleaned up by the runner's default `--cleanup` behavior.
+The runner deploys the template via SAM, invokes each function once per
+requirement ID, and reports `PASSED` / `FAILED` / `UNCOVERED` per requirement. A
+non-zero exit means at least one requirement failed. Stacks are cleaned up by
+the runner's default `--cleanup` behavior.
 
 ## Authoring a new test case
 

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/README.md
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/README.md
@@ -7,11 +7,10 @@ language-agnostic conformance runner
 which invokes each function, pulls its execution history, and asserts it matches
 the shared requirement specification.
 
-The runner and the requirement specifications (the `test-requirements/` YAML
-files) are **not** in this repo — they live in
+The runner and requirement specifications are maintained in
 [`aws/aws-durable-execution-conformance-tests`](https://github.com/aws/aws-durable-execution-conformance-tests).
-This package owns only the **Python handlers** and the **SAM templates** that
-wire them to requirement IDs.
+This package owns the Python handlers and SAM templates that wire them to
+requirement IDs.
 
 ## Layout
 
@@ -20,20 +19,20 @@ handlers/
   <suite>/                  # one .py handler per conformance scenario
 template_<suite>.yaml       # maps suite handlers to requirement IDs
 scripts/
+  discover_suites.py        # derives supported suites from templates
   build_examples.py         # assembles lambda-build/ from the local monorepo SDK
   inject_execution_role.py  # CI: point functions at a pre-existing role
 tests/                      # unit tests for the scripts
 ```
 
 Each `template_<suite>.yaml` is a self-contained deployment for one conformance
-suite. The checked-in templates and the CI workflow matrix are the source of
-truth for supported suites; this README intentionally does not duplicate that
-list.
+suite. Templates are the single source of truth: the local build and GitHub
+Actions matrix discover suites from them automatically.
 
 ## How a handler maps to a requirement
 
 The link is the `TestingMetadata.TestDescription` field on each function in the
-SAM template — a list of requirement IDs the handler satisfies:
+SAM template:
 
 ```yaml
 RequirementCase:
@@ -49,47 +48,41 @@ RequirementCase:
       ExecutionTimeout: 300
 ```
 
-The runner invokes the function once per requirement ID using that requirement's
-`Input`, then diffs the resulting execution history against the requirement's
-`ExpectedExecutionHistory`.
+The runner invokes the function once per requirement ID using the requirement's
+`Input`, then compares the execution history with `ExpectedExecutionHistory`.
 
 ## Building locally
 
-`scripts/build_examples.py` assembles the Lambda deployment package under
-`lambda-build/` (git-ignored) from the **local monorepo SDK source** — not a PyPI
-release — so the handlers exercise exactly the code in this checkout. `boto3`
-(the SDK's only runtime dependency) is provided by the Lambda Python runtime and
-is intentionally not vendored.
+`scripts/build_examples.py` assembles `lambda-build/` from the local monorepo
+SDK source, not a PyPI release. `boto3` is provided by the Lambda runtime and is
+not vendored.
 
 ```bash
 cd packages/aws-durable-execution-sdk-python-conformance-tests
-python3 scripts/build_examples.py     # local SDK auto-located from the monorepo
+python3 scripts/build_examples.py
 ```
 
-This produces:
+The script discovers every `template_<suite>.yaml`, verifies a matching
+`handlers/<suite>/` directory exists, and copies all discovered suites:
 
 ```
 lambda-build/
-  aws_durable_execution_sdk_python/   # copied from the local SDK package
-  <suite>/                            # copied from handlers/<suite>
+  aws_durable_execution_sdk_python/
+  <suite>/
 ```
 
 ## Running a suite
 
 Prerequisites: Python ≥ 3.14, the AWS SAM CLI, and AWS credentials for an
-account where the Durable Execution service is available.
+account where Durable Execution is available.
 
 ```bash
 cd packages/aws-durable-execution-sdk-python-conformance-tests
 SUITE=<suite>
 
-# 1. Assemble lambda-build/ from the local SDK
 python3 scripts/build_examples.py
-
-# 2. Install the pinned conformance runner
 pip install aws-durable-execution-conformance-tests==0.1.0
 
-# 3. Deploy + invoke + validate the selected suite
 python -m aws_durable_execution_conformance_tests.app \
   --template "template_${SUITE}.yaml" \
   --language python \
@@ -100,34 +93,29 @@ python -m aws_durable_execution_conformance_tests.app \
   --report junit --report-file "report-${SUITE}"
 ```
 
-The runner deploys the template via SAM, invokes each function once per
-requirement ID, and reports `PASSED` / `FAILED` / `UNCOVERED` per requirement. A
-non-zero exit means at least one requirement failed. Stacks are cleaned up by
-the runner's default `--cleanup` behavior.
+The runner deploys the template, invokes each function, validates its result and
+history, and cleans up the stack by default.
 
 ## Authoring a new test case
 
-1. **Find (or add) the requirement** in the conformance repo under
+1. Find or add the requirement in the conformance repository under
    `test-requirements/<suite>/<id>.yaml`.
-2. **Write the handler** at `handlers/<suite>/<descriptive_name>.py` exporting a
-   `handler`. Use the SDK's **real API** — never hand-roll logic to force the
-   expected result. A handler that fails because the SDK is non-compliant is a
-   valid, valuable outcome; that failure is the signal. Naming convention:
-   descriptive `snake_case`, no numeric IDs in the filename (IDs live in
-   `TestDescription`).
-3. **Register it** in `template_<suite>.yaml` with `Handler: <suite>.<name>.handler`
-   and the matching `TestDescription: ["<id>"]`.
-4. **Rebuild and run** (above).
+2. Add `handlers/<suite>/<descriptive_name>.py` exporting `handler`. Use the
+   SDK's real API; never hand-roll behavior to force an expected result.
+3. Register it in `template_<suite>.yaml` with
+   `Handler: <suite>.<name>.handler` and `TestDescription: ["<id>"]`.
+4. Rebuild and run the suite.
+
+For a new suite, adding its template and handler directory is sufficient; the
+build and CI matrix discover it automatically.
 
 ## CI
 
-`.github/workflows/conformance-tests.yml` runs the same flow on pull requests
-that touch this package and on manual dispatch, one parallel job per suite (a
-build matrix). It assumes AWS credentials via OIDC using the repository's
-existing integration secrets (`TEST_ROLE_ARN` for the SAM-capable deploy role).
+`.github/workflows/conformance-tests.yml` first discovers all suites from
+`template_<suite>.yaml`, then runs one parallel matrix job per suite. CI assumes
+AWS credentials through the repository's existing OIDC secrets.
 
-Before deploying, CI runs `scripts/inject_execution_role.py` to point every
-function at the pre-existing execution role
-(`TEST_LAMBDA_EXECUTION_ROLE_ARN`) and drop the template's self-created
-`DurableFunctionRole` — so CI deploys don't create IAM roles. This rewrites only
-CI's checkout; the checked-in template stays self-contained for local runs.
+Before deployment, `scripts/inject_execution_role.py` points every function at
+the pre-existing execution role (`TEST_LAMBDA_EXECUTION_ROLE_ARN`) and removes
+the template's self-created `DurableFunctionRole`. The checked-in templates
+remain self-contained for local runs.

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/README.md
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/README.md
@@ -1,0 +1,135 @@
+# Durable Execution Python SDK — Conformance Tests
+
+Cross-SDK **conformance test handlers** for the Durable Execution Python SDK.
+These handlers deploy as AWS Lambda functions and are exercised by the
+language-agnostic conformance runner
+[`aws-durable-execution-conformance-tests`](https://pypi.org/project/aws-durable-execution-conformance-tests/),
+which invokes each function, pulls its execution history, and asserts it matches
+the shared requirement specification.
+
+The runner and the requirement specifications (the `test-requirements/` YAML
+files) are **not** in this repo — they live in
+[`aws/aws-durable-execution-conformance-tests`](https://github.com/aws/aws-durable-execution-conformance-tests).
+This package owns only the **Python handlers** and the **SAM templates** that
+wire them to requirement IDs.
+
+## Layout
+
+```
+handlers/
+  step/                     # one .py handler per scenario (context.step)
+  wait/                     # one .py handler per scenario (context.wait)
+template_step.yaml          # SAM template: maps each handler -> requirement ID(s)
+template_wait.yaml
+scripts/
+  build_examples.py         # assembles lambda-build/ from the local monorepo SDK
+  inject_execution_role.py  # CI: point functions at a pre-existing role
+tests/                      # unit tests for the scripts
+```
+
+Each SAM template is a self-contained deployment for one **suite** (operation
+category). Suites are added incrementally; today this package ships `step`
+(requirements `1-1`..`1-20`) and `wait` (`2-1`..`2-5`).
+
+## How a handler maps to a requirement
+
+The link is the `TestingMetadata.TestDescription` field on each function in the
+SAM template — a list of requirement IDs the handler satisfies:
+
+```yaml
+StepBasic:
+  Type: AWS::Serverless::Function
+  TestingMetadata:
+    TestDescription: ["1-1"]      # <- requirement ID(s) in the conformance repo
+  Properties:
+    CodeUri: lambda-build/
+    Handler: step.step_basic.handler   # <- lambda-build/step/step_basic.py, `handler`
+    Role: !GetAtt DurableFunctionRole.Arn
+    DurableConfig:
+      RetentionPeriodInDays: 7
+      ExecutionTimeout: 300
+```
+
+The runner invokes the function once per requirement ID using that requirement's
+`Input`, then diffs the resulting execution history against the requirement's
+`ExpectedExecutionHistory`.
+
+## Building locally
+
+`scripts/build_examples.py` assembles the Lambda deployment package under
+`lambda-build/` (git-ignored) from the **local monorepo SDK source** — not a PyPI
+release — so the handlers exercise exactly the code in this checkout. `boto3`
+(the SDK's only runtime dependency) is provided by the Lambda Python runtime and
+is intentionally not vendored.
+
+```bash
+cd packages/aws-durable-execution-sdk-python-conformance-tests
+python3 scripts/build_examples.py     # local SDK auto-located from the monorepo
+```
+
+This produces:
+
+```
+lambda-build/
+  aws_durable_execution_sdk_python/   # copied from the local SDK package
+  step/                               # from handlers/step
+  wait/                               # from handlers/wait
+```
+
+## Running a suite
+
+Prerequisites: Python ≥ 3.11, the AWS SAM CLI, and AWS credentials for an
+account where the Durable Execution service is available.
+
+```bash
+cd packages/aws-durable-execution-sdk-python-conformance-tests
+
+# 1. Assemble lambda-build/ from the local SDK
+python3 scripts/build_examples.py
+
+# 2. Install the pinned conformance runner
+pip install aws-durable-execution-conformance-tests==0.1.0
+
+# 3. Deploy + invoke + validate one suite (step or wait)
+python -m aws_durable_execution_conformance_tests.app \
+  --template template_step.yaml \
+  --language python \
+  --suite step \
+  --name conformance-python-step-local \
+  --region us-west-2 \
+  --history-dir history-step \
+  --report junit --report-file report-step
+```
+
+Swap `template_step.yaml`/`--suite step` for `template_wait.yaml`/`--suite wait`
+to run the wait suite. The runner deploys the template via SAM, invokes each
+function once per requirement ID, and reports `PASSED` / `FAILED` / `UNCOVERED`
+per requirement. A non-zero exit means at least one requirement failed. Stacks
+are cleaned up by the runner's default `--cleanup` behavior.
+
+## Authoring a new test case
+
+1. **Find (or add) the requirement** in the conformance repo under
+   `test-requirements/<suite>/<id>.yaml`.
+2. **Write the handler** at `handlers/<suite>/<descriptive_name>.py` exporting a
+   `handler`. Use the SDK's **real API** — never hand-roll logic to force the
+   expected result. A handler that fails because the SDK is non-compliant is a
+   valid, valuable outcome; that failure is the signal. Naming convention:
+   descriptive `snake_case`, no numeric IDs in the filename (IDs live in
+   `TestDescription`).
+3. **Register it** in `template_<suite>.yaml` with `Handler: <suite>.<name>.handler`
+   and the matching `TestDescription: ["<id>"]`.
+4. **Rebuild and run** (above).
+
+## CI
+
+`.github/workflows/conformance-tests.yml` runs the same flow on pull requests
+that touch this package and on manual dispatch, one parallel job per suite (a
+build matrix). It assumes AWS credentials via OIDC using the repository's
+existing integration secrets (`TEST_ROLE_ARN` for the SAM-capable deploy role).
+
+Before deploying, CI runs `scripts/inject_execution_role.py` to point every
+function at the pre-existing execution role
+(`TEST_LAMBDA_EXECUTION_ROLE_ARN`) and drop the template's self-created
+`DurableFunctionRole` — so CI deploys don't create IAM roles. This rewrites only
+CI's checkout; the checked-in template stays self-contained for local runs.

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/step/step_and_wait_replay.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/step/step_and_wait_replay.py
@@ -1,0 +1,21 @@
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import Duration
+from aws_durable_execution_sdk_python.context import (
+    DurableContext,
+    StepContext,
+    durable_step,
+)
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_step
+def compute(_step_context: StepContext) -> str:
+    return "computed"
+
+
+@durable_execution
+def handler(_event: Any, context: DurableContext) -> str:
+    result: str = context.step(compute())
+    context.wait(Duration.from_seconds(2))
+    return result

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/step/step_at_most_once_no_retry.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/step/step_at_most_once_no_retry.py
@@ -1,0 +1,35 @@
+"""1-17: AtMostOnce interrupted (no retry) - Lambda crash, StepInterruptedError, fails permanently."""
+
+import os
+import time
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import StepConfig, StepSemantics
+from aws_durable_execution_sdk_python.context import (
+    DurableContext,
+    StepContext,
+    durable_step,
+)
+from aws_durable_execution_sdk_python.execution import durable_execution
+from aws_durable_execution_sdk_python.retries import RetryPresets
+
+
+@durable_step
+def at_most_once_flaky_step(_step_context: StepContext, *, input_1: str) -> str:
+    print(input_1, flush=True)
+    time.sleep(1)  # Allow time for logs to flush to CloudWatch
+    os._exit(1)  # Simulate Lambda crash
+    return "unreachable"
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> str:
+    result: str = context.step(
+        at_most_once_flaky_step(input_1=str(event)),
+        name="at_most_once_flaky_step",
+        config=StepConfig(
+            retry_strategy=RetryPresets.none(),
+            step_semantics=StepSemantics.AT_MOST_ONCE_PER_RETRY,
+        ),
+    )
+    return result

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/step/step_at_most_once_with_retry.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/step/step_at_most_once_with_retry.py
@@ -1,0 +1,50 @@
+"""1-18: AtMostOnce interrupted (with retry, uses the step context attempt number)."""
+
+import os
+import time
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import Duration, StepConfig, StepSemantics
+from aws_durable_execution_sdk_python.context import (
+    DurableContext,
+    StepContext,
+    durable_step,
+)
+from aws_durable_execution_sdk_python.execution import durable_execution
+from aws_durable_execution_sdk_python.retries import (
+    RetryStrategyConfig,
+    create_retry_strategy,
+)
+
+
+@durable_step
+def at_most_once_step(step_context: StepContext, *, input_1: str) -> str:
+    # Print input to stdout each time step executes
+    print(input_1, flush=True)
+    time.sleep(1)  # Allow time for logs to flush to CloudWatch
+
+    # The attempt number is the SDK's built-in durable counter from the step
+    # context (1-based). Under AtMostOncePerRetry the interrupted first attempt
+    # is consumed, so the retry re-executes as attempt 2.
+    if step_context.attempt < 2:
+        # First attempt: simulate Lambda crash
+        os._exit(1)
+    # Second attempt (retry): succeed
+    return "succeeded on second attempt"
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> str:
+    retry_config = RetryStrategyConfig(
+        max_attempts=3,
+        initial_delay=Duration.from_seconds(1),
+    )
+
+    result: str = context.step(
+        at_most_once_step(input_1=str(event)),
+        config=StepConfig(
+            retry_strategy=create_retry_strategy(retry_config),
+            step_semantics=StepSemantics.AT_MOST_ONCE_PER_RETRY,
+        ),
+    )
+    return result

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/step/step_basic.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/step/step_basic.py
@@ -1,0 +1,19 @@
+from typing import Any
+
+from aws_durable_execution_sdk_python.context import (
+    DurableContext,
+    StepContext,
+    durable_step,
+)
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_step
+def greet(_step_context: StepContext, name: str) -> str:
+    return f"Hello, {name}!"
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> str:
+    result: str = context.step(greet(event))
+    return result

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/step/step_complex_object.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/step/step_complex_object.py
@@ -1,0 +1,27 @@
+"""1-4: Returning complex object."""
+
+from typing import Any
+
+from aws_durable_execution_sdk_python.context import (
+    DurableContext,
+    StepContext,
+    durable_step,
+)
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_step
+def build_response(_step_context: StepContext, name: str, tags: list[str]) -> dict:
+    return {
+        "user": {
+            "name": name,
+            "tags": tags,
+        },
+        "count": len(tags),
+    }
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> dict:
+    result: dict = context.step(build_response(event["name"], event["tags"]))
+    return result

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/step/step_custom_serdes.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/step/step_custom_serdes.py
@@ -1,0 +1,36 @@
+"""1-6: Custom serdes (per-step) - transforms result to uppercase."""
+
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import StepConfig
+from aws_durable_execution_sdk_python.context import (
+    DurableContext,
+    StepContext,
+    durable_step,
+)
+from aws_durable_execution_sdk_python.execution import durable_execution
+from aws_durable_execution_sdk_python.serdes import SerDes, SerDesContext
+
+
+class UppercaseSerDes(SerDes[str]):
+    """Custom serdes that transforms strings to uppercase on serialization."""
+
+    def serialize(self, value: str, _: SerDesContext) -> str:
+        return value.upper()
+
+    def deserialize(self, data: str, _: SerDesContext) -> str:
+        return data
+
+
+@durable_step
+def return_input(_step_context: StepContext, value: str) -> str:
+    return value
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> str:
+    result: str = context.step(
+        return_input(event),
+        config=StepConfig(serdes=UppercaseSerDes()),
+    )
+    return result

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/step/step_default_retry.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/step/step_default_retry.py
@@ -1,0 +1,27 @@
+"""1-13: Default retry strategy (uses the step context attempt number)."""
+
+from typing import Any
+
+from aws_durable_execution_sdk_python.context import (
+    DurableContext,
+    StepContext,
+    durable_step,
+)
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_step
+def unreliable(step_context: StepContext) -> str:
+    # Fail on the first two attempts, succeed on the third, using the SDK's
+    # built-in durable attempt counter from the step context (1-based).
+    if step_context.attempt < 3:
+        msg = f"Attempt {step_context.attempt} failed"
+        raise RuntimeError(msg)
+    return "recovered"
+
+
+@durable_execution
+def handler(_event: Any, context: DurableContext) -> str:
+    # Step with no explicit retry config — uses SDK default
+    result: str = context.step(unreliable())
+    return result

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/step/step_error_caught.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/step/step_error_caught.py
@@ -1,0 +1,37 @@
+"""1-20: Error caught and handled (try/catch) - step fails, error caught, execution continues."""
+
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import StepConfig
+from aws_durable_execution_sdk_python.context import (
+    DurableContext,
+    StepContext,
+    durable_step,
+)
+from aws_durable_execution_sdk_python.execution import durable_execution
+from aws_durable_execution_sdk_python.retries import RetryPresets
+
+
+@durable_step
+def failing_step(_step_context: StepContext) -> str:
+    msg = "Something went wrong"
+    raise RuntimeError(msg)
+
+
+@durable_step
+def fallback_step(_step_context: StepContext) -> str:
+    return "fallback_result"
+
+
+@durable_execution
+def handler(_event: Any, context: DurableContext) -> str:
+    try:
+        context.step(
+            failing_step(),
+            config=StepConfig(retry_strategy=RetryPresets.none()),
+        )
+    except Exception:
+        pass
+
+    result: str = context.step(fallback_step())
+    return result

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/step/step_logging.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/step/step_logging.py
@@ -1,0 +1,28 @@
+"""Step handler that uses the SDK's step context logger.
+
+Validates that the logger provided by StepContext correctly emits log
+entries to CloudWatch during step execution.
+"""
+
+from typing import Any
+
+from aws_durable_execution_sdk_python.context import (
+    DurableContext,
+    StepContext,
+    durable_step,
+)
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_step
+def greet(step_context: StepContext, name: str) -> str:
+    step_context.logger.info(f"Greeting step started for: {name}")
+    result = f"Hello, {name}!"
+    step_context.logger.info(f"Greeting step completed with: {result}")
+    return result
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> str:
+    result: str = context.step(greet(event))
+    return result

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/step/step_nested.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/step/step_nested.py
@@ -1,0 +1,25 @@
+from typing import Any
+
+from aws_durable_execution_sdk_python.context import (
+    DurableContext,
+    StepContext,
+    durable_step,
+)
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_step
+def step_one(_step_context: StepContext) -> str:
+    return "first"
+
+
+@durable_step
+def step_two(_step_context: StepContext, previous: str) -> str:
+    return f"{previous}_second"
+
+
+@durable_execution
+def handler(_event: Any, context: DurableContext) -> str:
+    result1: str = context.step(step_one())
+    result2: str = context.step(step_two(result1))
+    return result2

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/step/step_null_result.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/step/step_null_result.py
@@ -1,0 +1,21 @@
+"""1-5: Undefined/null result."""
+
+from typing import Any
+
+from aws_durable_execution_sdk_python.context import (
+    DurableContext,
+    StepContext,
+    durable_step,
+)
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_step
+def do_nothing(_step_context: StepContext) -> None:
+    return None
+
+
+@durable_execution
+def handler(_event: Any, context: DurableContext) -> None:
+    result = context.step(do_nothing())
+    return result

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/step/step_replay_rethrows_failed.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/step/step_replay_rethrows_failed.py
@@ -1,0 +1,33 @@
+"""1-10: Replay re-throws failed step - step logs once, proving no re-execution on replay."""
+
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import Duration, StepConfig
+from aws_durable_execution_sdk_python.context import (
+    DurableContext,
+    StepContext,
+    durable_step,
+)
+from aws_durable_execution_sdk_python.execution import durable_execution
+from aws_durable_execution_sdk_python.retries import RetryPresets
+
+
+@durable_step
+def failing_with_log(step_context: StepContext) -> str:
+    step_context.logger.info("step executed")
+    msg = "Something went wrong"
+    raise RuntimeError(msg)
+
+
+@durable_execution
+def handler(_event: Any, context: DurableContext) -> str:
+    try:
+        context.step(
+            failing_with_log(),
+            config=StepConfig(retry_strategy=RetryPresets.none()),
+        )
+    except Exception as e:
+        error_msg = str(e)
+
+    context.wait(Duration.from_seconds(1))
+    return f"caught: {error_msg}"

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/step/step_replay_skips_succeeded.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/step/step_replay_skips_succeeded.py
@@ -1,0 +1,24 @@
+"""1-9: Replay skips succeeded step - step logs once, proving no re-execution on replay."""
+
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import Duration
+from aws_durable_execution_sdk_python.context import (
+    DurableContext,
+    StepContext,
+    durable_step,
+)
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_step
+def compute_with_log(step_context: StepContext) -> str:
+    step_context.logger.info("step executed")
+    return "cached_value"
+
+
+@durable_execution
+def handler(_event: Any, context: DurableContext) -> str:
+    result: str = context.step(compute_with_log())
+    context.wait(Duration.from_seconds(1))
+    return result

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/step/step_retry_custom_config.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/step/step_retry_custom_config.py
@@ -1,0 +1,41 @@
+"""1-14: Retry with custom config (uses the step context attempt number)."""
+
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import Duration, JitterStrategy, StepConfig
+from aws_durable_execution_sdk_python.context import (
+    DurableContext,
+    StepContext,
+    durable_step,
+)
+from aws_durable_execution_sdk_python.execution import durable_execution
+from aws_durable_execution_sdk_python.retries import (
+    RetryStrategyConfig,
+    create_retry_strategy,
+)
+
+
+@durable_step
+def flaky(step_context: StepContext) -> str:
+    # Fail on the first two attempts, succeed on the third, using the SDK's
+    # built-in durable attempt counter from the step context (1-based).
+    if step_context.attempt < 3:
+        msg = f"Attempt {step_context.attempt} failed"
+        raise RuntimeError(msg)
+    return "finally succeeded"
+
+
+@durable_execution
+def handler(_event: Any, context: DurableContext) -> str:
+    retry_config = RetryStrategyConfig(
+        max_attempts=5,
+        initial_delay=Duration.from_seconds(2),
+        backoff_rate=3,
+        jitter_strategy=JitterStrategy.NONE,
+    )
+
+    result: str = context.step(
+        flaky(),
+        config=StepConfig(retry_strategy=create_retry_strategy(retry_config)),
+    )
+    return result

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/step/step_retry_exhaustion.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/step/step_retry_exhaustion.py
@@ -1,0 +1,37 @@
+"""1-12: Retry exhaustion (max attempts) - always fails, 4 total attempts."""
+
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import Duration, JitterStrategy, StepConfig
+from aws_durable_execution_sdk_python.context import (
+    DurableContext,
+    StepContext,
+    durable_step,
+)
+from aws_durable_execution_sdk_python.execution import durable_execution
+from aws_durable_execution_sdk_python.retries import (
+    RetryStrategyConfig,
+    create_retry_strategy,
+)
+
+
+@durable_step
+def always_fail(_step_context: StepContext) -> str:
+    msg = "Always fails"
+    raise RuntimeError(msg)
+
+
+@durable_execution
+def handler(_event: Any, context: DurableContext) -> str:
+    retry_config = RetryStrategyConfig(
+        max_attempts=4,
+        initial_delay=Duration.from_seconds(1),
+        backoff_rate=1,
+        jitter_strategy=JitterStrategy.NONE,
+    )
+
+    result: str = context.step(
+        always_fail(),
+        config=StepConfig(retry_strategy=create_retry_strategy(retry_config)),
+    )
+    return result

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/step/step_retry_non_retryable.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/step/step_retry_non_retryable.py
@@ -1,0 +1,43 @@
+"""1-16: Retry specific exception (non-retryable fails) - TransientError not in retryable list."""
+
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import Duration, StepConfig
+from aws_durable_execution_sdk_python.context import (
+    DurableContext,
+    StepContext,
+    durable_step,
+)
+from aws_durable_execution_sdk_python.execution import durable_execution
+from aws_durable_execution_sdk_python.retries import (
+    RetryStrategyConfig,
+    create_retry_strategy,
+)
+
+
+class TransientError(Exception):
+    """Custom error that is NOT in the retryable list."""
+
+
+class ValidationError(Exception):
+    """The only error type configured as retryable."""
+
+
+@durable_step
+def throw_transient(_step_context: StepContext) -> str:
+    raise TransientError("transient failure")
+
+
+@durable_execution
+def handler(_event: Any, context: DurableContext) -> str:
+    retry_config = RetryStrategyConfig(
+        max_attempts=3,
+        initial_delay=Duration.from_seconds(1),
+        retryable_error_types=[ValidationError],
+    )
+
+    result: str = context.step(
+        throw_transient(),
+        config=StepConfig(retry_strategy=create_retry_strategy(retry_config)),
+    )
+    return result

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/step/step_retry_specific_exception.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/step/step_retry_specific_exception.py
@@ -1,0 +1,43 @@
+"""1-15: Retry specific exception (uses the step context attempt number)."""
+
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import Duration, StepConfig
+from aws_durable_execution_sdk_python.context import (
+    DurableContext,
+    StepContext,
+    durable_step,
+)
+from aws_durable_execution_sdk_python.execution import durable_execution
+from aws_durable_execution_sdk_python.retries import (
+    RetryStrategyConfig,
+    create_retry_strategy,
+)
+
+
+class TransientError(Exception):
+    """Custom transient error that should be retried."""
+
+
+@durable_step
+def transient_on_first(step_context: StepContext) -> str:
+    # Fail on the first attempt, succeed on the second, using the SDK's
+    # built-in durable attempt counter from the step context (1-based).
+    if step_context.attempt < 2:
+        raise TransientError("Temporary failure")
+    return "recovered from transient"
+
+
+@durable_execution
+def handler(_event: Any, context: DurableContext) -> str:
+    retry_config = RetryStrategyConfig(
+        max_attempts=3,
+        initial_delay=Duration.from_seconds(1),
+        retryable_error_types=[TransientError],
+    )
+
+    result: str = context.step(
+        transient_on_first(),
+        config=StepConfig(retry_strategy=create_retry_strategy(retry_config)),
+    )
+    return result

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/step/step_with_error.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/step/step_with_error.py
@@ -1,0 +1,25 @@
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import StepConfig
+from aws_durable_execution_sdk_python.context import (
+    DurableContext,
+    StepContext,
+    durable_step,
+)
+from aws_durable_execution_sdk_python.execution import durable_execution
+from aws_durable_execution_sdk_python.retries import RetryPresets
+
+
+@durable_step
+def failing_step(_step_context: StepContext) -> str:
+    msg = "Something went wrong"
+    raise RuntimeError(msg)
+
+
+@durable_execution
+def handler(_event: Any, context: DurableContext) -> str:
+    result: str = context.step(
+        failing_step(),
+        config=StepConfig(retry_strategy=RetryPresets.none()),
+    )
+    return result

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/step/step_with_name.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/step/step_with_name.py
@@ -1,0 +1,19 @@
+from typing import Any
+
+from aws_durable_execution_sdk_python.context import (
+    DurableContext,
+    StepContext,
+    durable_step,
+)
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_step
+def greet(_step_context: StepContext, name: str) -> str:
+    return f"Hello, {name}!"
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> str:
+    result: str = context.step(greet(event), name="custom_step_name")
+    return result

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/step/step_with_retry.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/step/step_with_retry.py
@@ -1,0 +1,40 @@
+"""1-11: Step with retry (fails then succeeds, uses the step context attempt number)."""
+
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import StepConfig
+from aws_durable_execution_sdk_python.context import (
+    DurableContext,
+    StepContext,
+    durable_step,
+)
+from aws_durable_execution_sdk_python.execution import durable_execution
+from aws_durable_execution_sdk_python.retries import (
+    RetryStrategyConfig,
+    create_retry_strategy,
+)
+
+
+@durable_step
+def unreliable_operation(step_context: StepContext) -> str:
+    # Fail on the first attempt, succeed on the second. The attempt number is
+    # the SDK's built-in durable counter from the step context (1-based).
+    if step_context.attempt < 2:
+        msg = f"Attempt {step_context.attempt} failed"
+        raise RuntimeError(msg)
+    return "Operation succeeded"
+
+
+@durable_execution
+def handler(_event: Any, context: DurableContext) -> str:
+    retry_config = RetryStrategyConfig(
+        max_attempts=3,
+        retryable_error_types=[RuntimeError],
+    )
+
+    result: str = context.step(
+        unreliable_operation(),
+        config=StepConfig(create_retry_strategy(retry_config)),
+    )
+
+    return result

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/wait/wait_basic.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/wait/wait_basic.py
@@ -1,0 +1,11 @@
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import Duration
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_execution
+def handler(_event: Any, context: DurableContext) -> str:
+    context.wait(Duration.from_seconds(2))
+    return "Wait completed"

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/wait/wait_duration_units.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/wait/wait_duration_units.py
@@ -1,0 +1,13 @@
+"""2-4: Wait with different duration units."""
+
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import Duration
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_execution
+def handler(_event: Any, context: DurableContext) -> str:
+    context.wait(Duration.from_minutes(1))
+    return "Wait with minutes completed"

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/wait/wait_long_duration.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/wait/wait_long_duration.py
@@ -1,0 +1,13 @@
+"""2-5: Wait with long duration (1 hour)."""
+
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import Duration
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_execution
+def handler(_event: Any, context: DurableContext) -> str:
+    context.wait(Duration.from_hours(1))
+    return "Wait with hours completed"

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/wait/wait_multiple_sequential.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/wait/wait_multiple_sequential.py
@@ -1,0 +1,14 @@
+"""2-3: Multiple sequential waits."""
+
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import Duration
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_execution
+def handler(_event: Any, context: DurableContext) -> dict:
+    context.wait(Duration.from_seconds(2), name="wait-1")
+    context.wait(Duration.from_seconds(2), name="wait-2")
+    return {"completedWaits": 2}

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/wait/wait_with_name.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/wait/wait_with_name.py
@@ -1,0 +1,11 @@
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import Duration
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_execution
+def handler(_event: Any, context: DurableContext) -> str:
+    context.wait(Duration.from_seconds(2), name="custom_wait_name")
+    return "Wait with name completed"

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/pyproject.toml
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/pyproject.toml
@@ -1,0 +1,40 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "aws-durable-execution-sdk-python-conformance-tests"
+version = "0.0.0"
+description = "Cross-SDK conformance test handlers for the AWS Durable Execution SDK for Python, exercised by the aws-durable-execution-conformance-tests runner."
+requires-python = ">=3.11"
+dependencies = [
+  "aws-durable-execution-sdk-python==1.7.0",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["handlers"]
+
+[tool.ruff]
+line-length = 88
+target-version = "py311"
+
+[tool.ruff.lint]
+preview = true
+select = ["E4", "E7", "E9", "F", "TID252"]  # pycodestyle (E4/E7/E9) + Pyflakes + absolute imports
+
+[tool.ruff.lint.isort]
+known-first-party = ["aws_durable_execution_sdk_python"]
+force-single-line = false
+lines-after-imports = 2
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = [
+  "ARG001",
+  "ARG002",
+  "ARG005",
+  "E402",
+  "S101",
+  "PLR2004",
+  "SIM117",
+  "TRY301",
+]

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/scripts/build_examples.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/scripts/build_examples.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Assemble the Lambda deployment package for the conformance handlers.
+
+Builds against the **local monorepo SDK source** (not a PyPI release) so the
+handlers exercise exactly the code in this checkout. Output lands in an ignored
+``lambda-build/`` directory that the SAM templates reference via ``CodeUri: lambda-build/``.
+
+Layout produced::
+
+    lambda-build/
+      aws_durable_execution_sdk_python/   # copied from the local SDK package
+      step/                               # copied from handlers/step
+      wait/                               # copied from handlers/wait
+
+``boto3`` (the core SDK's only runtime dependency) is provided by the Lambda
+Python runtime, so it is intentionally not vendored here -- this keeps the
+deployment package free of open-ended dependency ranges.
+
+Usage::
+
+    python3 scripts/build_examples.py            # local SDK auto-located
+    python3 scripts/build_examples.py --sdk-src /path/to/aws_durable_execution_sdk_python
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from pathlib import Path
+
+
+PKG_DIR = Path(__file__).resolve().parents[1]
+BUILD_DIR = PKG_DIR / "lambda-build"
+HANDLER_SUITES = ("step", "wait")
+
+# Default local SDK source: packages/aws-durable-execution-sdk-python/src/...
+DEFAULT_SDK_SRC = (
+    PKG_DIR.parent
+    / "aws-durable-execution-sdk-python"
+    / "src"
+    / "aws_durable_execution_sdk_python"
+)
+
+
+def build(sdk_src: Path) -> None:
+    if not sdk_src.is_dir():
+        raise SystemExit(f"Local SDK source not found: {sdk_src}")
+
+    if BUILD_DIR.exists():
+        shutil.rmtree(BUILD_DIR)
+    BUILD_DIR.mkdir(parents=True)
+
+    # Vendor the local SDK source.
+    shutil.copytree(
+        sdk_src,
+        BUILD_DIR / "aws_durable_execution_sdk_python",
+        ignore=shutil.ignore_patterns("__pycache__", "*.pyc"),
+    )
+
+    # Copy handler suites (build/step, build/wait) matching the template
+    # Handler paths (e.g. step.step_basic.handler).
+    for suite in HANDLER_SUITES:
+        src = PKG_DIR / "handlers" / suite
+        if not src.is_dir():
+            raise SystemExit(f"Handler suite not found: {src}")
+        shutil.copytree(
+            src,
+            BUILD_DIR / suite,
+            ignore=shutil.ignore_patterns("__pycache__", "*.pyc"),
+        )
+
+    print(f"Build complete: {BUILD_DIR}")
+    print(f"  SDK source: {sdk_src}")
+    print(f"  Suites:     {', '.join(HANDLER_SUITES)}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--sdk-src",
+        type=Path,
+        default=DEFAULT_SDK_SRC,
+        help="Path to the local aws_durable_execution_sdk_python source package.",
+    )
+    args = parser.parse_args()
+    build(args.sdk_src)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/scripts/build_examples.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/scripts/build_examples.py
@@ -3,22 +3,25 @@
 
 Builds against the **local monorepo SDK source** (not a PyPI release) so the
 handlers exercise exactly the code in this checkout. Output lands in an ignored
-``lambda-build/`` directory that the SAM templates reference via ``CodeUri: lambda-build/``.
+``lambda-build/`` directory that the SAM templates reference via
+``CodeUri: lambda-build/``.
+
+Suites are discovered from checked-in ``template_<suite>.yaml`` files. Each
+template must have a matching ``handlers/<suite>/`` directory containing at
+least one handler module.
 
 Layout produced::
 
     lambda-build/
       aws_durable_execution_sdk_python/   # copied from the local SDK package
-      step/                               # copied from handlers/step
-      wait/                               # copied from handlers/wait
+      <suite>/                            # copied from handlers/<suite>
 
 ``boto3`` (the core SDK's only runtime dependency) is provided by the Lambda
-Python runtime, so it is intentionally not vendored here -- this keeps the
-deployment package free of open-ended dependency ranges.
+Python runtime, so it is intentionally not vendored here.
 
 Usage::
 
-    python3 scripts/build_examples.py            # local SDK auto-located
+    python3 scripts/build_examples.py
     python3 scripts/build_examples.py --sdk-src /path/to/aws_durable_execution_sdk_python
 """
 
@@ -29,10 +32,11 @@ import shutil
 import sys
 from pathlib import Path
 
+from discover_suites import discover_suites
+
 
 PKG_DIR = Path(__file__).resolve().parents[1]
 BUILD_DIR = PKG_DIR / "lambda-build"
-HANDLER_SUITES = ("step", "wait")
 
 # Default local SDK source: packages/aws-durable-execution-sdk-python/src/...
 DEFAULT_SDK_SRC = (
@@ -47,32 +51,28 @@ def build(sdk_src: Path) -> None:
     if not sdk_src.is_dir():
         raise SystemExit(f"Local SDK source not found: {sdk_src}")
 
+    suites = discover_suites(PKG_DIR)
+
     if BUILD_DIR.exists():
         shutil.rmtree(BUILD_DIR)
     BUILD_DIR.mkdir(parents=True)
 
-    # Vendor the local SDK source.
     shutil.copytree(
         sdk_src,
         BUILD_DIR / "aws_durable_execution_sdk_python",
         ignore=shutil.ignore_patterns("__pycache__", "*.pyc"),
     )
 
-    # Copy handler suites (build/step, build/wait) matching the template
-    # Handler paths (e.g. step.step_basic.handler).
-    for suite in HANDLER_SUITES:
-        src = PKG_DIR / "handlers" / suite
-        if not src.is_dir():
-            raise SystemExit(f"Handler suite not found: {src}")
+    for suite in suites:
         shutil.copytree(
-            src,
+            PKG_DIR / "handlers" / suite,
             BUILD_DIR / suite,
             ignore=shutil.ignore_patterns("__pycache__", "*.pyc"),
         )
 
     print(f"Build complete: {BUILD_DIR}")
     print(f"  SDK source: {sdk_src}")
-    print(f"  Suites:     {', '.join(HANDLER_SUITES)}")
+    print(f"  Suites:     {', '.join(suites)}")
 
 
 def main() -> None:

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/scripts/discover_suites.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/scripts/discover_suites.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Discover conformance suites from template files."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+PKG_DIR = Path(__file__).resolve().parents[1]
+TEMPLATE_PREFIX = "template_"
+TEMPLATE_SUFFIX = ".yaml"
+
+
+def discover_suites(package_dir: Path = PKG_DIR) -> tuple[str, ...]:
+    """Return sorted suites with matching templates and non-empty handler dirs."""
+    templates = sorted(package_dir.glob(f"{TEMPLATE_PREFIX}*{TEMPLATE_SUFFIX}"))
+    if not templates:
+        raise SystemExit(f"No {TEMPLATE_PREFIX}<suite>{TEMPLATE_SUFFIX} files found")
+
+    suites: list[str] = []
+    for template in templates:
+        suite = template.name[len(TEMPLATE_PREFIX) : -len(TEMPLATE_SUFFIX)]
+        if not suite:
+            raise SystemExit(f"Invalid conformance template name: {template.name}")
+
+        handlers_dir = package_dir / "handlers" / suite
+        if not handlers_dir.is_dir():
+            raise SystemExit(
+                f"Template {template.name} has no matching handler directory: "
+                f"{handlers_dir}"
+            )
+
+        handler_files = [
+            path for path in handlers_dir.glob("*.py") if path.name != "__init__.py"
+        ]
+        if not handler_files:
+            raise SystemExit(
+                f"No handler modules found for suite {suite}: {handlers_dir}"
+            )
+
+        suites.append(suite)
+
+    return tuple(suites)
+
+
+def main() -> None:
+    print(json.dumps(discover_suites(), separators=(",", ":")))
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/scripts/inject_execution_role.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/scripts/inject_execution_role.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Inject a pre-existing Lambda execution role into a conformance SAM template.
+
+Rewrites the given template in place so that every AWS::Serverless::Function
+uses the provided execution role ARN, and removes the self-created
+DurableFunctionRole resource. Used by CI to avoid creating an IAM role per
+deploy; the checked-in template stays self-contained for local runs.
+
+Usage:
+    python3 scripts/inject_execution_role.py --template template_step.yaml \
+        --role-arn arn:aws:iam::123456789012:role/my-execution-role
+
+Requires PyYAML (already a dependency of the conformance runner).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+import yaml
+
+
+SELF_CREATED_ROLE = "DurableFunctionRole"
+FUNCTION_TYPE = "AWS::Serverless::Function"
+
+
+def inject(template_path: str, role_arn: str) -> int:
+    """Rewrite template_path in place; return the number of functions updated."""
+    with open(template_path, encoding="utf-8") as f:
+        doc = yaml.safe_load(f)
+
+    resources = doc.get("Resources")
+    if not isinstance(resources, dict):
+        raise SystemExit(f"{template_path}: no Resources section found")
+
+    resources.pop(SELF_CREATED_ROLE, None)
+
+    updated = 0
+    for resource in resources.values():
+        if resource.get("Type") == FUNCTION_TYPE:
+            resource.setdefault("Properties", {})["Role"] = role_arn
+            updated += 1
+
+    if updated == 0:
+        raise SystemExit(f"{template_path}: no {FUNCTION_TYPE} resources found")
+
+    with open(template_path, "w", encoding="utf-8") as f:
+        yaml.safe_dump(doc, f, sort_keys=False)
+
+    return updated
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--template",
+        required=True,
+        help="Path to the SAM template to rewrite in place.",
+    )
+    parser.add_argument(
+        "--role-arn",
+        required=True,
+        help="Execution role ARN to set on every serverless function.",
+    )
+    args = parser.parse_args()
+
+    updated = inject(args.template, args.role_arn)
+    print(f"Injected execution role into {updated} functions in {args.template}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/template_step.yaml
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/template_step.yaml
@@ -1,0 +1,330 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Globals:
+  Function:
+    Runtime: python3.13
+    Timeout: 60
+    MemorySize: 128
+Resources:
+  DurableFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: lambda.amazonaws.com
+          Action: sts:AssumeRole
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+      - PolicyName: DurableExecutionPolicy
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - lambda:CheckpointDurableExecution
+            - lambda:GetDurableExecutionState
+            Resource: '*'
+  StepBasic:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["1-1"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: step.step_basic.handler
+      Description: Step basic (succeeds on first attempt)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  StepWithName:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["1-2"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: step.step_with_name.handler
+      Description: Step with explicit name parameter
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  StepNested:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["1-3"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: step.step_nested.handler
+      Description: Sequential steps where second depends on first
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  StepComplexObject:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["1-4"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: step.step_complex_object.handler
+      Description: Returning complex object with nested structure
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  StepNullResult:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["1-5"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: step.step_null_result.handler
+      Description: Undefined/null result
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  StepCustomSerdes:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["1-6"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: step.step_custom_serdes.handler
+      Description: Custom serdes (per-step) transforms to uppercase
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  StepLogging:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["1-7"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: step.step_logging.handler
+      Description: Step with context logger
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  StepAndWaitReplay:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["1-8"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: step.step_and_wait_replay.handler
+      Description: Step and wait with replay
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  StepReplaySkipsSucceeded:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["1-9"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: step.step_replay_skips_succeeded.handler
+      Description: Replay skips succeeded step
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  StepReplayRethrowsFailed:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["1-10"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: step.step_replay_rethrows_failed.handler
+      Description: Replay re-throws failed step
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  StepWithRetry:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["1-11"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: step.step_with_retry.handler
+      Description: Step with retry (fails then succeeds)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  StepRetryExhaustion:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["1-12"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: step.step_retry_exhaustion.handler
+      Description: Retry exhaustion (max attempts)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  StepDefaultRetry:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["1-13"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: step.step_default_retry.handler
+      Description: Default retry strategy
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  StepRetryCustomConfig:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["1-14"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: step.step_retry_custom_config.handler
+      Description: Retry with custom config (fixed interval and backoff)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  StepRetrySpecificException:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["1-15"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: step.step_retry_specific_exception.handler
+      Description: Retry specific exception
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  StepRetryNonRetryable:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["1-16"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: step.step_retry_non_retryable.handler
+      Description: Retry specific exception (non-retryable fails)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  StepAtMostOnceNoRetry:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["1-17"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: step.step_at_most_once_no_retry.handler
+      Description: Step with AtMostOncePerRetry semantics (interrupted, no retry)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  StepAtMostOnceWithRetry:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["1-18"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: step.step_at_most_once_with_retry.handler
+      Description: AtMostOnce interrupted (with retry, succeeds on second attempt)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  StepWithError:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["1-19"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: step.step_with_error.handler
+      Description: Step with error (fails permanently)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  StepErrorCaught:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["1-20"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: step.step_error_caught.handler
+      Description: Error caught and handled (try/catch)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/template_wait.yaml
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/template_wait.yaml
@@ -1,0 +1,105 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Globals:
+  Function:
+    Runtime: python3.13
+    Timeout: 60
+    MemorySize: 128
+Resources:
+  DurableFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: lambda.amazonaws.com
+          Action: sts:AssumeRole
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+      - PolicyName: DurableExecutionPolicy
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - lambda:CheckpointDurableExecution
+            - lambda:GetDurableExecutionState
+            Resource: '*'
+  WaitBasic:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["2-1"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: wait.wait_basic.handler
+      Description: Wait basic
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  WaitWithName:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["2-2"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: wait.wait_with_name.handler
+      Description: Wait with explicit name parameter
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  WaitMultipleSequential:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["2-3"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: wait.wait_multiple_sequential.handler
+      Description: Multiple sequential waits
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  WaitDurationUnits:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["2-4"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: wait.wait_duration_units.handler
+      Description: Wait with different duration units (minutes)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 3700
+  WaitLongDuration:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["2-5"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: wait.wait_long_duration.handler
+      Description: Wait with long duration (1 hour)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 7200

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/tests/test_discover_suites.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/tests/test_discover_suites.py
@@ -1,0 +1,56 @@
+"""Unit tests for scripts/discover_suites.py."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import discover_suites  # noqa: E402
+
+
+def _add_suite(package_dir: Path, suite: str) -> None:
+    (package_dir / f"template_{suite}.yaml").write_text("Resources: {}\n")
+    handlers_dir = package_dir / "handlers" / suite
+    handlers_dir.mkdir(parents=True)
+    (handlers_dir / "case.py").write_text("def handler():\n    pass\n")
+
+
+def test_discovers_suites_from_templates_in_sorted_order(tmp_path: Path) -> None:
+    _add_suite(tmp_path, "zeta")
+    _add_suite(tmp_path, "alpha")
+
+    assert discover_suites.discover_suites(tmp_path) == ("alpha", "zeta")
+
+
+def test_ignores_non_template_yaml_files(tmp_path: Path) -> None:
+    _add_suite(tmp_path, "example")
+    (tmp_path / "samconfig.yaml").write_text("version: 0.1\n")
+
+    assert discover_suites.discover_suites(tmp_path) == ("example",)
+
+
+def test_fails_when_no_templates_exist(tmp_path: Path) -> None:
+    with pytest.raises(SystemExit, match="No template_<suite>.yaml files found"):
+        discover_suites.discover_suites(tmp_path)
+
+
+def test_fails_when_handler_directory_is_missing(tmp_path: Path) -> None:
+    (tmp_path / "template_example.yaml").write_text("Resources: {}\n")
+
+    with pytest.raises(SystemExit, match="no matching handler directory"):
+        discover_suites.discover_suites(tmp_path)
+
+
+def test_fails_when_handler_directory_is_empty(tmp_path: Path) -> None:
+    (tmp_path / "template_example.yaml").write_text("Resources: {}\n")
+    (tmp_path / "handlers" / "example").mkdir(parents=True)
+
+    with pytest.raises(SystemExit, match="No handler modules found"):
+        discover_suites.discover_suites(tmp_path)

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/tests/test_inject_execution_role.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/tests/test_inject_execution_role.py
@@ -1,0 +1,112 @@
+"""Unit tests for scripts/inject_execution_role.py."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import inject_execution_role  # noqa: E402
+
+
+ROLE_ARN = "arn:aws:iam::123456789012:role/my-execution-role"
+
+
+def _write(tmp_path: Path, doc: dict) -> str:
+    path = tmp_path / "template.yaml"
+    with open(path, "w", encoding="utf-8") as f:
+        yaml.safe_dump(doc, f, sort_keys=False)
+    return str(path)
+
+
+def test_inject_rewrites_functions_and_drops_role(tmp_path: Path) -> None:
+    template = _write(
+        tmp_path,
+        {
+            "Resources": {
+                "DurableFunctionRole": {"Type": "AWS::IAM::Role"},
+                "StepBasic": {
+                    "Type": "AWS::Serverless::Function",
+                    "Properties": {
+                        "Handler": "step.step_basic.handler",
+                        "Role": {"Fn::GetAtt": ["DurableFunctionRole", "Arn"]},
+                    },
+                },
+                "WaitBasic": {
+                    "Type": "AWS::Serverless::Function",
+                    "Properties": {"Handler": "wait.wait_basic.handler"},
+                },
+            }
+        },
+    )
+
+    updated = inject_execution_role.inject(template, ROLE_ARN)
+
+    assert updated == 2
+    with open(template, encoding="utf-8") as f:
+        doc = yaml.safe_load(f)
+    resources = doc["Resources"]
+    assert "DurableFunctionRole" not in resources
+    assert resources["StepBasic"]["Properties"]["Role"] == ROLE_ARN
+    assert resources["WaitBasic"]["Properties"]["Role"] == ROLE_ARN
+
+
+def test_inject_sets_role_when_properties_missing(tmp_path: Path) -> None:
+    template = _write(
+        tmp_path,
+        {
+            "Resources": {
+                "StepBasic": {"Type": "AWS::Serverless::Function"},
+            }
+        },
+    )
+
+    updated = inject_execution_role.inject(template, ROLE_ARN)
+
+    assert updated == 1
+    with open(template, encoding="utf-8") as f:
+        doc = yaml.safe_load(f)
+    assert doc["Resources"]["StepBasic"]["Properties"]["Role"] == ROLE_ARN
+
+
+def test_inject_ignores_non_function_resources(tmp_path: Path) -> None:
+    template = _write(
+        tmp_path,
+        {
+            "Resources": {
+                "SomeTable": {"Type": "AWS::DynamoDB::Table"},
+                "StepBasic": {"Type": "AWS::Serverless::Function"},
+            }
+        },
+    )
+
+    updated = inject_execution_role.inject(template, ROLE_ARN)
+
+    assert updated == 1
+    with open(template, encoding="utf-8") as f:
+        doc = yaml.safe_load(f)
+    assert "Role" not in doc["Resources"]["SomeTable"]
+
+
+def test_inject_raises_when_no_resources(tmp_path: Path) -> None:
+    template = _write(tmp_path, {"AWSTemplateFormatVersion": "2010-09-09"})
+
+    with pytest.raises(SystemExit):
+        inject_execution_role.inject(template, ROLE_ARN)
+
+
+def test_inject_raises_when_no_functions(tmp_path: Path) -> None:
+    template = _write(
+        tmp_path,
+        {"Resources": {"DurableFunctionRole": {"Type": "AWS::IAM::Role"}}},
+    )
+
+    with pytest.raises(SystemExit):
+        inject_execution_role.inject(template, ROLE_ARN)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
   "pytest-xdist",
   "opentelemetry-sdk>=1.20.0,<=1.42.1",
   "aws-durable-execution-sdk-python-testing",
+  "PyYAML==6.0.2",
 ]
 
 [tool.hatch.envs.test.scripts]
@@ -31,6 +32,7 @@ testpaths = [
     "packages/aws-durable-execution-sdk-python-otel/tests",
     "packages/aws-durable-execution-sdk-python-testing/tests",
     "packages/aws-durable-execution-sdk-python-examples/test",
+    "packages/aws-durable-execution-sdk-python-conformance-tests/tests",
 ]
 markers = [
   # Used for test selection with -m example


### PR DESCRIPTION
## Summary
- add the `aws-durable-execution-sdk-python-conformance-tests` package
- add Python handlers and SAM mappings for all step (1-1..1-20) and wait (2-1..2-5) requirements
- add CI execution-role injection
- run step and wait as parallel GitHub Actions matrix jobs using the pinned public runner 0.1.0

## Validation
- `hatch fmt --check`
- package `hatch build`
- full repository tests: 2900 passed, 2 skipped
- injector tests: 5 passed
- exact template coverage: 20 step + 5 wait, no missing/duplicate IDs
- `sam validate --lint` passed for both templates
- live account smoke tests: step 20/20 passed; wait 5/5 passed

## Notes
- Lambda bundles are assembled from the local SDK 1.7.0 source into `lambda-build/`
- runner SAM output remains under `build/`, avoiding recursive CodeUri copying
- CI reuses existing `TEST_ROLE_ARN`, `TEST_ACCOUNT_ID`, and `TEST_LAMBDA_EXECUTION_ROLE_ARN` secrets