### PR TITLE
ci: run conformance tests on main SDK package changes

### DIFF
--- a/.github/workflows/conformance-tests.yml
+++ b/.github/workflows/conformance-tests.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     branches: ["main"]
     paths:
+      - "packages/aws-durable-execution-sdk-python/**"
       - "packages/aws-durable-execution-sdk-python-conformance-tests/**"
       - ".github/workflows/conformance-tests.yml"
   workflow_dispatch:


### PR DESCRIPTION
## Summary
The conformance workflow builds its Lambda bundles from the local monorepo SDK (`packages/aws-durable-execution-sdk-python`), so SDK changes can affect conformance results but previously did not trigger the workflow.

This adds `packages/aws-durable-execution-sdk-python/**` to the `pull_request` path filter so the conformance suites also run when the main SDK package changes.

Note: the glob's trailing `/` scopes it to the SDK package only — it does not match the sibling `aws-durable-execution-sdk-python-*` packages.

## Testing
- YAML validated.
- This PR itself modifies the workflow file, so the conformance jobs will run on it.