### PR TITLE
fix(plugin): set OperationStartInfo start_time from operation

### DIFF
--- a/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/plugin.py
+++ b/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/plugin.py
@@ -4,10 +4,10 @@ import contextlib
 import datetime
 import functools
 import logging
+from collections.abc import Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from enum import Enum
-from collections.abc import Mapping, Sequence
 from typing import Any, Callable, MutableMapping, cast
 
 from aws_durable_execution_sdk_python.identifier import OperationIdentifier
@@ -381,7 +381,9 @@ class PluginExecutor:
             UserFunctionEndInfo.from_start_info(start_info, error), sync=True
         )
 
-    def on_operation_action(self, update: OperationUpdate):
+    def on_operation_action(
+        self, update: OperationUpdate, operation: Operation | None = None
+    ):
         """Execute any registered plugins for a given operation when an update is checkpointed
 
         Args:
@@ -398,7 +400,7 @@ class PluginExecutor:
                     sub_type=update.sub_type,
                     name=update.name,
                     parent_id=update.parent_id,
-                    start_time=datetime.datetime.now(datetime.UTC),
+                    start_time=operation.start_timestamp if operation else None,
                     is_replayed=False,
                     status=OperationStatus.STARTED,
                 ),

--- a/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/state.py
+++ b/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/state.py
@@ -751,7 +751,9 @@ class ExecutionState:
                         output.new_execution_state.next_marker,
                     )
                     for update in updates:
-                        self._plugin_executor.on_operation_action(update)
+                        self._plugin_executor.on_operation_action(
+                            update, self.operations.get(update.operation_id)
+                        )
 
                     self._plugin_executor.on_operation_update(
                         updated_operations,

--- a/packages/aws-durable-execution-sdk-python/tests/plugin_test.py
+++ b/packages/aws-durable-execution-sdk-python/tests/plugin_test.py
@@ -554,6 +554,36 @@ class TestPluginExecutorOnOperationAction(unittest.TestCase):
         self.assertIn("operation_start:op-1", self.plugin.calls)
         self.assertEqual(captured[0].status, OperationStatus.STARTED)
 
+    def test_start_action_uses_server_start_timestamp(self):
+        captured: list[OperationStartInfo] = []
+
+        class _CapturingPlugin(_TrackingPlugin):
+            def on_operation_start(self, info: OperationStartInfo) -> None:
+                super().on_operation_start(info)
+                captured.append(info)
+
+        self.plugin = _CapturingPlugin()
+        self.executor = PluginExecutor(plugins=[self.plugin])
+        update = MagicMock()
+        update.action = OperationAction.START
+        update.operation_id = "op-1"
+        update.operation_type = OperationType.STEP
+        update.sub_type = OperationSubType.STEP
+        update.name = "my-step"
+        update.parent_id = "parent-1"
+
+        operation = Operation(
+            operation_id="op-1",
+            operation_type=OperationType.STEP,
+            status=OperationStatus.STARTED,
+            start_timestamp=START_TS,
+        )
+
+        with self.executor.run():
+            self.executor.on_operation_action(update, operation)
+
+        self.assertEqual(captured[0].start_time, START_TS)
+
     def test_non_start_action_does_not_fire(self):
         update = MagicMock()
         update.action = OperationAction.SUCCEED


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-durable-execution-sdk-python/issues/557

*Description of changes:*

`OperationStartInfo.start_time` was being set from the local clock (`datetime.now()`) in `on_operation_action`, while `OperationEndInfo.end_time` came from the operation's recorded timestamp. For fast operations, it was possible for the recorded end time to precede the local start, resulting in negative durations.

`plugin.py`
- Added an optional `Operation` parameter to `on_operation_action()`, so we can set `start_time` to the recorded start timestamp from the operation.
- If the operation is missing, the `start_time` is set to `None`, which matches behaviour in the JS SDK.

`state.py`
- The checkpoint loop now passes the checkpointed operation into `on_operation_action`.

`plugin_test.py`
- Added a new test which checks that the operation start hook's `start_time` matches the operation's start timestamp.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
