### PR TITLE
feat(plugin)!: add execution_start_time to invocation info

### DIFF
--- a/packages/aws-durable-execution-sdk-python-otel/src/aws_durable_execution_sdk_python_otel/plugin.py
+++ b/packages/aws-durable-execution-sdk-python-otel/src/aws_durable_execution_sdk_python_otel/plugin.py
@@ -320,7 +320,7 @@ class OtelPlugin(DurableInstrumentationPlugin):
         logger.debug("Durable invocation started: %s", info)
         self._execution_arn = info.execution_arn or ""
         self._extracted_context = self._context_extractor(info)
-        self._id_generator.set_trace_id(self._execution_arn, info.start_time)
+        self._id_generator.set_trace_id(self._execution_arn, info.execution_start_time)
 
         self._start_span(
             operation_id=None,
@@ -331,16 +331,15 @@ class OtelPlugin(DurableInstrumentationPlugin):
     def on_invocation_end(self, info: InvocationEndInfo) -> None:
         """Called at the end of each invocation. Ends the invocation span and flushes."""
         logger.debug("Durable invocation ended: %s", info)
-        end_time = info.end_time
         # end all pending spans
         with self._operation_spans_lock:
             operation_ids = list(self._operation_spans.keys())
         for operation_id in operation_ids:
             if operation_id:
-                self._end_span(operation_id, end_time)
+                self._end_span(operation_id)
 
         # end the invocation span
-        self._end_span(None, end_time)
+        self._end_span(None)
 
         # Clear all per-invocation state to prevent leaks across warm Lambda reuses
         self._execution_arn = ""

--- a/packages/aws-durable-execution-sdk-python-otel/tests/test_log_filter.py
+++ b/packages/aws-durable-execution-sdk-python-otel/tests/test_log_filter.py
@@ -49,7 +49,7 @@ def _invocation_start_info() -> InvocationStartInfo:
     return InvocationStartInfo(
         request_id="request-1",
         execution_arn=EXECUTION_ARN,
-        start_time=START_TIME,
+        execution_start_time=START_TIME,
         is_first_invocation=True,
     )
 

--- a/packages/aws-durable-execution-sdk-python-otel/tests/test_plugin.py
+++ b/packages/aws-durable-execution-sdk-python-otel/tests/test_plugin.py
@@ -70,7 +70,7 @@ def _invocation_start_info() -> InvocationStartInfo:
     return InvocationStartInfo(
         request_id="request-1",
         execution_arn=EXECUTION_ARN,
-        start_time=START_TIME,
+        execution_start_time=START_TIME,
         is_first_invocation=True,
     )
 
@@ -80,10 +80,9 @@ def _invocation_end_info() -> InvocationEndInfo:
     return InvocationEndInfo(
         request_id="request-1",
         execution_arn=EXECUTION_ARN,
-        start_time=START_TIME,
+        execution_start_time=START_TIME,
         is_first_invocation=True,
         status=InvocationStatus.SUCCEEDED,
-        end_time=END_TIME,
         error=None,
     )
 

--- a/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/plugin.py
+++ b/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/plugin.py
@@ -161,8 +161,8 @@ class UserFunctionEndInfo(OperationInfo):
 class InvocationInfo:
     request_id: str | None
     execution_arn: str | None
-    start_time: datetime.datetime | None
     is_first_invocation: bool
+    execution_start_time: datetime.datetime | None = None
 
 
 @dataclass(frozen=True)
@@ -172,9 +172,8 @@ class InvocationStartInfo(InvocationInfo):
 
 @dataclass(frozen=True)
 class InvocationEndInfo(InvocationInfo):
-    status: InvocationStatus
-    end_time: datetime.datetime | None
-    error: ErrorObject | None
+    status: InvocationStatus | None = None
+    error: ErrorObject | None = None
 
     @classmethod
     def from_durable_execution_invocation_output(
@@ -185,10 +184,9 @@ class InvocationEndInfo(InvocationInfo):
         return InvocationEndInfo(
             request_id=invocation_start_info.request_id,
             execution_arn=invocation_start_info.execution_arn,
-            start_time=invocation_start_info.start_time,
             is_first_invocation=invocation_start_info.is_first_invocation,
+            execution_start_time=invocation_start_info.execution_start_time,
             status=output.status,
-            end_time=datetime.datetime.now(datetime.UTC),
             error=output.error,
         )
 
@@ -325,16 +323,11 @@ class PluginExecutor:
         lambda_context: LambdaContext | None,
     ) -> None:
         aws_request_id = lambda_context.aws_request_id if lambda_context else None
-        invocation_start_time = (
-            datetime.datetime.now(datetime.UTC)
-            if is_first_invocation
-            else execution_start_time
-        )
         self._invocation_status = InvocationStartInfo(
             execution_arn=execution_arn,
             request_id=aws_request_id,
             is_first_invocation=is_first_invocation,
-            start_time=invocation_start_time,
+            execution_start_time=execution_start_time,
         )
         self.execute_plugins(self._invocation_status, sync=True)
 

--- a/packages/aws-durable-execution-sdk-python/tests/plugin_test.py
+++ b/packages/aws-durable-execution-sdk-python/tests/plugin_test.py
@@ -68,17 +68,16 @@ OPERATION_CHANGE_INFO = OperationChangeInfo(
 INVOCATION_START_INFO = InvocationStartInfo(
     request_id="req-1",
     execution_arn="arn:aws:lambda:us-east-1:123:durable:abc",
-    start_time=START_TS,
+    execution_start_time=START_TS,
     is_first_invocation=True,
 )
 INVOCATION_END_INFO = InvocationEndInfo(
     request_id="req-1",
     execution_arn="arn:test",
-    start_time=START_TS,
+    execution_start_time=START_TS,
     status=InvocationStatus.FAILED,
     error=ERROR,
     is_first_invocation=False,
-    end_time=END_TS,
 )
 
 USER_FUNCTION_START_INFO = UserFunctionStartInfo(
@@ -137,17 +136,16 @@ class TestDataClasses(unittest.TestCase):
             INVOCATION_START_INFO.execution_arn,
             "arn:aws:lambda:us-east-1:123:durable:abc",
         )
-        self.assertEqual(INVOCATION_START_INFO.start_time, START_TS)
+        self.assertEqual(INVOCATION_START_INFO.execution_start_time, START_TS)
         self.assertTrue(INVOCATION_START_INFO.is_first_invocation)
 
     def test_invocation_end_info(self):
         self.assertEqual(INVOCATION_END_INFO.request_id, "req-1")
         self.assertEqual(INVOCATION_END_INFO.execution_arn, "arn:test")
-        self.assertEqual(INVOCATION_END_INFO.start_time, START_TS)
+        self.assertEqual(INVOCATION_END_INFO.execution_start_time, START_TS)
         self.assertFalse(INVOCATION_END_INFO.is_first_invocation)
         self.assertEqual(INVOCATION_END_INFO.status, InvocationStatus.FAILED)
         self.assertEqual(INVOCATION_END_INFO.error.message, "boom")
-        self.assertEqual(INVOCATION_END_INFO.end_time, END_TS)
 
     def test_user_function_start_info(self):
         self.assertEqual(USER_FUNCTION_START_INFO.operation_id, "op-1")
@@ -408,7 +406,9 @@ class TestPluginExecutorOnInvocationStart(unittest.TestCase):
             self.assertEqual(
                 LAMBDA_CTX.aws_request_id, self.executor._invocation_status.request_id
             )
-            self.assertEqual(START_TS, self.executor._invocation_status.start_time)
+            self.assertEqual(
+                START_TS, self.executor._invocation_status.execution_start_time
+            )
             self.assertFalse(self.executor._invocation_status.is_first_invocation)
 
         self.assertIsNone(self.executor._invocation_status)


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-durable-execution-sdk-python/issues/560

*Description of changes:*

This PR includes breaking changes to the plugin interface (which is still experimental). 
These changes follow the implementation of the JS SDK plugin interface, which the Python SDK uses as a baseline.

`InvocationInfo.start_time` and `InvocationEndInfo.end_time` are both removed:
- `InvocationInfo.start_time` was set to the local clock time for new invocations. `InvocationEndInfo.end_time` was always set to the local clock time. Passing this value is not useful because plugins can simply get local clock time themselves.
- `InvocationInfo.start_time` was set to the execution start time for replay invocations, which is misleading because the variable name implied that it's value was the invocation's start time.

`InvocationInfo.execution_start_time` added:
- `execution_start_time` is present in both `InvocationStartInfo` and `InvocationEndInfo`, just like in the JS SDK plugin interface.

`plugin_test.py`
- Updated tests to use `execution_start_time`.

*This PR also updates the OTel plugin to work with the above breaking changes to the plugin interface.*

- Replaced `start_time` with `execution_start_time` when deriving trace ID.
- Removed usage of `end_time`. Invocation end span timestamps now default to using the current wall-clock time, same as in the JS OTel plugin.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
