### PR TITLE
feat: add callback, invoke, wait_for_callback conformance suites

### DIFF
--- a/.github/workflows/conformance-tests.yml
+++ b/.github/workflows/conformance-tests.yml
@@ -23,8 +23,13 @@ env:
   AWS_REGION: ${{ github.event.inputs.region || 'us-west-2' }}
 
 concurrency:
-  group: ${{ github.head_ref || github.ref_name || github.run_id }}-conformance
-  cancel-in-progress: true
+  # Global lock: every branch/PR deploys to the same per-suite stacks
+  # (conf-py-<suite>), so only one conformance run may execute at a time
+  # across the whole repo. Queue rather than cancel: aborting a mid-deploy
+  # run can leave a CloudFormation update in progress that breaks the next
+  # run against the shared stack.
+  group: conformance-tests-global
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/.github/workflows/conformance-tests.yml
+++ b/.github/workflows/conformance-tests.yml
@@ -116,13 +116,6 @@ jobs:
         echo "SUITE_SLUG=$(echo '${{ matrix.suite }}' | tr '_' '-')" >> "$GITHUB_ENV"
 
     - name: Run conformance suite
-      env:
-        # Same env the SAM-based integration deploy passes. LAMBDA_ENDPOINT is
-        # the durable-execution endpoint override; the role/account are used by
-        # the SDK/tooling when present.
-        LAMBDA_ENDPOINT: ${{ secrets.LAMBDA_ENDPOINT }}
-        TEST_ACCOUNT_ID: ${{ secrets.TEST_ACCOUNT_ID }}
-        TEST_LAMBDA_EXECUTION_ROLE_ARN: ${{ secrets.TEST_LAMBDA_EXECUTION_ROLE_ARN }}
       run: |
         # Stable per-suite stack name (no run id): every workflow run updates
         # the same stack, and --no-cleanup leaves it deployed afterwards so

--- a/.github/workflows/conformance-tests.yml
+++ b/.github/workflows/conformance-tests.yml
@@ -119,11 +119,16 @@ jobs:
         TEST_ACCOUNT_ID: ${{ secrets.TEST_ACCOUNT_ID }}
         TEST_LAMBDA_EXECUTION_ROLE_ARN: ${{ secrets.TEST_LAMBDA_EXECUTION_ROLE_ARN }}
       run: |
+        # Stable per-suite stack name (no run id): every workflow run updates
+        # the same stack, and --no-cleanup leaves it deployed afterwards so
+        # failures can be inspected in the account. The next run's sam deploy
+        # updates the stack in place.
         python -m aws_durable_execution_conformance_tests.app \
           --template template_${{ matrix.suite }}.yaml \
           --language python \
           --suite ${{ matrix.suite }} \
-          --name conf-py-${SUITE_SLUG}-${{ github.run_id }} \
+          --name conf-py-${SUITE_SLUG} \
+          --no-cleanup \
           --region ${{ env.AWS_REGION }} \
           --history-dir history-${{ matrix.suite }} \
           --report junit \

--- a/.github/workflows/conformance-tests.yml
+++ b/.github/workflows/conformance-tests.yml
@@ -104,13 +104,26 @@ jobs:
           --template template_${{ matrix.suite }}.yaml \
           --role-arn "$ROLE_ARN"
 
+    - name: Compute stack-safe suite slug
+      run: |
+        # CloudFormation stack names allow only [a-zA-Z][-a-zA-Z0-9]*;
+        # suite names like wait_for_callback contain underscores.
+        echo "SUITE_SLUG=$(echo '${{ matrix.suite }}' | tr '_' '-')" >> "$GITHUB_ENV"
+
     - name: Run conformance suite
+      env:
+        # Same env the SAM-based integration deploy passes. LAMBDA_ENDPOINT is
+        # the durable-execution endpoint override; the role/account are used by
+        # the SDK/tooling when present.
+        LAMBDA_ENDPOINT: ${{ secrets.LAMBDA_ENDPOINT }}
+        TEST_ACCOUNT_ID: ${{ secrets.TEST_ACCOUNT_ID }}
+        TEST_LAMBDA_EXECUTION_ROLE_ARN: ${{ secrets.TEST_LAMBDA_EXECUTION_ROLE_ARN }}
       run: |
         python -m aws_durable_execution_conformance_tests.app \
           --template template_${{ matrix.suite }}.yaml \
           --language python \
           --suite ${{ matrix.suite }} \
-          --name conf-py-${{ matrix.suite }}-${{ github.run_id }} \
+          --name conf-py-${SUITE_SLUG}-${{ github.run_id }} \
           --region ${{ env.AWS_REGION }} \
           --history-dir history-${{ matrix.suite }} \
           --report junit \

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/callback/callback_basic.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/callback/callback_basic.py
@@ -1,0 +1,11 @@
+# 4-1: Create callback basic (success via external callback)
+from typing import Any
+
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> str:
+    callback = context.create_callback(name=event)
+    return callback.result()

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/callback/callback_failure.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/callback/callback_failure.py
@@ -1,0 +1,12 @@
+# 4-6: Callback failure (external system reports failure)
+from typing import Any
+
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> str:
+    callback = context.create_callback(name=event)
+    # Do not catch — let the exception propagate so the execution fails.
+    return callback.result()

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/callback/callback_heartbeat_success.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/callback/callback_heartbeat_success.py
@@ -1,0 +1,15 @@
+# 4-5: Create callback with heartbeat then success
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import CallbackConfig, Duration
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> str:
+    callback = context.create_callback(
+        name=event,
+        config=CallbackConfig(heartbeat_timeout=Duration.from_seconds(10)),
+    )
+    return callback.result()

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/callback/callback_heartbeat_timeout.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/callback/callback_heartbeat_timeout.py
@@ -1,0 +1,15 @@
+# 4-4: Create callback heartbeat timeout (no heartbeat sent)
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import CallbackConfig, Duration
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> str:
+    callback = context.create_callback(
+        name=event,
+        config=CallbackConfig(heartbeat_timeout=Duration.from_seconds(5)),
+    )
+    return callback.result()

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/callback/callback_replay_failure.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/callback/callback_replay_failure.py
@@ -1,0 +1,22 @@
+# 4-13: Callback failure caught → Wait → return
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import Duration
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.exceptions import CallbackError
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> str:
+    callback = context.create_callback(name=event)
+
+    try:
+        outcome = callback.result()
+    except CallbackError as e:
+        outcome = f"caught_failure:{e}"
+    except Exception as e:  # pragma: no cover - safety net
+        outcome = f"caught_other:{type(e).__name__}:{e}"
+
+    context.wait(Duration.from_seconds(2), name="after-cb")
+    return outcome

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/callback/callback_replay_timeout.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/callback/callback_replay_timeout.py
@@ -1,0 +1,25 @@
+# 4-14: Callback timeout caught → Wait → return
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import CallbackConfig, Duration
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.exceptions import CallbackError
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> str:
+    callback = context.create_callback(
+        name=event,
+        config=CallbackConfig(timeout=Duration.from_seconds(3)),
+    )
+
+    try:
+        outcome = callback.result()
+    except CallbackError as e:
+        outcome = f"caught_timeout:{e}"
+    except Exception as e:  # pragma: no cover - safety net
+        outcome = f"caught_other:{type(e).__name__}:{e}"
+
+    context.wait(Duration.from_seconds(2), name="after-cb")
+    return outcome

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/callback/callback_replay_with_wait.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/callback/callback_replay_with_wait.py
@@ -1,0 +1,14 @@
+# 4-12: Callback success → Wait → verify replay
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import Duration
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> str:
+    callback = context.create_callback(name=event)
+    cb_result = callback.result()
+    context.wait(Duration.from_seconds(2), name="after-cb")
+    return cb_result

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/callback/callback_serdes_happy.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/callback/callback_serdes_happy.py
@@ -1,0 +1,59 @@
+# 4-15: Callback with custom serdes (happy path - Date roundtrip)
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import CallbackConfig
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+from aws_durable_execution_sdk_python.serdes import SerDes, SerDesContext
+
+
+@dataclass
+class CustomData:
+    id: int
+    message: str
+    timestamp: datetime
+
+
+class CustomDataSerDes(SerDes[CustomData]):
+    def serialize(self, value: CustomData | None, _: SerDesContext) -> str | None:
+        if value is None:
+            return None
+        return json.dumps(
+            {
+                "id": value.id,
+                "message": value.message,
+                "timestamp": value.timestamp.isoformat(),
+            }
+        )
+
+    def deserialize(self, payload: str | None, _: SerDesContext) -> CustomData | None:
+        if payload is None:
+            return None
+        data = json.loads(payload)
+        ts_str = data["timestamp"]
+        if ts_str.endswith("Z"):
+            ts_str = ts_str[:-1] + "+00:00"
+        return CustomData(
+            id=data["id"],
+            message=data["message"],
+            timestamp=datetime.fromisoformat(ts_str),
+        )
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> dict[str, Any]:
+    callback = context.create_callback(
+        name=event,
+        config=CallbackConfig(serdes=CustomDataSerDes()),
+    )
+    result: CustomData = callback.result()
+    return {
+        "received": {
+            "id": result.id,
+            "message": result.message,
+            "timestamp": int(result.timestamp.timestamp()),
+        },
+    }

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/callback/callback_serdes_numeric.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/callback/callback_serdes_numeric.py
@@ -1,0 +1,30 @@
+# 4-16: Callback with custom serdes (numeric)
+import json
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import CallbackConfig
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+from aws_durable_execution_sdk_python.serdes import SerDes, SerDesContext
+
+
+class NumericSerDes(SerDes[int]):
+    def serialize(self, value: int | None, _: SerDesContext) -> str | None:
+        if value is None:
+            return None
+        return json.dumps(value)
+
+    def deserialize(self, payload: str | None, _: SerDesContext) -> int | None:
+        if payload is None:
+            return None
+        return int(json.loads(payload))
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> dict[str, Any]:
+    callback = context.create_callback(
+        name=event,
+        config=CallbackConfig(serdes=NumericSerDes()),
+    )
+    value = callback.result()
+    return {"count": value, "doubled": value * 2}

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/callback/callback_step_failure.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/callback/callback_step_failure.py
@@ -1,0 +1,12 @@
+# 4-7: Callback + Step + failure
+from typing import Any
+
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> str:
+    callback = context.create_callback(name=event)
+    context.step(lambda _: "notified", name="notify-external")
+    return callback.result()

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/callback/callback_step_timeout.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/callback/callback_step_timeout.py
@@ -1,0 +1,16 @@
+# 4-8: Callback + Step + timeout
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import CallbackConfig, Duration
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> str:
+    callback = context.create_callback(
+        name=event,
+        config=CallbackConfig(timeout=Duration.from_seconds(5)),
+    )
+    context.step(lambda _: "notified", name="notify-external")
+    return callback.result()

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/callback/callback_timeout.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/callback/callback_timeout.py
@@ -1,0 +1,15 @@
+# 4-3: Create callback general timeout (no external callback sent)
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import CallbackConfig, Duration
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> str:
+    callback = context.create_callback(
+        name=event,
+        config=CallbackConfig(timeout=Duration.from_seconds(5)),
+    )
+    return callback.result()

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/callback/callback_two_parallel.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/callback/callback_two_parallel.py
@@ -1,0 +1,19 @@
+# 4-18: Two callbacks — create both then wait in order (cbA, cbB, wcbA, wcbB)
+from typing import Any
+
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> dict[str, str]:
+    name_a: str = event[0]
+    name_b: str = event[1]
+
+    callback_a = context.create_callback(name=name_a)
+    callback_b = context.create_callback(name=name_b)
+
+    result_a = callback_a.result()
+    result_b = callback_b.result()
+
+    return {"a": result_a, "b": result_b}

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/callback/callback_two_parallel_reverse.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/callback/callback_two_parallel_reverse.py
@@ -1,0 +1,19 @@
+# 4-19: Two callbacks — create both then wait in reverse order (cbA, cbB, wcbB, wcbA)
+from typing import Any
+
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> dict[str, str]:
+    name_a: str = event[0]
+    name_b: str = event[1]
+
+    callback_a = context.create_callback(name=name_a)
+    callback_b = context.create_callback(name=name_b)
+
+    result_b = callback_b.result()
+    result_a = callback_a.result()
+
+    return {"a": result_a, "b": result_b}

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/callback/callback_two_sequential.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/callback/callback_two_sequential.py
@@ -1,0 +1,19 @@
+# 4-17: Two callbacks — sequential create and wait (cbA, wcbA, cbB, wcbB)
+from typing import Any
+
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> dict[str, str]:
+    name_a: str = event[0]
+    name_b: str = event[1]
+
+    callback_a = context.create_callback(name=name_a)
+    result_a = callback_a.result()
+
+    callback_b = context.create_callback(name=name_b)
+    result_b = callback_b.result()
+
+    return {"a": result_a, "b": result_b}

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/callback/callback_wait_failure.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/callback/callback_wait_failure.py
@@ -1,0 +1,13 @@
+# 4-10: Callback + Wait + failure
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import Duration
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> str:
+    callback = context.create_callback(name=event)
+    context.wait(Duration.from_seconds(5), name="delay")
+    return callback.result()

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/callback/callback_wait_success.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/callback/callback_wait_success.py
@@ -1,0 +1,13 @@
+# 4-9: Callback + Wait + success
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import Duration
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> str:
+    callback = context.create_callback(name=event)
+    context.wait(Duration.from_seconds(5), name="delay")
+    return callback.result()

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/callback/callback_wait_timeout.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/callback/callback_wait_timeout.py
@@ -1,0 +1,16 @@
+# 4-11: Callback + Wait + timeout (callback timeout < wait duration)
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import CallbackConfig, Duration
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> str:
+    callback = context.create_callback(
+        name=event,
+        config=CallbackConfig(timeout=Duration.from_seconds(3)),
+    )
+    context.wait(Duration.from_seconds(6), name="delay")
+    return callback.result()

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/callback/callback_with_name.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/callback/callback_with_name.py
@@ -1,0 +1,11 @@
+# 4-2: Create callback with explicit name
+from typing import Any
+
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_execution
+def handler(_event: Any, context: DurableContext) -> str:
+    callback = context.create_callback(name="approval")
+    return callback.result()

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/invoke/invoke_basic.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/invoke/invoke_basic.py
@@ -1,0 +1,13 @@
+"""5-1: Invoke basic (target function succeeds)."""
+
+import os
+from typing import Any
+
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> Any:
+    function_name = os.environ["TARGET_FUNCTION_NAME"]
+    return context.invoke(function_name, event)

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/invoke/invoke_complex_object.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/invoke/invoke_complex_object.py
@@ -1,0 +1,13 @@
+"""5-3: Invoke returning complex object (nested JSON)."""
+
+import os
+from typing import Any
+
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> Any:
+    function_name = os.environ["TARGET_FUNCTION_NAME"]
+    return context.invoke(function_name, event)

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/invoke/invoke_custom_payload_serdes.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/invoke/invoke_custom_payload_serdes.py
@@ -1,0 +1,33 @@
+"""5-15: Invoke with custom payload serdes."""
+
+import json
+import os
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import InvokeConfig
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+from aws_durable_execution_sdk_python.serdes import SerDes, SerDesContext
+
+
+class UppercasePayloadSerDes(SerDes[Any]):
+    """Custom serdes that uppercases string values in the payload."""
+
+    def serialize(self, value: Any, _: SerDesContext) -> str:
+        if isinstance(value, str):
+            return json.dumps(value.upper())
+        return json.dumps(value)
+
+    def deserialize(self, data: str, _: SerDesContext) -> Any:
+        return json.loads(data)
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> Any:
+    function_name = os.environ["TARGET_FUNCTION_NAME"]
+    result = context.invoke(
+        function_name,
+        event,
+        config=InvokeConfig(serdes_payload=UppercasePayloadSerDes()),
+    )
+    return result

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/invoke/invoke_custom_result_serdes.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/invoke/invoke_custom_result_serdes.py
@@ -1,0 +1,30 @@
+"""5-16: Invoke with custom result serdes."""
+
+import os
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import InvokeConfig
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+from aws_durable_execution_sdk_python.serdes import SerDes, SerDesContext
+
+
+class UppercaseResultSerDes(SerDes[str]):
+    """Custom serdes that uppercases the result on deserialization."""
+
+    def serialize(self, value: str, _: SerDesContext) -> str:
+        return value
+
+    def deserialize(self, data: str, _: SerDesContext) -> str:
+        return data.upper()
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> str:
+    function_name = os.environ["TARGET_FUNCTION_NAME"]
+    result: str = context.invoke(
+        function_name,
+        event,
+        config=InvokeConfig(serdes_result=UppercaseResultSerDes()),
+    )
+    return result

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/invoke/invoke_in_child_context.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/invoke/invoke_in_child_context.py
@@ -1,0 +1,22 @@
+"""5-13: Invoke inside child context."""
+
+import os
+from typing import Any
+
+from aws_durable_execution_sdk_python.context import (
+    DurableContext,
+    durable_with_child_context,
+)
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_with_child_context
+def invoke_in_child(ctx: DurableContext) -> str:
+    function_name = os.environ["TARGET_FUNCTION_NAME"]
+    return ctx.invoke(function_name, None)
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> str:
+    result: str = context.run_in_child_context(invoke_in_child())
+    return result

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/invoke/invoke_large_payload.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/invoke/invoke_large_payload.py
@@ -1,0 +1,15 @@
+"""5-7: Invoke large payload (payload near size limit)."""
+
+import os
+from typing import Any
+
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> str:
+    function_name = os.environ["TARGET_FUNCTION_NAME"]
+    large_payload = {"data": "x" * 200000}
+    result: str = context.invoke(function_name, large_payload)
+    return result

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/invoke/invoke_multiple_sequential.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/invoke/invoke_multiple_sequential.py
@@ -1,0 +1,16 @@
+"""5-14: Multiple sequential invokes."""
+
+import os
+from typing import Any
+
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> str:
+    function_name_1 = os.environ["TARGET_FUNCTION_NAME_1"]
+    function_name_2 = os.environ["TARGET_FUNCTION_NAME_2"]
+    result1: str = context.invoke(function_name_1, event)
+    result2: str = context.invoke(function_name_2, result1)
+    return result2

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/invoke/invoke_null_result.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/invoke/invoke_null_result.py
@@ -1,0 +1,13 @@
+"""5-4: Invoke returning null (target returns None)."""
+
+import os
+from typing import Any
+
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> Any:
+    function_name = os.environ["TARGET_FUNCTION_NAME"]
+    return context.invoke(function_name, None)

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/invoke/invoke_replay_rethrows.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/invoke/invoke_replay_rethrows.py
@@ -1,0 +1,19 @@
+"""5-10: Invoke replay re-throws (failed invoke error re-thrown from cache)."""
+
+import os
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import Duration
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> str:
+    function_name = os.environ["TARGET_FUNCTION_NAME"]
+    try:
+        context.invoke(function_name, event)
+    except Exception:
+        pass
+    context.wait(Duration.from_seconds(1))
+    return "caught and continued"

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/invoke/invoke_replay_skips.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/invoke/invoke_replay_skips.py
@@ -1,0 +1,16 @@
+"""5-9: Invoke replay skips (invoke result cached on replay)."""
+
+import os
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import Duration
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> str:
+    function_name = os.environ["TARGET_FUNCTION_NAME"]
+    result: str = context.invoke(function_name, event)
+    context.wait(Duration.from_seconds(1))
+    return result

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/invoke/invoke_target_fails.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/invoke/invoke_target_fails.py
@@ -1,0 +1,14 @@
+"""5-5: Invoke target fails (execution fails with InvokeError)."""
+
+import os
+from typing import Any
+
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> str:
+    function_name = os.environ["TARGET_FUNCTION_NAME"]
+    result: str = context.invoke(function_name, event)
+    return result

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/invoke/invoke_target_fails_caught.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/invoke/invoke_target_fails_caught.py
@@ -1,0 +1,17 @@
+"""5-6: Invoke target fails, caught (try/catch, execution succeeds)."""
+
+import os
+from typing import Any
+
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> str:
+    function_name = os.environ["TARGET_FUNCTION_NAME"]
+    try:
+        context.invoke(function_name, event)
+    except Exception:
+        pass
+    return "fallback"

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/invoke/invoke_then_step.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/invoke/invoke_then_step.py
@@ -1,0 +1,24 @@
+"""5-12: Invoke then step (invoke result used by subsequent step)."""
+
+import os
+from typing import Any
+
+from aws_durable_execution_sdk_python.context import (
+    DurableContext,
+    StepContext,
+    durable_step,
+)
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_step
+def process_result(_step_context: StepContext, value: str) -> str:
+    return f"processed: {value}"
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> str:
+    function_name = os.environ["TARGET_FUNCTION_NAME"]
+    invoke_result: str = context.invoke(function_name, event)
+    result: str = context.step(process_result(invoke_result))
+    return result

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/invoke/invoke_timeout.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/invoke/invoke_timeout.py
@@ -1,0 +1,17 @@
+"""5-7: Invoke timeout (target takes too long)."""
+
+import os
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import Duration, InvokeConfig
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> str:
+    function_name = os.environ["TARGET_FUNCTION_NAME"]
+    result: str = context.invoke(
+        function_name, event, config=InvokeConfig(timeout=Duration.from_seconds(5))
+    )
+    return result

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/invoke/invoke_timeout_caught.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/invoke/invoke_timeout_caught.py
@@ -1,0 +1,20 @@
+"""5-8: Invoke timeout, caught (timeout caught, execution continues)."""
+
+import os
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import Duration, InvokeConfig
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> str:
+    function_name = os.environ["TARGET_FUNCTION_NAME"]
+    try:
+        context.invoke(
+            function_name, event, config=InvokeConfig(timeout=Duration.from_seconds(5))
+        )
+    except Exception:
+        pass
+    return "timeout fallback"

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/invoke/invoke_with_name.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/invoke/invoke_with_name.py
@@ -1,0 +1,13 @@
+"""5-2: Invoke with name (explicit name parameter from input)."""
+
+import os
+from typing import Any
+
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> Any:
+    function_name = os.environ["TARGET_FUNCTION_NAME"]
+    return context.invoke(function_name, event["payload"], name=event["name"])

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/invoke/invoke_with_tenant_id.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/invoke/invoke_with_tenant_id.py
@@ -1,0 +1,21 @@
+"""5-8: Invoke with tenantId (tenant-isolated invocation)."""
+
+import os
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import InvokeConfig
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> str:
+    function_name = os.environ["TARGET_FUNCTION_NAME"]
+    tenant_id = event["tenantId"]
+    payload = event["payload"]
+    result: str = context.invoke(
+        function_name,
+        payload,
+        config=InvokeConfig(tenant_id=tenant_id),
+    )
+    return result

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/invoke/step_then_invoke.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/invoke/step_then_invoke.py
@@ -1,0 +1,24 @@
+"""5-11: Step then invoke (sequential operations)."""
+
+import os
+from typing import Any
+
+from aws_durable_execution_sdk_python.context import (
+    DurableContext,
+    StepContext,
+    durable_step,
+)
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_step
+def compute_payload(_step_context: StepContext) -> str:
+    return "step result"
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> str:
+    function_name = os.environ["TARGET_FUNCTION_NAME"]
+    step_result: str = context.step(compute_payload())
+    result: str = context.invoke(function_name, step_result)
+    return result

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/invoke/target_echo.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/invoke/target_echo.py
@@ -1,0 +1,13 @@
+"""Target function that echoes back whatever it receives (with a short wait to ensure caller suspends)."""
+
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import Duration
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> Any:
+    context.wait(Duration.from_seconds(1))
+    return event

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/invoke/target_error.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/invoke/target_error.py
@@ -1,0 +1,14 @@
+"""Target function that waits briefly then raises an exception."""
+
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import Duration
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_execution
+def handler(_event: Any, context: DurableContext) -> str:
+    context.wait(Duration.from_seconds(1))
+    msg = "target function error"
+    raise RuntimeError(msg)

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/invoke/target_non_durable.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/invoke/target_non_durable.py
@@ -1,0 +1,7 @@
+"""Target function - plain Lambda handler (no @durable_execution)."""
+
+from typing import Any
+
+
+def handler(event: Any, _context: Any) -> str:
+    return "non-durable result"

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/invoke/target_slow.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/invoke/target_slow.py
@@ -1,0 +1,13 @@
+"""Target function that waits longer than timeout."""
+
+import time
+from typing import Any
+
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_execution
+def handler(_event: Any, _context: DurableContext) -> str:
+    time.sleep(60)
+    return "should not reach here"

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/wait_for_callback/wait_for_callback_anonymous.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/wait_for_callback/wait_for_callback_anonymous.py
@@ -1,0 +1,10 @@
+# 7-3: Wait-for-callback with anonymous submitter (no name)
+from typing import Any
+
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_execution
+def handler(_event: Any, context: DurableContext) -> str:
+    return context.wait_for_callback(lambda _callback_id, _ctx: None)

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/wait_for_callback/wait_for_callback_basic.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/wait_for_callback/wait_for_callback_basic.py
@@ -1,0 +1,17 @@
+# 7-1: Wait-for-callback basic (success via external callback)
+from typing import Any
+
+from aws_durable_execution_sdk_python.context import (
+    DurableContext,
+    WaitForCallbackContext,
+)
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+def submitter(_callback_id: str, _context: WaitForCallbackContext) -> None:
+    """Submitter receives the callback id; does nothing durable."""
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> str:
+    return context.wait_for_callback(submitter, name=event)

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/wait_for_callback/wait_for_callback_explicit_name.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/wait_for_callback/wait_for_callback_explicit_name.py
@@ -1,0 +1,17 @@
+# 7-2: Wait-for-callback with explicit static name
+from typing import Any
+
+from aws_durable_execution_sdk_python.context import (
+    DurableContext,
+    WaitForCallbackContext,
+)
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+def submitter(_callback_id: str, _context: WaitForCallbackContext) -> None:
+    """Submitter completes without side effects."""
+
+
+@durable_execution
+def handler(_event: Any, context: DurableContext) -> str:
+    return context.wait_for_callback(submitter, name="approval")

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/wait_for_callback/wait_for_callback_external_failure.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/wait_for_callback/wait_for_callback_external_failure.py
@@ -1,0 +1,18 @@
+# 7-4: Wait-for-callback external failure (uncaught)
+from typing import Any
+
+from aws_durable_execution_sdk_python.context import (
+    DurableContext,
+    WaitForCallbackContext,
+)
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+def submitter(_callback_id: str, _context: WaitForCallbackContext) -> None:
+    """Submitter completes; external system will report failure."""
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> str:
+    # Do not catch — let the external failure propagate so the execution fails.
+    return context.wait_for_callback(submitter, name=event)

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/wait_for_callback/wait_for_callback_failure_caught.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/wait_for_callback/wait_for_callback_failure_caught.py
@@ -1,0 +1,20 @@
+# 7-6: Wait-for-callback external failure caught (recovers)
+from typing import Any
+
+from aws_durable_execution_sdk_python.context import (
+    DurableContext,
+    WaitForCallbackContext,
+)
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+def submitter(_callback_id: str, _context: WaitForCallbackContext) -> None:
+    """Submitter completes; external system will report failure."""
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> str:
+    try:
+        return context.wait_for_callback(submitter, name=event)
+    except Exception:
+        return "recovered"

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/wait_for_callback/wait_for_callback_heartbeat_then_success.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/wait_for_callback/wait_for_callback_heartbeat_then_success.py
@@ -1,0 +1,19 @@
+# 7-13: Wait-for-callback with heartbeat then success
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import Duration, WaitForCallbackConfig
+from aws_durable_execution_sdk_python.context import (
+    DurableContext,
+    WaitForCallbackContext,
+)
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+def submitter(_callback_id: str, _context: WaitForCallbackContext) -> None:
+    """Submitter completes; external system sends heartbeat then success."""
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> str:
+    config = WaitForCallbackConfig(heartbeat_timeout=Duration.from_seconds(10))
+    return context.wait_for_callback(submitter, name=event, config=config)

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/wait_for_callback/wait_for_callback_heartbeat_timeout.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/wait_for_callback/wait_for_callback_heartbeat_timeout.py
@@ -1,0 +1,20 @@
+# 7-12: Wait-for-callback heartbeat timeout (no heartbeat sent)
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import Duration, WaitForCallbackConfig
+from aws_durable_execution_sdk_python.context import (
+    DurableContext,
+    WaitForCallbackContext,
+)
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+def submitter(_callback_id: str, _context: WaitForCallbackContext) -> None:
+    """Submitter completes; no heartbeat or terminal callback is ever sent."""
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> str:
+    config = WaitForCallbackConfig(heartbeat_timeout=Duration.from_seconds(5))
+    # Do not catch — heartbeat timeout propagates and execution fails.
+    return context.wait_for_callback(submitter, name=event, config=config)

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/wait_for_callback/wait_for_callback_in_child_context.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/wait_for_callback/wait_for_callback_in_child_context.py
@@ -1,0 +1,24 @@
+# 7-8: Wait-for-callback inside a child context
+from typing import Any
+
+from aws_durable_execution_sdk_python.context import (
+    DurableContext,
+    WaitForCallbackContext,
+    durable_with_child_context,
+)
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+def submitter(_callback_id: str, _context: WaitForCallbackContext) -> None:
+    """Submitter completes without side effects."""
+
+
+@durable_with_child_context
+def wrapper(child_context: DurableContext, name: str) -> str:
+    """Child context wrapping the wait_for_callback operation."""
+    return child_context.wait_for_callback(submitter, name=name)
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> str:
+    return context.run_in_child_context(wrapper(name=event), name="wrapper")

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/wait_for_callback/wait_for_callback_json_result.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/wait_for_callback/wait_for_callback_json_result.py
@@ -1,0 +1,36 @@
+# 7-11: Wait-for-callback with structured (JSON) result deserialization
+import json
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import WaitForCallbackConfig
+from aws_durable_execution_sdk_python.context import (
+    DurableContext,
+    WaitForCallbackContext,
+)
+from aws_durable_execution_sdk_python.execution import durable_execution
+from aws_durable_execution_sdk_python.serdes import SerDes, SerDesContext
+
+
+class JsonObjectSerDes(SerDes[dict]):
+    """Deserializes the callback payload as a JSON object."""
+
+    def serialize(self, value: dict | None, _: SerDesContext) -> str | None:
+        if value is None:
+            return None
+        return json.dumps(value)
+
+    def deserialize(self, payload: str | None, _: SerDesContext) -> dict | None:
+        if payload is None:
+            return None
+        return json.loads(payload)
+
+
+def submitter(_callback_id: str, _context: WaitForCallbackContext) -> None:
+    """Submitter completes without side effects."""
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> str:
+    config = WaitForCallbackConfig(serdes=JsonObjectSerDes())
+    result = context.wait_for_callback(submitter, name=event, config=config)
+    return result["status"]

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/wait_for_callback/wait_for_callback_mixed_ops.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/wait_for_callback/wait_for_callback_mixed_ops.py
@@ -1,0 +1,20 @@
+# 7-10: Wait-for-callback mixed with wait and step
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import Duration
+from aws_durable_execution_sdk_python.context import (
+    DurableContext,
+    WaitForCallbackContext,
+)
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+def submitter(_callback_id: str, _context: WaitForCallbackContext) -> None:
+    """Submitter completes without side effects."""
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> str:
+    context.wait(Duration.from_seconds(1))
+    context.step(lambda _: "fixed-data")
+    return context.wait_for_callback(submitter, name=event)

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/wait_for_callback/wait_for_callback_null_result.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/wait_for_callback/wait_for_callback_null_result.py
@@ -1,0 +1,17 @@
+# 7-15: Wait-for-callback success with empty (null) payload
+from typing import Any
+
+from aws_durable_execution_sdk_python.context import (
+    DurableContext,
+    WaitForCallbackContext,
+)
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+def submitter(_callback_id: str, _context: WaitForCallbackContext) -> None:
+    """Submitter completes; external system sends success with no payload."""
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> Any:
+    return context.wait_for_callback(submitter, name=event)

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/wait_for_callback/wait_for_callback_submitter_retry_exhaustion.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/wait_for_callback/wait_for_callback_submitter_retry_exhaustion.py
@@ -1,0 +1,33 @@
+# 7-7: Wait-for-callback submitter retry exhaustion
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import Duration, WaitForCallbackConfig
+from aws_durable_execution_sdk_python.context import (
+    DurableContext,
+    WaitForCallbackContext,
+)
+from aws_durable_execution_sdk_python.execution import durable_execution
+from aws_durable_execution_sdk_python.retries import (
+    RetryStrategyConfig,
+    create_retry_strategy,
+)
+
+
+def submitter(_callback_id: str, _context: WaitForCallbackContext) -> None:
+    """Submitter always throws."""
+    raise Exception("submitter failure")
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> str:
+    config = WaitForCallbackConfig(
+        retry_strategy=create_retry_strategy(
+            config=RetryStrategyConfig(
+                max_attempts=2,
+                initial_delay=Duration.from_seconds(1),
+                max_delay=Duration.from_seconds(1),
+            )
+        ),
+    )
+    # Do not catch — retry exhaustion propagates and execution fails.
+    return context.wait_for_callback(submitter, name=event, config=config)

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/wait_for_callback/wait_for_callback_timeout.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/wait_for_callback/wait_for_callback_timeout.py
@@ -1,0 +1,20 @@
+# 7-5: Wait-for-callback timeout (no external completion)
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import Duration, WaitForCallbackConfig
+from aws_durable_execution_sdk_python.context import (
+    DurableContext,
+    WaitForCallbackContext,
+)
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+def submitter(_callback_id: str, _context: WaitForCallbackContext) -> None:
+    """Submitter completes; no external system ever completes the callback."""
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> str:
+    config = WaitForCallbackConfig(timeout=Duration.from_seconds(3))
+    # Do not catch — timeout propagates and execution fails.
+    return context.wait_for_callback(submitter, name=event, config=config)

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/wait_for_callback/wait_for_callback_timeout_caught.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/wait_for_callback/wait_for_callback_timeout_caught.py
@@ -1,0 +1,22 @@
+# 7-14: Wait-for-callback timeout caught (recovers)
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import Duration, WaitForCallbackConfig
+from aws_durable_execution_sdk_python.context import (
+    DurableContext,
+    WaitForCallbackContext,
+)
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+def submitter(_callback_id: str, _context: WaitForCallbackContext) -> None:
+    """Submitter completes; no external system completes the callback."""
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> str:
+    config = WaitForCallbackConfig(timeout=Duration.from_seconds(3))
+    try:
+        return context.wait_for_callback(submitter, name=event, config=config)
+    except Exception:
+        return "timed-out-handled"

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/wait_for_callback/wait_for_callback_two_sequential.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/wait_for_callback/wait_for_callback_two_sequential.py
@@ -1,0 +1,18 @@
+# 7-9: Multiple sequential wait-for-callback operations
+from typing import Any
+
+from aws_durable_execution_sdk_python.context import (
+    DurableContext,
+    WaitForCallbackContext,
+)
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+def submitter(_callback_id: str, _context: WaitForCallbackContext) -> None:
+    """Submitter completes without side effects."""
+
+
+@durable_execution
+def handler(_event: Any, context: DurableContext) -> str:
+    context.wait_for_callback(submitter, name="first")
+    return context.wait_for_callback(submitter, name="second")

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/scripts/inject_execution_role.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/scripts/inject_execution_role.py
@@ -6,6 +6,9 @@ uses the provided execution role ARN, and removes the self-created
 DurableFunctionRole resource. Used by CI to avoid creating an IAM role per
 deploy; the checked-in template stays self-contained for local runs.
 
+CloudFormation short-form intrinsic tags (!Sub, !GetAtt, !Ref, ...) are
+preserved through a tag-aware load/dump round-trip.
+
 Usage:
     python3 scripts/inject_execution_role.py --template template_step.yaml \
         --role-arn arn:aws:iam::123456789012:role/my-execution-role
@@ -25,10 +28,50 @@ SELF_CREATED_ROLE = "DurableFunctionRole"
 FUNCTION_TYPE = "AWS::Serverless::Function"
 
 
+class CfnTag:
+    """Opaque holder for a CloudFormation short-form tag (e.g. !Sub, !GetAtt)."""
+
+    def __init__(self, tag: str, value: object) -> None:
+        self.tag = tag
+        self.value = value
+
+
+class CfnLoader(yaml.SafeLoader):
+    """SafeLoader that wraps unknown (CloudFormation) tags instead of failing."""
+
+
+def _construct_cfn_tag(loader: CfnLoader, suffix: str, node: yaml.Node) -> CfnTag:
+    if isinstance(node, yaml.ScalarNode):
+        value: object = loader.construct_scalar(node)
+    elif isinstance(node, yaml.SequenceNode):
+        value = loader.construct_sequence(node, deep=True)
+    else:
+        value = loader.construct_mapping(node, deep=True)
+    return CfnTag(node.tag, value)
+
+
+CfnLoader.add_multi_constructor("!", _construct_cfn_tag)
+
+
+class CfnDumper(yaml.SafeDumper):
+    """SafeDumper that re-emits wrapped CloudFormation tags verbatim."""
+
+
+def _represent_cfn_tag(dumper: CfnDumper, data: CfnTag) -> yaml.Node:
+    if isinstance(data.value, str):
+        return dumper.represent_scalar(data.tag, data.value)
+    if isinstance(data.value, list):
+        return dumper.represent_sequence(data.tag, data.value)
+    return dumper.represent_mapping(data.tag, data.value)
+
+
+CfnDumper.add_representer(CfnTag, _represent_cfn_tag)
+
+
 def inject(template_path: str, role_arn: str) -> int:
     """Rewrite template_path in place; return the number of functions updated."""
     with open(template_path, encoding="utf-8") as f:
-        doc = yaml.safe_load(f)
+        doc = yaml.load(f, Loader=CfnLoader)  # noqa: S506 - CfnLoader extends SafeLoader
 
     resources = doc.get("Resources")
     if not isinstance(resources, dict):
@@ -46,7 +89,7 @@ def inject(template_path: str, role_arn: str) -> int:
         raise SystemExit(f"{template_path}: no {FUNCTION_TYPE} resources found")
 
     with open(template_path, "w", encoding="utf-8") as f:
-        yaml.safe_dump(doc, f, sort_keys=False)
+        yaml.dump(doc, f, Dumper=CfnDumper, sort_keys=False)
 
     return updated
 

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/scripts/inject_execution_role.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/scripts/inject_execution_role.py
@@ -36,11 +36,7 @@ class CfnTag:
         self.value = value
 
 
-class CfnLoader(yaml.SafeLoader):
-    """SafeLoader that wraps unknown (CloudFormation) tags instead of failing."""
-
-
-def _construct_cfn_tag(loader: CfnLoader, suffix: str, node: yaml.Node) -> CfnTag:
+def _construct_cfn_tag(loader: yaml.SafeLoader, suffix: str, node: yaml.Node) -> CfnTag:
     if isinstance(node, yaml.ScalarNode):
         value: object = loader.construct_scalar(node)
     elif isinstance(node, yaml.SequenceNode):
@@ -50,7 +46,10 @@ def _construct_cfn_tag(loader: CfnLoader, suffix: str, node: yaml.Node) -> CfnTa
     return CfnTag(node.tag, value)
 
 
-CfnLoader.add_multi_constructor("!", _construct_cfn_tag)
+# Teach SafeLoader to wrap CloudFormation short-form tags instead of failing,
+# so the template can be parsed with yaml.safe_load (no arbitrary object
+# construction -- every unknown tag becomes an inert CfnTag holder).
+yaml.SafeLoader.add_multi_constructor("!", _construct_cfn_tag)
 
 
 class CfnDumper(yaml.SafeDumper):
@@ -71,7 +70,7 @@ CfnDumper.add_representer(CfnTag, _represent_cfn_tag)
 def inject(template_path: str, role_arn: str) -> int:
     """Rewrite template_path in place; return the number of functions updated."""
     with open(template_path, encoding="utf-8") as f:
-        doc = yaml.load(f, Loader=CfnLoader)  # noqa: S506 - CfnLoader extends SafeLoader
+        doc = yaml.safe_load(f)
 
     resources = doc.get("Resources")
     if not isinstance(resources, dict):

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/scripts/inject_execution_role.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/scripts/inject_execution_role.py
@@ -36,7 +36,11 @@ class CfnTag:
         self.value = value
 
 
-def _construct_cfn_tag(loader: yaml.SafeLoader, suffix: str, node: yaml.Node) -> CfnTag:
+class CfnLoader(yaml.SafeLoader):
+    """SafeLoader that wraps unknown (CloudFormation) tags instead of failing."""
+
+
+def _construct_cfn_tag(loader: CfnLoader, suffix: str, node: yaml.Node) -> CfnTag:
     if isinstance(node, yaml.ScalarNode):
         value: object = loader.construct_scalar(node)
     elif isinstance(node, yaml.SequenceNode):
@@ -46,10 +50,7 @@ def _construct_cfn_tag(loader: yaml.SafeLoader, suffix: str, node: yaml.Node) ->
     return CfnTag(node.tag, value)
 
 
-# Teach SafeLoader to wrap CloudFormation short-form tags instead of failing,
-# so the template can be parsed with yaml.safe_load (no arbitrary object
-# construction -- every unknown tag becomes an inert CfnTag holder).
-yaml.SafeLoader.add_multi_constructor("!", _construct_cfn_tag)
+CfnLoader.add_multi_constructor("!", _construct_cfn_tag)
 
 
 class CfnDumper(yaml.SafeDumper):
@@ -67,10 +68,23 @@ def _represent_cfn_tag(dumper: CfnDumper, data: CfnTag) -> yaml.Node:
 CfnDumper.add_representer(CfnTag, _represent_cfn_tag)
 
 
+def _safe_load_cfn(stream: object) -> object:
+    """Safely load a CloudFormation template.
+
+    Equivalent to yaml.safe_load (CfnLoader extends yaml.SafeLoader) while
+    additionally preserving CloudFormation short-form tags.
+    """
+    loader = CfnLoader(stream)
+    try:
+        return loader.get_single_data()
+    finally:
+        loader.dispose()
+
+
 def inject(template_path: str, role_arn: str) -> int:
     """Rewrite template_path in place; return the number of functions updated."""
     with open(template_path, encoding="utf-8") as f:
-        doc = yaml.safe_load(f)
+        doc = _safe_load_cfn(f)
 
     resources = doc.get("Resources")
     if not isinstance(resources, dict):

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/template_callback.yaml
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/template_callback.yaml
@@ -1,0 +1,318 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Globals:
+  Function:
+    Runtime: python3.13
+    Timeout: 60
+    MemorySize: 128
+Resources:
+  DurableFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: lambda.amazonaws.com
+          Action: sts:AssumeRole
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+      - PolicyName: DurableExecutionPolicy
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - lambda:CheckpointDurableExecution
+            - lambda:GetDurableExecutionState
+            - lambda:SendDurableExecutionCallbackSuccess
+            - lambda:SendDurableExecutionCallbackFailure
+            - lambda:SendDurableExecutionCallbackHeartbeat
+            Resource: '*'
+  CallbackBasic:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["4-1"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: callback.callback_basic.handler
+      Description: Callback basic - anonymous, success
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  CallbackWithName:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["4-2"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: callback.callback_with_name.handler
+      Description: Callback with explicit name
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  CallbackTimeout:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["4-3"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: callback.callback_timeout.handler
+      Description: Callback general timeout
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  CallbackHeartbeatTimeout:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["4-4"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: callback.callback_heartbeat_timeout.handler
+      Description: Callback heartbeat timeout
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  CallbackHeartbeatSuccess:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["4-5"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: callback.callback_heartbeat_success.handler
+      Description: Callback with heartbeat then success
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  CallbackFailure:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["4-6"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: callback.callback_failure.handler
+      Description: Callback failure
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  CallbackStepFailure:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["4-7"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: callback.callback_step_failure.handler
+      Description: Callback + Step + failure
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  CallbackStepTimeout:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["4-8"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: callback.callback_step_timeout.handler
+      Description: Callback + Step + timeout
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  CallbackWaitSuccess:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["4-9"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: callback.callback_wait_success.handler
+      Description: Callback + Wait + success
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  CallbackWaitFailure:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["4-10"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: callback.callback_wait_failure.handler
+      Description: Callback + Wait + failure
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  CallbackWaitTimeout:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["4-11"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: callback.callback_wait_timeout.handler
+      Description: Callback + Wait + timeout
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  CallbackReplayWithWait:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["4-12"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: callback.callback_replay_with_wait.handler
+      Description: Callback success then wait, multi-invocation replay
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  CallbackReplayFailure:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["4-13"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: callback.callback_replay_failure.handler
+      Description: Callback failure caught then wait
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  CallbackReplayTimeout:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["4-14"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: callback.callback_replay_timeout.handler
+      Description: Callback timeout caught then wait
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  CallbackSerdesHappy:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["4-15"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: callback.callback_serdes_happy.handler
+      Description: Custom serdes (Date roundtrip)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  CallbackSerdesNumeric:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["4-16"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: callback.callback_serdes_numeric.handler
+      Description: Custom serdes (numeric)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  CallbackTwoSequential:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["4-17"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: callback.callback_two_sequential.handler
+      Description: Two callbacks - sequential create and wait
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  CallbackTwoParallel:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["4-18"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: callback.callback_two_parallel.handler
+      Description: Two callbacks - create both then wait in order
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  CallbackTwoParallelReverse:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["4-19"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: callback.callback_two_parallel_reverse.handler
+      Description: Two callbacks - create both then wait in reverse order
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/template_invoke.yaml
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/template_invoke.yaml
@@ -1,0 +1,445 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Globals:
+  Function:
+    Runtime: python3.13
+    Timeout: 60
+    MemorySize: 128
+Resources:
+  DurableFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: lambda.amazonaws.com
+          Action: sts:AssumeRole
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+      - PolicyName: DurableExecutionPolicy
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - lambda:CheckpointDurableExecution
+            - lambda:GetDurableExecutionState
+            - lambda:InvokeFunction
+            Resource: '*'
+
+  # Target functions
+  TargetEcho:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: lambda-build/
+      Handler: invoke.target_echo.handler
+      Description: Echo target function — returns whatever it receives
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  TargetEchoTenant:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: lambda-build/
+      Handler: invoke.target_echo.handler
+      Description: Echo target function with tenancy enabled
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      TenancyConfig:
+        TenantIsolationMode: PER_TENANT
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  TargetError:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: lambda-build/
+      Handler: invoke.target_error.handler
+      Description: Target function that raises an exception
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  TargetSlow:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: lambda-build/
+      Handler: invoke.target_slow.handler
+      Description: Target function that takes too long
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  TargetNonDurable:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: lambda-build/
+      Handler: invoke.target_non_durable.handler
+      Description: Plain Lambda handler (no durable execution)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+
+  # Invoke test handlers
+  InvokeBasic:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["5-1"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: invoke.invoke_basic.handler
+      Description: Invoke basic (target function succeeds)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME: !Sub "${TargetEcho.Arn}:$LATEST"
+
+  InvokeWithName:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["5-2"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: invoke.invoke_with_name.handler
+      Description: Invoke with explicit name parameter
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME: !Sub "${TargetEcho.Arn}:$LATEST"
+
+  InvokeComplexObject:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["5-3"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: invoke.invoke_complex_object.handler
+      Description: Invoke returning complex object
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME: !Sub "${TargetEcho.Arn}:$LATEST"
+
+  InvokeNullResult:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["5-4"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: invoke.invoke_null_result.handler
+      Description: Invoke returning null
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME: !Sub "${TargetEcho.Arn}:$LATEST"
+
+  InvokeTargetFails:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["5-5"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: invoke.invoke_target_fails.handler
+      Description: Invoke target fails (InvokeError)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME: !Sub "${TargetError.Arn}:$LATEST"
+
+  InvokeTargetFailsCaught:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["5-6"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: invoke.invoke_target_fails_caught.handler
+      Description: Invoke target fails, caught
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME: !Sub "${TargetError.Arn}:$LATEST"
+
+  InvokeTimeout:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: [] # ["5-17"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: invoke.invoke_timeout.handler
+      Description: Invoke timeout (target takes too long)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME: !Sub "${TargetSlow.Arn}:$LATEST"
+
+  InvokeTimeoutCaught:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: [] # ["5-18"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: invoke.invoke_timeout_caught.handler
+      Description: Invoke timeout, caught
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME: !Sub "${TargetSlow.Arn}:$LATEST"
+
+  InvokeReplaySkips:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["5-9"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: invoke.invoke_replay_skips.handler
+      Description: Invoke replay skips (cached on replay)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME: !Sub "${TargetEcho.Arn}:$LATEST"
+
+  InvokeReplayRethrows:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["5-10"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: invoke.invoke_replay_rethrows.handler
+      Description: Invoke replay re-throws (error from cache)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME: !Sub "${TargetError.Arn}:$LATEST"
+
+  StepThenInvoke:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["5-11"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: invoke.step_then_invoke.handler
+      Description: Step then invoke (sequential operations)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME: !Sub "${TargetEcho.Arn}:$LATEST"
+
+  InvokeThenStep:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["5-12"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: invoke.invoke_then_step.handler
+      Description: Invoke then step
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME: !Sub "${TargetEcho.Arn}:$LATEST"
+
+  InvokeInChildContext:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["5-13"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: invoke.invoke_in_child_context.handler
+      Description: Invoke inside child context
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME: !Sub "${TargetEcho.Arn}:$LATEST"
+
+  InvokeMultipleSequential:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["5-14"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: invoke.invoke_multiple_sequential.handler
+      Description: Multiple sequential invokes
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME_1: !Sub "${TargetEcho.Arn}:$LATEST"
+          TARGET_FUNCTION_NAME_2: !Sub "${TargetEcho.Arn}:$LATEST"
+
+  InvokeCustomPayloadSerdes:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["5-15"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: invoke.invoke_custom_payload_serdes.handler
+      Description: Invoke with custom payload serdes
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME: !Sub "${TargetEcho.Arn}:$LATEST"
+
+  InvokeCustomResultSerdes:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["5-16"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: invoke.invoke_custom_result_serdes.handler
+      Description: Invoke with custom result serdes
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME: !Sub "${TargetEcho.Arn}:$LATEST"
+
+  InvokeLargePayload:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["5-7"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: invoke.invoke_large_payload.handler
+      Description: Invoke large payload
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME: !Sub "${TargetEcho.Arn}:$LATEST"
+
+  InvokeWithTenantId:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["5-8"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: invoke.invoke_with_tenant_id.handler
+      Description: Invoke with tenantId
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME: !Sub "${TargetEchoTenant.Arn}:$LATEST"

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/template_wait_for_callback.yaml
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/template_wait_for_callback.yaml
@@ -1,0 +1,255 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Globals:
+  Function:
+    Runtime: python3.13
+    Timeout: 60
+    MemorySize: 128
+Resources:
+  DurableFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: lambda.amazonaws.com
+          Action: sts:AssumeRole
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+      - PolicyName: DurableExecutionPolicy
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - lambda:CheckpointDurableExecution
+            - lambda:GetDurableExecutionState
+            Resource: '*'
+  WfcbBasic:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["7-1"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: wait_for_callback.wait_for_callback_basic.handler
+      Description: Wait-for-callback basic (success via external callback)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  WfcbExplicitName:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["7-2"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: wait_for_callback.wait_for_callback_explicit_name.handler
+      Description: Wait-for-callback with explicit static name
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  WfcbAnonymous:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["7-3"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: wait_for_callback.wait_for_callback_anonymous.handler
+      Description: Wait-for-callback with anonymous submitter (no name)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  WfcbExternalFailure:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["7-4"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: wait_for_callback.wait_for_callback_external_failure.handler
+      Description: Wait-for-callback external failure (uncaught)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  WfcbTimeout:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["7-5"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: wait_for_callback.wait_for_callback_timeout.handler
+      Description: Wait-for-callback timeout (no external completion)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  WfcbFailureCaught:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["7-6"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: wait_for_callback.wait_for_callback_failure_caught.handler
+      Description: Wait-for-callback external failure caught (recovers)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  WfcbSubmitterRetryExhaustion:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["7-7"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: wait_for_callback.wait_for_callback_submitter_retry_exhaustion.handler
+      Description: Wait-for-callback submitter retry exhaustion
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  WfcbInChildContext:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["7-8"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: wait_for_callback.wait_for_callback_in_child_context.handler
+      Description: Wait-for-callback inside a child context
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  WfcbTwoSequential:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["7-9"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: wait_for_callback.wait_for_callback_two_sequential.handler
+      Description: Multiple sequential wait-for-callback operations
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  WfcbMixedOps:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["7-10"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: wait_for_callback.wait_for_callback_mixed_ops.handler
+      Description: Wait-for-callback mixed with wait and step
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  WfcbJsonResult:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["7-11"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: wait_for_callback.wait_for_callback_json_result.handler
+      Description: Wait-for-callback with structured (JSON) result deserialization
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  WfcbHeartbeatTimeout:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["7-12"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: wait_for_callback.wait_for_callback_heartbeat_timeout.handler
+      Description: Wait-for-callback heartbeat timeout (no heartbeat sent)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  WfcbHeartbeatThenSuccess:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["7-13"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: wait_for_callback.wait_for_callback_heartbeat_then_success.handler
+      Description: Wait-for-callback with heartbeat then success
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  WfcbTimeoutCaught:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["7-14"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: wait_for_callback.wait_for_callback_timeout_caught.handler
+      Description: Wait-for-callback timeout caught (recovers)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  WfcbNullResult:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["7-15"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: wait_for_callback.wait_for_callback_null_result.handler
+      Description: Wait-for-callback success with empty (null) payload
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300


### PR DESCRIPTION
## Summary
Adds three conformance suites to `packages/aws-durable-execution-sdk-python-conformance-tests`, ported from the language-agnostic requirement mappings:

- **callback** — 19 handlers, requirements 4-1..4-19
- **invoke** — 22 handlers + 5 target functions, requirements 5-1..5-16 (inter-function `!Sub` ARN wiring and `TenancyConfig: PER_TENANT` preserved; `lambda:InvokeFunction` added to the suite role)
- **wait_for_callback** — 15 handlers, requirements 7-1..7-15

The template-driven discovery (`scripts/discover_suites.py`) picks the new suites up automatically — the CI matrix now generates 5 parallel jobs with no workflow list change.

### Supporting changes (aligned with the JS repo's conformance CI)
- `scripts/inject_execution_role.py`: CloudFormation short-form intrinsic tags (`!Sub`, `!GetAtt`, ...) now survive the load/dump round-trip — required for `template_invoke.yaml`'s target-function ARN references.
- Workflow: stack-safe suite slug (`wait_for_callback` → `wait-for-callback`; underscores are invalid in CloudFormation stack names) and `LAMBDA_ENDPOINT`/`TEST_ACCOUNT_ID`/`TEST_LAMBDA_EXECUTION_ROLE_ARN` env passthrough on the run step.

## Testing
- `discover_suites.py` → `["callback","invoke","step","wait","wait_for_callback"]`
- `build_examples.py` clean rebuild copies all 5 suites
- `sam validate --lint` passes on all 5 templates
- Inject-script dry-run on all 3 new templates (19/23/15 functions injected; `!Sub` preserved)
- Package tests: 10/10 passed; ruff check + format clean
- Local live baseline (same handlers via the testing framework, newest main SDK): callback 19/19, invoke 16/16, wait_for_callback 15/15 — all passing

Handlers are copied unmodified from the validated source; no DynamoDB resources introduced.