### PR TITLE
feat(errors): Add graded callback error types

### DIFF
--- a/packages/aws-durable-execution-sdk-python-examples/test/wait_for_callback/test_wait_for_callback_failure.py
+++ b/packages/aws-durable-execution-sdk-python-examples/test/wait_for_callback/test_wait_for_callback_failure.py
@@ -21,11 +21,9 @@ def test_wait_for_callback_failure(durable_runner):
 
     assert result.status is InvocationStatus.FAILED
     assert isinstance(result.error, ErrorObject)
-    # The callback failure raises CallbackError inside the child context that
-    # wait_for_callback runs in; it is wrapped as ChildContextError so first run
-    # and replay surface an identical type. The original CallbackError type is
-    # preserved on the error's error_type/__cause__.
+    # An externally-failed callback surfaces as CallbackExternalError, identical
+    # on first run and replay.
     assert result.error.to_dict() == {
         "ErrorMessage": "my callback error",
-        "ErrorType": "ChildContextError",
+        "ErrorType": "CallbackExternalError",
     }

--- a/packages/aws-durable-execution-sdk-python-examples/test/wait_for_callback/test_wait_for_callback_submitter_failure.py
+++ b/packages/aws-durable-execution-sdk-python-examples/test/wait_for_callback/test_wait_for_callback_submitter_failure.py
@@ -24,7 +24,10 @@ def test_fail_after_exhausting_retries_when_submitter_always_fails(durable_runne
     # Execution should fail after retries are exhausted
     assert result.status is InvocationStatus.FAILED
 
-    # Verify error details
+    # A failed submitter step surfaces as CallbackSubmitterError (the submitter's
+    # StepError is translated at the wait_for_callback call site). The type is
+    # identical on first run and replay, so the execution-level record pins it.
     error = result.error
     assert error is not None
+    assert error.type == "CallbackSubmitterError"
     assert "Simulated submitter failure" in error.message

--- a/packages/aws-durable-execution-sdk-python-examples/test/wait_for_callback/test_wait_for_callback_timeout.py
+++ b/packages/aws-durable-execution-sdk-python-examples/test/wait_for_callback/test_wait_for_callback_timeout.py
@@ -4,6 +4,7 @@ import pytest
 from aws_durable_execution_sdk_python.execution import InvocationStatus
 from aws_durable_execution_sdk_python.lambda_service import (
     OperationStatus,
+    OperationSubType,
     OperationType,
 )
 
@@ -46,3 +47,15 @@ def test_handle_wait_for_callback_timeout_scenarios(durable_runner):
         operation.status is OperationStatus.TIMED_OUT
         for operation in callback_operations
     )
+
+    # The wait_for_callback context records the graded CallbackTimeoutError,
+    # identical on first run and replay.
+    wait_for_callback_ops = [
+        operation
+        for operation in result.get_all_operations()
+        if operation.sub_type is OperationSubType.WAIT_FOR_CALLBACK
+    ]
+    assert len(wait_for_callback_ops) == 1
+    wait_for_callback_error = wait_for_callback_ops[0].error
+    assert wait_for_callback_error is not None
+    assert wait_for_callback_error.type == "CallbackTimeoutError"

--- a/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/__init__.py
+++ b/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/__init__.py
@@ -18,6 +18,10 @@ from aws_durable_execution_sdk_python.context import (
 
 # Most common exceptions - users need to handle these exceptions
 from aws_durable_execution_sdk_python.exceptions import (
+    CallbackError,
+    CallbackExternalError,
+    CallbackSubmitterError,
+    CallbackTimeoutError,
     ChildContextError,
     DurableExecutionsError,
     DurableOperationError,
@@ -39,6 +43,10 @@ from aws_durable_execution_sdk_python.types import StepContext
 
 __all__ = [
     "BatchResult",
+    "CallbackError",
+    "CallbackExternalError",
+    "CallbackSubmitterError",
+    "CallbackTimeoutError",
     "ChildContextError",
     "DurableContext",
     "DurableExecutionsError",

--- a/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/context.py
+++ b/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/context.py
@@ -5,7 +5,15 @@ import logging
 from contextlib import contextmanager
 from dataclasses import dataclass
 from threading import Lock
-from typing import TYPE_CHECKING, Any, Concatenate, Generic, ParamSpec, TypeVar
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Concatenate,
+    Generic,
+    NoReturn,
+    ParamSpec,
+    TypeVar,
+)
 
 from aws_durable_execution_sdk_python.config import (
     BatchedInput,
@@ -21,6 +29,11 @@ from aws_durable_execution_sdk_python.config import (
 )
 from aws_durable_execution_sdk_python.exceptions import (
     CallbackError,
+    CallbackExternalError,
+    CallbackSubmitterError,
+    CallbackTimeoutError,
+    ChildContextError,
+    StepError,
     SuspendExecution,
     ValidationError,
 )
@@ -69,6 +82,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
 
     from aws_durable_execution_sdk_python.concurrency.models import BatchResult
+    from aws_durable_execution_sdk_python.lambda_service import ErrorObject
     from aws_durable_execution_sdk_python.state import CheckpointedResult
     from aws_durable_execution_sdk_python.types import LambdaContext
     from aws_durable_execution_sdk_python.waits import WaitForConditionConfig
@@ -252,8 +266,10 @@ class Callback(Generic[T], CallbackProtocol[T]):  # noqa: PYI059
         )
 
         if not checkpointed_result.is_existent():
+            # Should never happen (create_callback already checkpointed this op).
+            # Not external/timeout/submitter, so raise the base CallbackError.
             msg = "Callback operation must exist"
-            raise CallbackError(message=msg, callback_id=self.callback_id)
+            raise CallbackError(message=msg)
 
         if (
             checkpointed_result.is_failed()
@@ -261,12 +277,7 @@ class Callback(Generic[T], CallbackProtocol[T]):  # noqa: PYI059
             or checkpointed_result.is_timed_out()
             or checkpointed_result.is_stopped()
         ):
-            msg = (
-                checkpointed_result.error.message
-                if checkpointed_result.error and checkpointed_result.error.message
-                else "Callback failed"
-            )
-            raise CallbackError(message=msg, callback_id=self.callback_id)
+            self._raise_terminal_failure(checkpointed_result)
 
         if checkpointed_result.is_succeeded():
             if checkpointed_result.result is None:
@@ -283,6 +294,29 @@ class Callback(Generic[T], CallbackProtocol[T]):  # noqa: PYI059
         # therefore we should wait
         msg = "Callback result not received yet. Suspending execution while waiting for result."
         raise SuspendExecution(msg)
+
+    def _raise_terminal_failure(
+        self, checkpointed_result: CheckpointedResult
+    ) -> NoReturn:
+        """Raise the graded error for a terminal callback failure.
+
+        TIMED_OUT -> CallbackTimeoutError; any other non-succeeded terminal
+        (external FAILED, cancelled, stopped) -> CallbackExternalError.
+        Carries the message/data/stack_trace; the external error's own type
+        stays on the callback operation's details.
+        """
+        error: ErrorObject | None = checkpointed_result.error
+        is_timeout: bool = checkpointed_result.is_timed_out()
+        error_cls: type[CallbackError] = (
+            CallbackTimeoutError if is_timeout else CallbackExternalError
+        )
+        default_message: str = "Callback timed out" if is_timeout else "Callback failed"
+        message: str = error.message if error and error.message else default_message
+        raise error_cls(
+            message=message,
+            data=error.data if error else None,
+            stack_trace=error.stack_trace if error else None,
+        )
 
 
 class DurableContext(DurableContextProtocol):
@@ -825,11 +859,29 @@ class DurableContext(DurableContextProtocol):
         def wait_in_child_context(context: DurableContext):
             return wait_for_callback_handler(context, submitter, step_name, config)
 
-        return self.run_in_child_context(
-            wait_in_child_context,
-            step_name,
-            ChildConfig(sub_type=OperationSubType.WAIT_FOR_CALLBACK),
-        )
+        # run_in_child_context is generic and raises ChildContextError with the
+        # inner failure on __cause__; translate to callback-typed errors here, at
+        # the call site, so it re-fires identically on replay.
+        try:
+            return self.run_in_child_context(
+                wait_in_child_context,
+                step_name,
+                ChildConfig(sub_type=OperationSubType.WAIT_FOR_CALLBACK),
+            )
+        except ChildContextError as e:
+            inner: BaseException | None = e.__cause__
+            # Callback failures (external/timeout/base) pass through.
+            if isinstance(inner, CallbackError):
+                raise inner
+            # A failed submitter step surfaces as CallbackSubmitterError, keeping
+            # the step's data/stack_trace (the StepError stays as its cause).
+            if isinstance(inner, StepError):
+                raise CallbackSubmitterError(
+                    inner.message or "Callback submitter failed",
+                    data=inner.data,
+                    stack_trace=inner.stack_trace,
+                ) from inner
+            raise
 
     def wait_for_condition(
         self,

--- a/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/exceptions.py
+++ b/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/exceptions.py
@@ -55,7 +55,6 @@ class TerminationReason(Enum):
     CHECKPOINT_FAILED = "CHECKPOINT_FAILED"
     NON_DETERMINISTIC_EXECUTION = "NON_DETERMINISTIC_EXECUTION"
     STEP_INTERRUPTED = "STEP_INTERRUPTED"
-    CALLBACK_ERROR = "CALLBACK_ERROR"
     SERIALIZATION_ERROR = "SERIALIZATION_ERROR"
 
 
@@ -99,14 +98,6 @@ class InvocationError(UnrecoverableError):
         error codes and HTTP status codes.
         """
         return True
-
-
-class CallbackError(ExecutionError):
-    """Error in callback handling."""
-
-    def __init__(self, message: str, callback_id: str | None = None):
-        super().__init__(message, TerminationReason.CALLBACK_ERROR)
-        self.callback_id = callback_id
 
 
 class DurableApiErrorCategory(Enum):
@@ -338,6 +329,32 @@ class WaitForConditionError(DurableOperationError):
     """Raised when a wait_for_condition operation fails."""
 
 
+class CallbackError(DurableOperationError):
+    """Base class for callback operation failures; catches all of them.
+
+    Graded subclasses distinguish the cause: :class:`CallbackExternalError`
+    (external system reported failure), :class:`CallbackTimeoutError` (timeout
+    or heartbeat expiry), and :class:`CallbackSubmitterError` (submitter step
+    failed). The base is raised directly for internal callback failures.
+    """
+
+
+class CallbackExternalError(CallbackError):
+    """Raised when the external system reports a callback failure.
+
+    Corresponds to the callback operation reaching FAILED because an external
+    entity called ``SendDurableExecutionCallbackFailure``.
+    """
+
+
+class CallbackTimeoutError(CallbackError):
+    """Raised when a callback times out (timeout or heartbeat expiry)."""
+
+
+class CallbackSubmitterError(CallbackError):
+    """Raised when the submitter step of a wait_for_callback fails."""
+
+
 # Reconstruction registry for replay: only the SDK's own operation-error types.
 # Any other discriminator falls back to DurableOperationError in
 # from_error_fields, so we never call a constructor the SDK doesn't control.
@@ -346,6 +363,10 @@ _DURABLE_OPERATION_ERROR_REGISTRY: dict[str, type[DurableOperationError]] = {
     "InvokeError": InvokeError,
     "ChildContextError": ChildContextError,
     "WaitForConditionError": WaitForConditionError,
+    "CallbackError": CallbackError,
+    "CallbackExternalError": CallbackExternalError,
+    "CallbackTimeoutError": CallbackTimeoutError,
+    "CallbackSubmitterError": CallbackSubmitterError,
 }
 
 

--- a/packages/aws-durable-execution-sdk-python/tests/context_test.py
+++ b/packages/aws-durable-execution-sdk-python/tests/context_test.py
@@ -26,6 +26,12 @@ from aws_durable_execution_sdk_python.context import (
 )
 from aws_durable_execution_sdk_python.exceptions import (
     CallbackError,
+    CallbackExternalError,
+    CallbackSubmitterError,
+    CallbackTimeoutError,
+    ChildContextError,
+    InvokeError,
+    StepError,
     SuspendExecution,
     ValidationError,
 )
@@ -205,8 +211,14 @@ def test_callback_result_failed():
 
     callback = Callback("callback5", "op5", mock_state)
 
-    with pytest.raises(CallbackError):
+    # A FAILED callback (external SendDurableExecutionCallbackFailure) surfaces
+    # as CallbackExternalError. The external error's own type stays on the
+    # callback operation, and there is no synthetic __cause__.
+    with pytest.raises(CallbackExternalError) as exc_info:
         callback.result()
+    assert exc_info.value.message == "Callback failed"
+    assert isinstance(exc_info.value, CallbackError)
+    assert exc_info.value.__cause__ is None
 
 
 def test_callback_result_not_started():
@@ -264,7 +276,32 @@ def test_callback_result_timed_out():
 
     callback = Callback("callback_timeout", "op_timeout", mock_state)
 
-    with pytest.raises(CallbackError):
+    # A TIMED_OUT callback surfaces as CallbackTimeoutError.
+    with pytest.raises(CallbackTimeoutError) as exc_info:
+        callback.result()
+    assert isinstance(exc_info.value, CallbackError)
+
+
+@pytest.mark.parametrize(
+    "status",
+    [OperationStatus.CANCELLED, OperationStatus.STOPPED],
+)
+def test_callback_result_cancelled_or_stopped_is_external(status):
+    """CANCELLED/STOPPED terminal callbacks surface as CallbackExternalError."""
+    mock_state = Mock(spec=ExecutionState)
+    mock_state.durable_execution_arn = "test_arn"
+    operation = Operation(
+        operation_id="op_cs",
+        operation_type=OperationType.CALLBACK,
+        status=status,
+        callback_details=CallbackDetails(callback_id="callback_cs"),
+    )
+    mock_result = CheckpointedResult.create_from_operation(operation)
+    mock_state.get_checkpoint_result.return_value = mock_result
+
+    callback = Callback("callback_cs", "op_cs", mock_state)
+
+    with pytest.raises(CallbackExternalError):
         callback.result()
 
 
@@ -1293,6 +1330,86 @@ def test_wait_for_callback_passes_child_context(mock_executor_class):
 
         assert result == "handler_result"
         mock_executor_class.assert_called_once()
+
+
+# region wait_for_callback error translation
+
+
+def _child_context_error_with_cause(cause: BaseException) -> ChildContextError:
+    """Build the ChildContextError that run_in_child_context raises, inner on __cause__.
+
+    Same shape on first run and replay (reconstructed from the FAILED checkpoint).
+    """
+    error = ChildContextError("child context failed")
+    error.__cause__ = cause
+    return error
+
+
+@pytest.mark.parametrize(
+    "inner",
+    [
+        CallbackError("internal callback failure"),
+        CallbackExternalError("callback failed"),
+        CallbackTimeoutError("callback timed out"),
+    ],
+)
+def test_wait_for_callback_passes_callback_errors_through(inner):
+    """Any CallbackError-family failure passes through wait_for_callback unchanged."""
+    mock_state = Mock(spec=ExecutionState)
+    mock_state.durable_execution_arn = "test_arn"
+    context = create_test_context(state=mock_state)
+
+    with patch.object(
+        DurableContext,
+        "run_in_child_context",
+        side_effect=_child_context_error_with_cause(inner),
+    ):
+        with pytest.raises(CallbackError) as exc_info:
+            context.wait_for_callback(Mock())
+    assert exc_info.value is inner
+
+
+def test_wait_for_callback_translates_submitter_step_failure():
+    """A failed submitter step (StepError inner) becomes CallbackSubmitterError."""
+    mock_state = Mock(spec=ExecutionState)
+    mock_state.durable_execution_arn = "test_arn"
+    context = create_test_context(state=mock_state)
+
+    inner = StepError("submitter blew up", data="payload", stack_trace=["frame"])
+    with patch.object(
+        DurableContext,
+        "run_in_child_context",
+        side_effect=_child_context_error_with_cause(inner),
+    ):
+        with pytest.raises(CallbackSubmitterError) as exc_info:
+            context.wait_for_callback(Mock())
+    # The original StepError is preserved as the cause, and its data/stack_trace
+    # carry onto the CallbackSubmitterError.
+    assert exc_info.value.__cause__ is inner
+    assert "submitter blew up" in str(exc_info.value)
+    assert exc_info.value.data == "payload"
+    assert exc_info.value.stack_trace == ["frame"]
+
+
+def test_wait_for_callback_reraises_unrelated_child_context_error():
+    """A non-callback, non-step failure re-raises the original ChildContextError."""
+    mock_state = Mock(spec=ExecutionState)
+    mock_state.durable_execution_arn = "test_arn"
+    context = create_test_context(state=mock_state)
+
+    inner = InvokeError("nested invoke failed")
+    child_error = _child_context_error_with_cause(inner)
+    with patch.object(
+        DurableContext,
+        "run_in_child_context",
+        side_effect=child_error,
+    ):
+        with pytest.raises(ChildContextError) as exc_info:
+            context.wait_for_callback(Mock())
+    assert exc_info.value is child_error
+
+
+# endregion wait_for_callback error translation
 
 
 # endregion wait_for_callback

--- a/packages/aws-durable-execution-sdk-python/tests/e2e/error_hierarchy_int_test.py
+++ b/packages/aws-durable-execution-sdk-python/tests/e2e/error_hierarchy_int_test.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from unittest.mock import Mock, patch
 
+import pytest
+
 from aws_durable_execution_sdk_python.config import StepConfig
 from aws_durable_execution_sdk_python.context import DurableContext
 from aws_durable_execution_sdk_python.execution import (
@@ -174,3 +176,138 @@ def test_failed_step_reconstructs_step_error_on_replay():
         assert result["Error"]["ErrorType"] == "StepError"
         assert result["Error"]["ErrorMessage"] == "prior boom"
         assert executed["count"] == 0
+
+
+@pytest.mark.parametrize(
+    ("checkpointed_type", "message"),
+    [
+        ("CallbackExternalError", "external boom"),
+        ("CallbackTimeoutError", "timed out"),
+        ("CallbackError", "internal callback boom"),
+    ],
+)
+def test_failed_callback_reconstructs_typed_error_on_replay(
+    checkpointed_type: str, message: str
+):
+    """A pre-seeded FAILED wait_for_callback context resurfaces the typed callback
+    error on replay (the CallbackError family passes through unchanged), without
+    re-running the submitter (reconstruction path)."""
+    submitter_runs = {"count": 0}
+
+    def submitter(_callback_id, _ctx) -> None:
+        submitter_runs["count"] += 1
+
+    @durable_execution
+    def my_handler(event, context: DurableContext) -> str:
+        return context.wait_for_callback(submitter, name="await-external")
+
+    # The wait_for_callback child context is the first top-level operation.
+    wfc_id = next(operation_id_sequence())
+
+    with patch(
+        "aws_durable_execution_sdk_python.execution.LambdaClient"
+    ) as mock_client_class:
+        mock_client = Mock()
+        mock_client_class.initialize_client.return_value = mock_client
+
+        mock_checkpoint, _checkpoint_calls = create_mock_checkpoint_with_operations()
+        mock_client.checkpoint = mock_checkpoint
+
+        event = {
+            "DurableExecutionArn": "test-arn/execution-1",
+            "CheckpointToken": "test-token",
+            "InitialExecutionState": {
+                "Operations": [
+                    {
+                        "Id": "execution-1",
+                        "Type": "EXECUTION",
+                        "Status": "STARTED",
+                        "ExecutionDetails": {"InputPayload": "{}"},
+                    },
+                    {
+                        "Id": wfc_id,
+                        "Type": "CONTEXT",
+                        "Status": "FAILED",
+                        "SubType": "WaitForCallback",
+                        "ParentId": "execution-1",
+                        "ContextDetails": {
+                            "Error": {
+                                "ErrorType": checkpointed_type,
+                                "ErrorMessage": message,
+                            }
+                        },
+                    },
+                ],
+                "NextMarker": "",
+            },
+            "LocalRunner": True,
+        }
+
+        result = my_handler(event, _lambda_context())
+
+        assert result["Status"] == InvocationStatus.FAILED.value
+        assert result["Error"]["ErrorType"] == checkpointed_type
+        assert result["Error"]["ErrorMessage"] == message
+        # Replay short-circuits from the FAILED checkpoint; the submitter never runs.
+        assert submitter_runs["count"] == 0
+
+
+def test_failed_submitter_reconstructs_callback_submitter_error_on_replay():
+    """A failed submitter records StepError at the context level but surfaces
+    CallbackSubmitterError to the caller on replay (console-parity contract)."""
+    submitter_runs = {"count": 0}
+
+    def submitter(_callback_id, _ctx) -> None:
+        submitter_runs["count"] += 1
+
+    @durable_execution
+    def my_handler(event, context: DurableContext) -> str:
+        return context.wait_for_callback(submitter, name="await-external")
+
+    wfc_id = next(operation_id_sequence())
+
+    with patch(
+        "aws_durable_execution_sdk_python.execution.LambdaClient"
+    ) as mock_client_class:
+        mock_client = Mock()
+        mock_client_class.initialize_client.return_value = mock_client
+
+        mock_checkpoint, _checkpoint_calls = create_mock_checkpoint_with_operations()
+        mock_client.checkpoint = mock_checkpoint
+
+        event = {
+            "DurableExecutionArn": "test-arn/execution-1",
+            "CheckpointToken": "test-token",
+            "InitialExecutionState": {
+                "Operations": [
+                    {
+                        "Id": "execution-1",
+                        "Type": "EXECUTION",
+                        "Status": "STARTED",
+                        "ExecutionDetails": {"InputPayload": "{}"},
+                    },
+                    {
+                        "Id": wfc_id,
+                        "Type": "CONTEXT",
+                        "Status": "FAILED",
+                        "SubType": "WaitForCallback",
+                        "ParentId": "execution-1",
+                        "ContextDetails": {
+                            "Error": {
+                                "ErrorType": "StepError",
+                                "ErrorMessage": "submitter boom",
+                            }
+                        },
+                    },
+                ],
+                "NextMarker": "",
+            },
+            "LocalRunner": True,
+        }
+
+        result = my_handler(event, _lambda_context())
+
+        assert result["Status"] == InvocationStatus.FAILED.value
+        assert result["Error"]["ErrorType"] == "CallbackSubmitterError"
+        assert result["Error"]["ErrorMessage"] == "submitter boom"
+        assert submitter_runs["count"] == 0

--- a/packages/aws-durable-execution-sdk-python/tests/exceptions_test.py
+++ b/packages/aws-durable-execution-sdk-python/tests/exceptions_test.py
@@ -9,6 +9,10 @@ from botocore.exceptions import ClientError  # type: ignore[import-untyped]
 from aws_durable_execution_sdk_python.exceptions import (
     _DURABLE_OPERATION_ERROR_REGISTRY,
     BotoClientError,
+    CallbackError,
+    CallbackExternalError,
+    CallbackSubmitterError,
+    CallbackTimeoutError,
     ChildContextError,
     CheckpointError,
     CheckpointErrorCategory,
@@ -242,7 +246,16 @@ def test_durable_operation_error_with_none_message():
 
 @pytest.mark.parametrize(
     "error_cls",
-    [StepError, InvokeError, ChildContextError, WaitForConditionError],
+    [
+        StepError,
+        InvokeError,
+        ChildContextError,
+        WaitForConditionError,
+        CallbackError,
+        CallbackExternalError,
+        CallbackTimeoutError,
+        CallbackSubmitterError,
+    ],
 )
 def test_operation_error_subclasses(error_cls):
     """Each per-operation subclass derives from DurableOperationError and self-types."""
@@ -262,6 +275,78 @@ def test_operation_error_registry_contains_all_subclasses():
         _DURABLE_OPERATION_ERROR_REGISTRY["WaitForConditionError"]
         is WaitForConditionError
     )
+    assert _DURABLE_OPERATION_ERROR_REGISTRY["CallbackError"] is CallbackError
+    assert (
+        _DURABLE_OPERATION_ERROR_REGISTRY["CallbackExternalError"]
+        is CallbackExternalError
+    )
+    assert (
+        _DURABLE_OPERATION_ERROR_REGISTRY["CallbackTimeoutError"]
+        is CallbackTimeoutError
+    )
+    assert (
+        _DURABLE_OPERATION_ERROR_REGISTRY["CallbackSubmitterError"]
+        is CallbackSubmitterError
+    )
+
+
+# =============================================================================
+# Callback error hierarchy
+# =============================================================================
+
+
+def test_callback_error_is_durable_operation_error_not_termination():
+    """CallbackError is a DurableOperationError, separate from the termination tree."""
+    error = CallbackError("callback failed")
+    assert isinstance(error, DurableOperationError)
+    assert isinstance(error, DurableExecutionsError)
+    # Termination-tree errors are a separate hierarchy carrying a termination_reason.
+    assert not isinstance(error, ExecutionError)
+    assert not isinstance(error, UnrecoverableError)
+    assert not hasattr(error, "termination_reason")
+
+
+def test_callback_error_defaults():
+    """CallbackError defaults error_type to its class name and carries no callback_id."""
+    error = CallbackError("boom")
+    assert error.message == "boom"
+    assert error.error_type == "CallbackError"
+    assert error.data is None
+    assert error.stack_trace is None
+    assert not hasattr(error, "callback_id")
+
+
+@pytest.mark.parametrize(
+    "error_cls",
+    [CallbackExternalError, CallbackTimeoutError, CallbackSubmitterError],
+)
+def test_graded_callback_errors_subclass_callback_error(error_cls):
+    """The graded callback errors subclass CallbackError so `except CallbackError` catches all."""
+    error = error_cls("failed")
+    assert isinstance(error, CallbackError)
+    assert isinstance(error, DurableOperationError)
+    assert error.error_type == error_cls.__name__
+
+
+@pytest.mark.parametrize(
+    "error_cls",
+    [
+        CallbackError,
+        CallbackExternalError,
+        CallbackTimeoutError,
+        CallbackSubmitterError,
+    ],
+)
+def test_from_error_fields_reconstructs_callback_types(error_cls):
+    """from_error_fields rebuilds each callback type from its class-name discriminator."""
+    error = DurableOperationError.from_error_fields(
+        error_cls.__name__, "callback boom", "payload", ["frame"]
+    )
+    assert isinstance(error, error_cls)
+    assert error.error_type == error_cls.__name__
+    assert error.message == "callback boom"
+    assert error.data == "payload"
+    assert error.stack_trace == ["frame"]
 
 
 def test_from_error_fields_user_subclass_falls_back_without_typeerror():

--- a/packages/aws-durable-execution-sdk-python/tests/operation/callback_test.py
+++ b/packages/aws-durable-execution-sdk-python/tests/operation/callback_test.py
@@ -12,7 +12,12 @@ from aws_durable_execution_sdk_python.config import (
     WaitForCallbackConfig,
 )
 from aws_durable_execution_sdk_python.context import Callback
-from aws_durable_execution_sdk_python.exceptions import CallbackError, ValidationError
+from aws_durable_execution_sdk_python.exceptions import (
+    CallbackError,
+    CallbackExternalError,
+    CallbackTimeoutError,
+    ValidationError,
+)
 from aws_durable_execution_sdk_python.identifier import OperationIdentifier
 from aws_durable_execution_sdk_python.lambda_service import (
     CallbackDetails,
@@ -1272,8 +1277,8 @@ def test_callback_result_raises_error_for_failed_callbacks():
         serdes=None,
     )
 
-    # Verify that result() raises CallbackError
-    with pytest.raises(CallbackError, match="Callback failed"):
+    # A FAILED callback surfaces as CallbackExternalError (a CallbackError).
+    with pytest.raises(CallbackExternalError, match="Callback failed"):
         callback.result()
 
 
@@ -1309,8 +1314,8 @@ def test_callback_result_raises_error_for_timed_out_callbacks():
         serdes=None,
     )
 
-    # Verify that result() raises CallbackError
-    with pytest.raises(CallbackError, match="Callback timed out"):
+    # A TIMED_OUT callback surfaces as CallbackTimeoutError (a CallbackError).
+    with pytest.raises(CallbackTimeoutError, match="Callback timed out"):
         callback.result()
 
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-durable-execution-sdk-python/issues/313
https://github.com/aws/aws-durable-execution-sdk-python/issues/564

*Description of changes:*
```
DurableOperationError
-> CallbackError            # base; internal-invariant case; keeps callback_id
---> CallbackExternalError  # callback FAILED (SendDurableExecutionCallbackFailure)
---> CallbackTimeoutError   # callback TIMED_OUT (timeout / heartbeat)
---> CallbackSubmitterError # submitter step failed
```


Before this change, callback failures collapsed into a generic error: a failed callback surfaced as `ChildContextError` and callers couldn't distinguish an external failure from a timeout or a submitter failure. Now each surfaces as a specific, catchable type.

### What changed

- `CallbackError` now subclasses `DurableOperationError` (plain subclass, no custom constructor - it inherits `message`, `error_type`, `data`, `stack_trace`). Dropped the unused `TerminationReason.CALLBACK_ERROR`.

- `Callback.result()` grades terminal failures: `TIMED_OUT` → `CallbackTimeoutError`; other terminal (external `FAILED`, cancelled, stopped) → `CallbackExternalError`; missing-operation invariant → base `CallbackError`. Preserves `message` / `data` / `stack_trace`.

- `wait_for_callback` translates at its own call site: the `CallbackError` family passes through unchanged; a submitter `StepError` becomes `CallbackSubmitterError`; anything else re-raises as the generic `ChildContextError`. Replay-safe: `run_in_child_context` re-raises from the FAILED checkpoint on replay, so the `except` fires identically on first run and replay.

- `callback_id` is not carried on callback errors. It isn't an error wire field, so it can't survive the `wait_for_callback` child-context boundary, and once that context is terminal (`replay_children=false`) its child operations are dropped from later invocations' `InitialExecutionState` - the CALLBACK op, and any id derived from it, is absent on replay. Rather than expose a field that is populated on first run and `None` after replay, we omit it; the caller already holds it from `create_callback()` / the submitter argument.

- No synthetic `__cause__` on terminal failures. The graded errors don't chain a reconstructed cause - it would only duplicate `message` / `data` / `stack_trace` already on the error, and the original external `ErrorType` remains on the CALLBACK operation's details for anyone who needs it. 

- Registered the four callback types in `_DURABLE_OPERATION_ERROR_REGISTRY` so they reconstruct on replay (including when `wait_for_callback` is nested in another child context); exported them from the package root.

### Breaking change

`CallbackError` is no longer an `ExecutionError`. Execution outcome is unchanged: the top-level `except Exception` still returns FAILED with no retry.

### Testing

- Unit tests
- Core integration tests
- Example integration tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
