### PR TITLE
fix(plugin): make InvocationEndInfo status required

### DIFF
--- a/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/plugin.py
+++ b/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/plugin.py
@@ -172,7 +172,7 @@ class InvocationStartInfo(InvocationInfo):
 
 @dataclass(frozen=True)
 class InvocationEndInfo(InvocationInfo):
-    status: InvocationStatus | None = None
+    status: InvocationStatus = field(kw_only=True)
     error: ErrorObject | None = None
 
     @classmethod


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Follow up to https://github.com/aws/aws-durable-execution-sdk-python/pull/561

Make `InvocationEndInfo InvocationStatus` mandatory.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
