### PR TITLE
fix(otel): preserve retried operation start spans

### DIFF
--- a/packages/aws-durable-execution-sdk-python-otel/tests/test_plugin.py
+++ b/packages/aws-durable-execution-sdk-python-otel/tests/test_plugin.py
@@ -320,6 +320,51 @@ def test_replayed_operation_start_emits_continuation_span_with_link():
     )
 
 
+def test_retried_operation_start_emits_continuation_span_with_link():
+    """Retried operation spans should not reuse the original deterministic span ID."""
+    plugin, exporter = _create_plugin()
+    plugin.on_invocation_start(_invocation_start_info())
+    operation_id = "step-retried"
+    random_span_id = int("abcdef1234567890", 16)
+    plugin._id_generator._fallback_id_generator.generate_span_id = lambda: (
+        random_span_id
+    )
+
+    plugin.on_operation_start(
+        OperationStartInfo(
+            operation_id=operation_id,
+            operation_type=OperationType.STEP,
+            sub_type=OperationSubType.STEP,
+            name="retried-step",
+            parent_id=None,
+            start_time=START_TIME,
+            is_replayed=True,
+            status=OperationStatus.STARTED,
+        )
+    )
+    plugin.on_operation_end(
+        OperationEndInfo(
+            operation_id=operation_id,
+            operation_type=OperationType.STEP,
+            sub_type=OperationSubType.STEP,
+            name="retried-step",
+            parent_id=None,
+            start_time=START_TIME,
+            is_replayed=False,
+            status=OperationStatus.SUCCEEDED,
+            end_time=END_TIME,
+            error=None,
+        )
+    )
+
+    span = exporter.get_finished_spans()[0]
+    assert span.name == "retried-step"
+    assert span.context.span_id == random_span_id
+    assert span.links[0].context.span_id == operation_id_to_span_id(
+        EXECUTION_ARN, operation_id
+    )
+
+
 def test_step_operation_span_parents_attempt_span():
     """STEP operations have a logical span with attempt spans beneath it."""
     plugin, exporter = _create_plugin()

--- a/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/plugin.py
+++ b/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/plugin.py
@@ -375,14 +375,18 @@ class PluginExecutor:
         )
 
     def on_operation_action(
-        self, update: OperationUpdate, operation: Operation | None = None
+        self,
+        update: OperationUpdate,
+        operation: Operation | None = None,
+        previous_operation: Operation | None = None,
     ):
         """Execute any registered plugins for a given operation when an update is checkpointed
 
         Args:
             update: the operation update that is checkpointed
+            operation: the operation after the checkpoint
+            previous_operation: the operation before the checkpoint
         """
-        # todo: this could be called more than once for step when it's retried
         if update.action is OperationAction.START:
             # we handle only START action here because on_operation_update may not be able to see a STARTED update
             # when START is checkpointed in batch with terminal status updates.
@@ -394,7 +398,7 @@ class PluginExecutor:
                     name=update.name,
                     parent_id=update.parent_id,
                     start_time=operation.start_timestamp if operation else None,
-                    is_replayed=False,
+                    is_replayed=previous_operation is not None,
                     status=OperationStatus.STARTED,
                 ),
                 sync=True,

--- a/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/state.py
+++ b/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/state.py
@@ -761,7 +761,9 @@ class ExecutionState:
                     )
                     for update in updates:
                         self._plugin_executor.on_operation_action(
-                            update, self.operations.get(update.operation_id)
+                            update,
+                            self.operations.get(update.operation_id),
+                            previous_operations.get(update.operation_id),
                         )
 
                     self._plugin_executor.on_operation_update(

--- a/packages/aws-durable-execution-sdk-python/tests/plugin_test.py
+++ b/packages/aws-durable-execution-sdk-python/tests/plugin_test.py
@@ -553,6 +553,7 @@ class TestPluginExecutorOnOperationAction(unittest.TestCase):
 
         self.assertIn("operation_start:op-1", self.plugin.calls)
         self.assertEqual(captured[0].status, OperationStatus.STARTED)
+        self.assertFalse(captured[0].is_replayed)
 
     def test_start_action_uses_server_start_timestamp(self):
         captured: list[OperationStartInfo] = []
@@ -583,6 +584,44 @@ class TestPluginExecutorOnOperationAction(unittest.TestCase):
             self.executor.on_operation_action(update, operation)
 
         self.assertEqual(captured[0].start_time, START_TS)
+
+    def test_start_action_for_existing_operation_is_replayed(self):
+        captured: list[OperationStartInfo] = []
+
+        class _CapturingPlugin(_TrackingPlugin):
+            def on_operation_start(self, info: OperationStartInfo) -> None:
+                super().on_operation_start(info)
+                captured.append(info)
+
+        self.plugin = _CapturingPlugin()
+        self.executor = PluginExecutor(plugins=[self.plugin])
+        update = MagicMock()
+        update.action = OperationAction.START
+        update.operation_id = "op-1"
+        update.operation_type = OperationType.STEP
+        update.sub_type = OperationSubType.STEP
+        update.name = "my-step"
+        update.parent_id = "parent-1"
+
+        current_operation = Operation(
+            operation_id="op-1",
+            operation_type=OperationType.STEP,
+            status=OperationStatus.STARTED,
+        )
+        previous_operation = Operation(
+            operation_id="op-1",
+            operation_type=OperationType.STEP,
+            status=OperationStatus.READY,
+        )
+
+        with self.executor.run():
+            self.executor.on_operation_action(
+                update,
+                operation=current_operation,
+                previous_operation=previous_operation,
+            )
+
+        self.assertTrue(captured[0].is_replayed)
 
     def test_non_start_action_does_not_fire(self):
         update = MagicMock()

--- a/packages/aws-durable-execution-sdk-python/tests/state_test.py
+++ b/packages/aws-durable-execution-sdk-python/tests/state_test.py
@@ -41,6 +41,7 @@ from aws_durable_execution_sdk_python.lambda_service import (
 )
 from aws_durable_execution_sdk_python.plugin import (
     DurableInstrumentationPlugin,
+    OperationStartInfo,
     PluginExecutor,
     UserFunctionEndInfo,
 )
@@ -3867,6 +3868,7 @@ class _RecordingPlugin(DurableInstrumentationPlugin):
 
     def __init__(self) -> None:
         self.calls: list[str] = []
+        self.operation_starts: list[OperationStartInfo] = []
 
     def on_execution_start(self, info):
         self.calls.append("execution_start")
@@ -3882,6 +3884,7 @@ class _RecordingPlugin(DurableInstrumentationPlugin):
 
     def on_operation_start(self, info):
         self.calls.append(f"operation_start:{info.operation_id}")
+        self.operation_starts.append(info)
 
     def on_operation_end(self, info):
         self.calls.append(f"operation_end:{info.operation_id}")
@@ -3963,6 +3966,59 @@ def test_plugin_executor_on_operation_action_called_on_checkpoint():
 
     # on_operation_action is called for START updates
     assert "operation_start:step-1" in plugin.calls
+    assert plugin.operation_starts[0].is_replayed is False
+
+
+def test_existing_operation_start_is_reported_as_replayed():
+    """A repeated START checkpoint reports that the operation already existed."""
+    mock_client = create_autospec(LambdaClient)
+    previous_step = Operation(
+        operation_id="step-1",
+        operation_type=OperationType.STEP,
+        status=OperationStatus.READY,
+        step_details=StepDetails(attempt=1),
+    )
+    completed_step = Operation(
+        operation_id="step-1",
+        operation_type=OperationType.STEP,
+        status=OperationStatus.SUCCEEDED,
+        step_details=StepDetails(attempt=2, result='"done"'),
+    )
+    mock_client.checkpoint.return_value = CheckpointOutput(
+        checkpoint_token="new_token",  # noqa: S106
+        new_execution_state=CheckpointUpdatedExecutionState(
+            operations=[completed_step],
+            next_marker=None,
+        ),
+    )
+
+    plugin = _RecordingPlugin()
+    plugin_executor = PluginExecutor(plugins=[plugin])
+    with plugin_executor.run():
+        state = ExecutionState(
+            durable_execution_arn="test_arn",
+            initial_checkpoint_token="token123",  # noqa: S106
+            operations={"step-1": previous_step},
+            service_client=mock_client,
+            plugin_executor=plugin_executor,
+        )
+
+        executor = ThreadPoolExecutor(max_workers=1)
+        executor.submit(state.checkpoint_batches_forever)
+
+        try:
+            operation_update = OperationUpdate(
+                operation_id="step-1",
+                operation_type=OperationType.STEP,
+                action=OperationAction.START,
+                name="my-step",
+            )
+            state.create_checkpoint(operation_update, is_sync=True)
+        finally:
+            state.stop_checkpointing()
+            executor.shutdown(wait=True)
+
+    assert plugin.operation_starts[0].is_replayed is True
 
 
 def test_plugin_executor_on_operation_update_called_for_terminal_operations():


### PR DESCRIPTION
## Summary
- correct `OperationStartInfo.is_replayed` for repeated START checkpoints by checking whether the logical operation existed before the checkpoint
- keep the plugin interface unchanged; no continuation-specific field is added
- let the OTel plugin emit retry and polling continuation spans with a fresh span ID linked to the deterministic initial operation span
- cover initial starts, repeated starts, batched terminal responses, and OTel span links

## Root cause
Retried STEP and wait-for-condition operations checkpoint START more than once for the same operation ID. The SDK hardcoded `OperationStartInfo.is_replayed=False` for every START, so the OTel plugin reused the deterministic operation span ID. X-Ray collapsed the earlier STARTED span into the later terminal span, causing cases 3 and 9 in aws/aws-durable-execution-conformance-tests#12 to fail.

## Solution
`ExecutionState` now supplies the operation snapshot from before the checkpoint to `PluginExecutor`. A START is reported with `is_replayed=True` when that logical operation already existed. OTel already treats replayed operation starts as existing spans, generating a random continuation span ID and linking it to the deterministic initial span.

## Verification
- `hatch run dev-core:python -m pytest packages/aws-durable-execution-sdk-python/tests/plugin_test.py packages/aws-durable-execution-sdk-python/tests/state_test.py -q` (196 passed)
- `hatch run dev-otel:python -m pytest packages/aws-durable-execution-sdk-python-otel/tests/test_plugin.py -q` (23 passed)
- `hatch run test:all` (2934 passed, 2 skipped)
- `hatch run dev-core:typecheck`
- `hatch run dev-otel:typecheck`
- `hatch fmt --check` for core and OTel
- `hatch run python .github/scripts/lintcommit.py`