### PR TITLE
test: add parallel and map early-stop cases

### DIFF
--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/map/map_fail_fast.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/map/map_fail_fast.py
@@ -1,0 +1,33 @@
+"""9-5: Map fail-fast (tolerated-failure-count=0) stops after first failure."""
+
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import CompletionConfig, MapConfig
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+def map_fn(_ctx: DurableContext, item: str, _index: int, _items: Any) -> str:
+    if item == "fail":
+        raise RuntimeError("item failed")
+    return item
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> dict:
+    result = context.map(
+        ["ok", "fail", "never"],
+        map_fn,
+        name="failfast",
+        config=MapConfig(
+            max_concurrency=1,
+            completion_config=CompletionConfig(tolerated_failure_count=0),
+        ),
+    )
+    return {
+        "completionReason": result.completion_reason.value,
+        "status": result.status.value,
+        "successCount": result.success_count,
+        "failureCount": result.failure_count,
+        "totalCount": result.total_count,
+    }

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/map/map_min_successful.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/map/map_min_successful.py
@@ -1,0 +1,29 @@
+"""9-7: Map min-successful early completion."""
+
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import CompletionConfig, MapConfig
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+def map_fn(_ctx: DurableContext, item: str, _index: int, _items: Any) -> str:
+    return item
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> dict:
+    result = context.map(
+        ["s0", "s1", "s2", "s3"],
+        map_fn,
+        name="min-successful",
+        config=MapConfig(
+            max_concurrency=1,
+            completion_config=CompletionConfig(min_successful=2),
+        ),
+    )
+    return {
+        "completionReason": result.completion_reason.value,
+        "successCount": result.success_count,
+        "totalCount": result.total_count,
+    }

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/map/map_throw_if_error.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/map/map_throw_if_error.py
@@ -1,0 +1,29 @@
+"""9-6: Map throw-if-error propagates an item failure to the execution."""
+
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import CompletionConfig, MapConfig
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+def map_fn(_ctx: DurableContext, item: str, _index: int, _items: Any) -> str:
+    if item == "fail":
+        raise RuntimeError("item failed")
+    return item
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> list:
+    result = context.map(
+        ["fail", "never"],
+        map_fn,
+        name="throwing",
+        config=MapConfig(
+            max_concurrency=1,
+            completion_config=CompletionConfig(tolerated_failure_count=0),
+        ),
+    )
+    # Rethrow the first item failure; uncaught -> the execution fails.
+    result.throw_if_error()
+    return result.get_results()

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/map/map_tolerated_exceeded.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/map/map_tolerated_exceeded.py
@@ -1,0 +1,32 @@
+"""9-9: Map tolerated-failure-count exceeded (stops early)."""
+
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import CompletionConfig, MapConfig
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+def map_fn(_ctx: DurableContext, item: str, _index: int, _items: Any) -> str:
+    if item != "never":
+        raise RuntimeError("item failed")
+    return item
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> dict:
+    result = context.map(
+        ["f0", "f1", "never"],
+        map_fn,
+        name="tolerated-exceeded",
+        config=MapConfig(
+            max_concurrency=1,
+            completion_config=CompletionConfig(tolerated_failure_count=1),
+        ),
+    )
+    return {
+        "completionReason": result.completion_reason.value,
+        "successCount": result.success_count,
+        "failureCount": result.failure_count,
+        "totalCount": result.total_count,
+    }

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/map/map_tolerated_pct.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/map/map_tolerated_pct.py
@@ -1,0 +1,32 @@
+"""9-10: Map tolerated-failure-percentage exceeded (stops early)."""
+
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import CompletionConfig, MapConfig
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+def map_fn(_ctx: DurableContext, item: str, _index: int, _items: Any) -> str:
+    if item != "never":
+        raise RuntimeError("item failed")
+    return item
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> dict:
+    result = context.map(
+        ["f0", "f1", "never", "never"],
+        map_fn,
+        name="tolerated-pct",
+        config=MapConfig(
+            max_concurrency=1,
+            completion_config=CompletionConfig(tolerated_failure_percentage=25),
+        ),
+    )
+    return {
+        "completionReason": result.completion_reason.value,
+        "successCount": result.success_count,
+        "failureCount": result.failure_count,
+        "totalCount": result.total_count,
+    }

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/parallel/parallel_bad_concurrency.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/parallel/parallel_bad_concurrency.py
@@ -1,0 +1,26 @@
+"""8-19: Parallel with invalid max-concurrency raises a validation error."""
+
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import ParallelConfig
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+def branch_a(_ctx: DurableContext) -> str:
+    return "a"
+
+
+def branch_b(_ctx: DurableContext) -> str:
+    return "b"
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> list:
+    # max_concurrency=0 is invalid; the SDK should reject it before any branch runs.
+    result = context.parallel(
+        [branch_a, branch_b],
+        name="bad-concurrency",
+        config=ParallelConfig(max_concurrency=0),
+    )
+    return result.get_results()

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/parallel/parallel_combined_config.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/parallel/parallel_combined_config.py
@@ -1,0 +1,40 @@
+"""8-18: Parallel with combined completion config (min-successful + tolerated-failure-count)."""
+
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import CompletionConfig, ParallelConfig
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+def branch_fail(_ctx: DurableContext) -> str:
+    raise RuntimeError("branch failed")
+
+
+def ok2(_ctx: DurableContext) -> str:
+    return "ok2"
+
+
+def ok3(_ctx: DurableContext) -> str:
+    return "ok3"
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> dict:
+    result = context.parallel(
+        [branch_fail, branch_fail, ok2, ok3],
+        name="combined",
+        config=ParallelConfig(
+            max_concurrency=1,
+            completion_config=CompletionConfig(
+                min_successful=3, tolerated_failure_count=1
+            ),
+        ),
+    )
+    # totalCount = started branches (succeeded + failed); matches Java's succeeded()+failed().
+    return {
+        "completionReason": result.completion_reason.value,
+        "successCount": result.success_count,
+        "failureCount": result.failure_count,
+        "totalCount": result.total_count,
+    }

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/parallel/parallel_fail_fast.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/parallel/parallel_fail_fast.py
@@ -1,0 +1,41 @@
+"""8-6: Parallel fail-fast (tolerated-failure-count=0) stops after first failure."""
+
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import CompletionConfig, ParallelConfig
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+def branch_ok(_ctx: DurableContext) -> str:
+    return "ok"
+
+
+def branch_fail(_ctx: DurableContext) -> str:
+    raise RuntimeError("branch failed")
+
+
+def branch_never(_ctx: DurableContext) -> str:
+    return "never"
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> dict:
+    # Fail-fast: tolerated_failure_count=0 stops on the first failure (portable across SDKs).
+    result = context.parallel(
+        [branch_ok, branch_fail, branch_never],
+        name="failfast",
+        config=ParallelConfig(
+            max_concurrency=1,
+            completion_config=CompletionConfig(tolerated_failure_count=0),
+        ),
+    )
+    # totalCount = started branches (succeeded + failed); early-stopped
+    # branches are not counted, matching Java's succeeded()+failed().
+    return {
+        "completionReason": result.completion_reason.value,
+        "status": result.status.value,
+        "successCount": result.success_count,
+        "failureCount": result.failure_count,
+        "totalCount": result.total_count,
+    }

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/parallel/parallel_min_not_reached.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/parallel/parallel_min_not_reached.py
@@ -1,0 +1,39 @@
+"""8-17: Parallel min-successful not reached (all branches run)."""
+
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import CompletionConfig, ParallelConfig
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+def ok0(_ctx: DurableContext) -> str:
+    return "ok0"
+
+
+def branch_fail(_ctx: DurableContext) -> str:
+    raise RuntimeError("branch failed")
+
+
+def ok2(_ctx: DurableContext) -> str:
+    return "ok2"
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> dict:
+    result = context.parallel(
+        [ok0, branch_fail, ok2],
+        name="min-not-reached",
+        config=ParallelConfig(
+            max_concurrency=1,
+            completion_config=CompletionConfig(min_successful=3),
+        ),
+    )
+    # totalCount = started branches (succeeded + failed); matches Java's succeeded()+failed().
+    return {
+        "completionReason": result.completion_reason.value,
+        "status": result.status.value,
+        "successCount": result.success_count,
+        "failureCount": result.failure_count,
+        "totalCount": result.total_count,
+    }

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/parallel/parallel_min_successful.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/parallel/parallel_min_successful.py
@@ -1,0 +1,42 @@
+"""8-8: Parallel min-successful early completion."""
+
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import CompletionConfig, ParallelConfig
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+def branch0(_ctx: DurableContext) -> str:
+    return "s0"
+
+
+def branch1(_ctx: DurableContext) -> str:
+    return "s1"
+
+
+def branch2(_ctx: DurableContext) -> str:
+    return "s2"
+
+
+def branch3(_ctx: DurableContext) -> str:
+    return "s3"
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> dict:
+    result = context.parallel(
+        [branch0, branch1, branch2, branch3],
+        name="min-successful",
+        config=ParallelConfig(
+            max_concurrency=1,
+            completion_config=CompletionConfig(min_successful=2),
+        ),
+    )
+    # totalCount = started branches (succeeded + failed); early-stopped
+    # branches are not counted, matching Java's succeeded()+failed().
+    return {
+        "completionReason": result.completion_reason.value,
+        "successCount": result.success_count,
+        "totalCount": result.total_count,
+    }

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/parallel/parallel_throw_if_error.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/parallel/parallel_throw_if_error.py
@@ -1,0 +1,31 @@
+"""8-7: Parallel throw-if-error propagates a branch failure to the execution (fail-fast config)."""
+
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import CompletionConfig, ParallelConfig
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+def branch_fail(_ctx: DurableContext) -> str:
+    raise RuntimeError("branch failed")
+
+
+def branch_never(_ctx: DurableContext) -> str:
+    return "never"
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> list:
+    # Fail-fast: tolerated_failure_count=0 stops on the first failure (portable across SDKs).
+    result = context.parallel(
+        [branch_fail, branch_never],
+        name="throwing",
+        config=ParallelConfig(
+            max_concurrency=1,
+            completion_config=CompletionConfig(tolerated_failure_count=0),
+        ),
+    )
+    # Rethrow the first branch failure; uncaught -> the execution fails.
+    result.throw_if_error()
+    return result.get_results()

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/parallel/parallel_tolerated_exceeded.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/parallel/parallel_tolerated_exceeded.py
@@ -1,0 +1,39 @@
+"""8-10: Parallel tolerated-failure-count exceeded (stops early)."""
+
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import CompletionConfig, ParallelConfig
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+def branch0(_ctx: DurableContext) -> str:
+    raise RuntimeError("branch failed")
+
+
+def branch1(_ctx: DurableContext) -> str:
+    raise RuntimeError("branch failed")
+
+
+def branch2(_ctx: DurableContext) -> str:
+    return "never"
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> dict:
+    result = context.parallel(
+        [branch0, branch1, branch2],
+        name="tolerated-exceeded",
+        config=ParallelConfig(
+            max_concurrency=1,
+            completion_config=CompletionConfig(tolerated_failure_count=1),
+        ),
+    )
+    # totalCount = started branches (succeeded + failed); early-stopped
+    # branches are not counted, matching Java's succeeded()+failed().
+    return {
+        "completionReason": result.completion_reason.value,
+        "successCount": result.success_count,
+        "failureCount": result.failure_count,
+        "totalCount": result.total_count,
+    }

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/parallel/parallel_tolerated_pct.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/parallel/parallel_tolerated_pct.py
@@ -1,0 +1,43 @@
+"""8-13: Parallel tolerated-failure-percentage exceeded (stops early)."""
+
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import CompletionConfig, ParallelConfig
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+def branch0(_ctx: DurableContext) -> str:
+    raise RuntimeError("branch failed")
+
+
+def branch1(_ctx: DurableContext) -> str:
+    raise RuntimeError("branch failed")
+
+
+def branch2(_ctx: DurableContext) -> str:
+    return "never"
+
+
+def branch3(_ctx: DurableContext) -> str:
+    return "never"
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> dict:
+    result = context.parallel(
+        [branch0, branch1, branch2, branch3],
+        name="tolerated-pct",
+        config=ParallelConfig(
+            max_concurrency=1,
+            completion_config=CompletionConfig(tolerated_failure_percentage=25),
+        ),
+    )
+    # totalCount = started branches (succeeded + failed); early-stopped
+    # branches are not counted, matching Java's succeeded()+failed().
+    return {
+        "completionReason": result.completion_reason.value,
+        "successCount": result.success_count,
+        "failureCount": result.failure_count,
+        "totalCount": result.total_count,
+    }

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/template_map.yaml
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/template_map.yaml
@@ -88,6 +88,51 @@ Resources:
       DurableConfig:
         RetentionPeriodInDays: 7
         ExecutionTimeout: 300
+  MapFailFast:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["9-5"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: map.map_fail_fast.handler
+      Description: Map fail-fast (tolerated-failure-count=0) stops after first failure
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  MapThrowIfError:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["9-6"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: map.map_throw_if_error.handler
+      Description: Map throw-if-error propagates an item failure to the execution
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  MapMinSuccessful:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["9-7"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: map.map_min_successful.handler
+      Description: Map min-successful early completion
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
   MapToleratedWithin:
     Type: AWS::Serverless::Function
     TestingMetadata:
@@ -96,6 +141,36 @@ Resources:
       CodeUri: lambda-build/
       Handler: map.map_tolerated_within.handler
       Description: Map tolerated-failure-count within tolerance (all items complete)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  MapToleratedExceeded:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["9-9"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: map.map_tolerated_exceeded.handler
+      Description: Map tolerated-failure-count exceeded (stops early)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  MapToleratedPct:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["9-10"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: map.map_tolerated_pct.handler
+      Description: Map tolerated-failure-percentage exceeded (stops early)
       Role:
         Fn::GetAtt:
         - DurableFunctionRole

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/template_parallel.yaml
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/template_parallel.yaml
@@ -103,6 +103,52 @@ Resources:
       DurableConfig:
         RetentionPeriodInDays: 7
         ExecutionTimeout: 300
+  ParallelFailFast:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["8-6"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: parallel.parallel_fail_fast.handler
+      Description: Parallel with a fail-fast completion config (tolerated-failure-count=0) stops on
+        the first branch failure
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ParallelThrowIfError:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["8-7"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: parallel.parallel_throw_if_error.handler
+      Description: Parallel where the handler rethrows, propagating a branch failure
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ParallelMinSuccessful:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["8-8"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: parallel.parallel_min_successful.handler
+      Description: Parallel with a min-successful completion config stops early
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
   ParallelTolerated:
     Type: AWS::Serverless::Function
     TestingMetadata:
@@ -111,6 +157,21 @@ Resources:
       CodeUri: lambda-build/
       Handler: parallel.parallel_tolerated_within.handler
       Description: Parallel tolerating one failure completes all branches
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ParallelToleratedExceeded:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["8-10"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: parallel.parallel_tolerated_exceeded.handler
+      Description: Parallel stops early once the failure count exceeds the tolerated-failure-count
       Role:
         Fn::GetAtt:
         - DurableFunctionRole
@@ -141,6 +202,21 @@ Resources:
       CodeUri: lambda-build/
       Handler: parallel.parallel_flat.handler
       Description: Parallel with FLAT nesting executes branches in virtual contexts
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ParallelToleratedPct:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["8-13"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: parallel.parallel_tolerated_pct.handler
+      Description: Parallel stops early once the failure percentage exceeds the tolerated-failure-percentage
       Role:
         Fn::GetAtt:
         - DurableFunctionRole
@@ -186,6 +262,51 @@ Resources:
       CodeUri: lambda-build/
       Handler: parallel.parallel_all_fail.handler
       Description: Parallel where all branches fail (within tolerance)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ParallelMinNotReached:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["8-17"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: parallel.parallel_min_not_reached.handler
+      Description: Parallel min-successful not reached (all branches run)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ParallelCombinedConfig:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["8-18"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: parallel.parallel_combined_config.handler
+      Description: Parallel combined completion config (min-successful + tolerated-failure-count)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ParallelBadConcurrency:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["8-19"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: parallel.parallel_bad_concurrency.handler
+      Description: Parallel with invalid max-concurrency raises a validation error
       Role:
         Fn::GetAtt:
         - DurableFunctionRole


### PR DESCRIPTION
## Summary
Adds the 13 early-stop / completion-config conformance cases that were intentionally omitted from #566:

- **parallel** (8): `8-6` fail-fast, `8-7` throw-if-error, `8-8` min-successful, `8-10` tolerated-count exceeded, `8-13` tolerated-percentage, `8-17` min-not-reached, `8-18` combined config, `8-19` bad concurrency validation
- **map** (5): `9-5` fail-fast, `9-6` throw-if-error, `9-7` min-successful, `9-9` tolerated-count exceeded, `9-10` tolerated-percentage

# The test should pass after #533 is merged