### PR TITLE
test: add child custom-serdes case (3-14)

### DIFF
--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/child/child_custom_serdes.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/child/child_custom_serdes.py
@@ -1,0 +1,41 @@
+"""3-14: Child context with custom serdes (succeed)."""
+
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import ChildConfig
+from aws_durable_execution_sdk_python.context import (
+    DurableContext,
+    StepContext,
+    durable_step,
+    durable_with_child_context,
+)
+from aws_durable_execution_sdk_python.execution import durable_execution
+from aws_durable_execution_sdk_python.serdes import SerDes, SerDesContext
+
+
+class UppercaseSerDes(SerDes[str]):
+    def serialize(self, value: str, _: SerDesContext) -> str:
+        return value.upper()
+
+    def deserialize(self, data: str, _: SerDesContext) -> str:
+        return data
+
+
+@durable_step
+def return_input(_step_context: StepContext, value: str) -> str:
+    return value
+
+
+@durable_with_child_context
+def serdes_child(ctx: DurableContext, value: str) -> str:
+    return ctx.step(return_input(value))
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> str:
+    result: str = context.run_in_child_context(
+        serdes_child(event),
+        name="serdes-child",
+        config=ChildConfig(serdes=UppercaseSerDes()),
+    )
+    return result

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/template_child.yaml
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/template_child.yaml
@@ -250,6 +250,21 @@ Resources:
       DurableConfig:
         RetentionPeriodInDays: 7
         ExecutionTimeout: 300
+  ChildCustomSerdes:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["3-14"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: child.child_custom_serdes.handler
+      Description: Child context with custom serdes (succeed)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
   ChildErrorNoStep:
     Type: AWS::Serverless::Function
     TestingMetadata:


### PR DESCRIPTION
## Summary
Adds the `3-14` **ChildCustomSerdes** conformance case (child context with custom serdes), completing the child suite's requirement coverage (`3-1..3-18`).

The handler is copied unmodified from the validated cross-SDK source and uses the SDK's real custom serdes API — no mocking.

# Should pass after #550 