### PR TITLE
test: add wait-strategy cases (6-5, 6-6)

### DIFF
--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/wait_for_condition/wait_for_condition_fixed_delay.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/wait_for_condition/wait_for_condition_fixed_delay.py
@@ -1,0 +1,34 @@
+"""6-5: Wait-for-condition fixed-delay wait strategy."""
+
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import Duration, JitterStrategy
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+from aws_durable_execution_sdk_python.types import WaitForConditionCheckContext
+from aws_durable_execution_sdk_python.waits import (
+    WaitForConditionConfig,
+    WaitStrategyConfig,
+    create_wait_strategy,
+)
+
+
+@durable_execution
+def handler(event: Any, context: DurableContext) -> int:
+    threshold = int(event)
+
+    def check(state: int, _ctx: WaitForConditionCheckContext) -> int:
+        return state + 1
+
+    config = WaitForConditionConfig(
+        wait_strategy=create_wait_strategy(
+            WaitStrategyConfig(
+                should_continue_polling=lambda s: s < threshold,
+                initial_delay=Duration.from_seconds(2),
+                backoff_rate=1,
+                jitter_strategy=JitterStrategy.NONE,
+            )
+        ),
+        initial_state=0,
+    )
+    return context.wait_for_condition(check=check, config=config)

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/wait_for_condition/wait_for_condition_max_attempts.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/wait_for_condition/wait_for_condition_max_attempts.py
@@ -1,0 +1,33 @@
+"""6-6: Wait-for-condition max attempts exceeded (failure)."""
+
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import Duration, JitterStrategy
+from aws_durable_execution_sdk_python.context import DurableContext
+from aws_durable_execution_sdk_python.execution import durable_execution
+from aws_durable_execution_sdk_python.types import WaitForConditionCheckContext
+from aws_durable_execution_sdk_python.waits import (
+    WaitForConditionConfig,
+    WaitStrategyConfig,
+    create_wait_strategy,
+)
+
+
+@durable_execution
+def handler(_event: Any, context: DurableContext) -> int:
+    def check(state: int, _ctx: WaitForConditionCheckContext) -> int:
+        return state + 1
+
+    config = WaitForConditionConfig(
+        wait_strategy=create_wait_strategy(
+            WaitStrategyConfig(
+                should_continue_polling=lambda _s: True,
+                max_attempts=3,
+                initial_delay=Duration.from_seconds(1),
+                backoff_rate=1,
+                jitter_strategy=JitterStrategy.NONE,
+            )
+        ),
+        initial_state=0,
+    )
+    return context.wait_for_condition(check=check, config=config)

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/template_wait_for_condition.yaml
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/template_wait_for_condition.yaml
@@ -88,6 +88,36 @@ Resources:
       DurableConfig:
         RetentionPeriodInDays: 7
         ExecutionTimeout: 300
+  WaitForConditionFixedDelay:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["6-5"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: wait_for_condition.wait_for_condition_fixed_delay.handler
+      Description: Wait-for-condition with fixed-delay wait strategy
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  WaitForConditionMaxAttempts:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["6-6"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: wait_for_condition.wait_for_condition_max_attempts.handler
+      Description: Wait-for-condition max attempts exceeded (failure)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
   WaitForConditionCheckThrows:
     Type: AWS::Serverless::Function
     TestingMetadata:


### PR DESCRIPTION
## Summary
Adds the two `wait_for_condition` cases that exercise the SDK's **built-in wait strategy** (`create_wait_strategy`), completing the suite's requirement coverage (`6-1..6-13`):

- `6-5` **WaitForConditionFixedDelay** — fixed-delay strategy (2s, no jitter/backoff); each continue decision should checkpoint an intermediate `StepSucceeded` with `NextAttemptDelaySeconds: 2`, suspend, and re-poll until the threshold is met (execution SUCCEEDED, result 3)
- `6-6` **WaitForConditionMaxAttempts** — strategy capped at 3 attempts with a never-satisfied condition; after two continue checkpoints the third poll should raise max-attempts-exceeded and checkpoint a terminal `StepFailed` (execution FAILED)

# Expected to fail until #530 is done