### PR TITLE
fix(otel): classify uncaught invocation errors

### DIFF
--- a/packages/aws-durable-execution-sdk-python-otel/src/aws_durable_execution_sdk_python_otel/plugin.py
+++ b/packages/aws-durable-execution-sdk-python-otel/src/aws_durable_execution_sdk_python_otel/plugin.py
@@ -350,7 +350,7 @@ class OtelPlugin(DurableInstrumentationPlugin):
             invocation_span.set_attribute(
                 "durable.invocation.status", info.status.value
             )
-            if info.status is InvocationStatus.FAILED:
+            if info.status in (InvocationStatus.FAILED, InvocationStatus.RETRY):
                 invocation_span.set_status(
                     StatusCode.ERROR, info.error.message if info.error else ""
                 )

--- a/packages/aws-durable-execution-sdk-python-otel/tests/test_plugin.py
+++ b/packages/aws-durable-execution-sdk-python-otel/tests/test_plugin.py
@@ -175,7 +175,7 @@ def test_invocation_span_records_subsequent_invocation():
     ("invocation_status", "expected_span_status"),
     [
         (InvocationStatus.PENDING, StatusCode.UNSET),
-        (InvocationStatus.RETRY, StatusCode.UNSET),
+        (InvocationStatus.RETRY, StatusCode.ERROR),
         (InvocationStatus.SUCCEEDED, StatusCode.OK),
         (InvocationStatus.FAILED, StatusCode.ERROR),
     ],
@@ -184,7 +184,7 @@ def test_invocation_span_status_reflects_execution_status(
     invocation_status: InvocationStatus,
     expected_span_status: StatusCode,
 ):
-    """Only terminal invocation spans receive a success or failure status."""
+    """Invocation spans reflect successful, failed, and retry outcomes."""
     plugin, exporter = _create_plugin()
 
     plugin.on_invocation_start(_invocation_start_info())

--- a/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/execution.py
+++ b/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/execution.py
@@ -14,6 +14,7 @@ from aws_durable_execution_sdk_python.exceptions import (
     BackgroundThreadError,
     BotoClientError,
     CheckpointError,
+    DurableExecutionsError,
     ExecutionError,
     InvocationError,
     SuspendExecution,
@@ -423,6 +424,11 @@ def durable_execution(
             except Exception as e:
                 # all user-space errors go here
                 logger.exception("Execution failed")
+
+                if not isinstance(e, DurableExecutionsError):
+                    # Preserve the terminal execution response while identifying
+                    # the uncaught handler error in invocation telemetry.
+                    plugin_executor.override_invocation_status(InvocationStatus.RETRY)
 
                 result = DurableExecutionInvocationOutput(
                     status=InvocationStatus.FAILED, error=ErrorObject.from_exception(e)

--- a/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/plugin.py
+++ b/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/plugin.py
@@ -263,6 +263,7 @@ class PluginExecutor:
         self._plugins = plugins or []
         self._executor: ThreadPoolExecutor | None = None
         self._invocation_status: InvocationStartInfo | None = None
+        self._invocation_status_override: InvocationStatus | None = None
 
     @contextlib.contextmanager
     def run(self):
@@ -275,6 +276,7 @@ class PluginExecutor:
             yield
         finally:
             self._invocation_status = None
+            self._invocation_status_override = None
             # Shut down the thread pool, waiting for pending tasks to complete.
             if self._executor:
                 self._executor.shutdown(wait=True)
@@ -329,7 +331,12 @@ class PluginExecutor:
             is_first_invocation=is_first_invocation,
             execution_start_time=execution_start_time,
         )
+        self._invocation_status_override = None
         self.execute_plugins(self._invocation_status, sync=True)
+
+    def override_invocation_status(self, status: InvocationStatus) -> None:
+        """Override the status reported to plugins without changing the output."""
+        self._invocation_status_override = status
 
     def on_invocation_end(
         self,
@@ -338,6 +345,14 @@ class PluginExecutor:
         if self._invocation_status is None:
             # on_invocation_start not called, skip
             return
+
+        if self._invocation_status_override is not None:
+            output = DurableExecutionInvocationOutput(
+                status=self._invocation_status_override,
+                result=output.result,
+                error=output.error,
+            )
+            self._invocation_status_override = None
 
         invocation_end_info = (
             InvocationEndInfo.from_durable_execution_invocation_output(

--- a/packages/aws-durable-execution-sdk-python/tests/execution_test.py
+++ b/packages/aws-durable-execution-sdk-python/tests/execution_test.py
@@ -18,6 +18,7 @@ from aws_durable_execution_sdk_python.exceptions import (
     ExecutionError,
     GetExecutionStateError,
     InvocationError,
+    StepError,
     SuspendExecution,
 )
 from aws_durable_execution_sdk_python.execution import (
@@ -2934,8 +2935,8 @@ def test_durable_execution_with_plugins_success():
     assert "invocation_end:SUCCEEDED" in plugin.calls
 
 
-def test_durable_execution_with_plugins_failure():
-    """Test that plugins receive invocation end and execution end on user error."""
+def test_durable_execution_with_plugins_uncaught_error():
+    """Test that plugins classify an uncaught user error as a retry."""
     mock_client = Mock(spec=DurableServiceClient)
     mock_output = CheckpointOutput(
         checkpoint_token="new_token",  # noqa: S106
@@ -2949,6 +2950,31 @@ def test_durable_execution_with_plugins_failure():
     def test_handler(event: Any, context: DurableContext) -> dict:
         msg = "user error"
         raise ValueError(msg)
+
+    result = test_handler(
+        _make_invocation_input(mock_client),
+        _make_lambda_context(),
+    )
+
+    assert result["Status"] == InvocationStatus.FAILED.value
+    assert "invocation_start" in plugin.calls
+    assert "invocation_end:RETRY" in plugin.calls
+
+
+def test_durable_execution_with_plugins_operation_failure():
+    """Test that plugins classify a durable operation error as failed."""
+    mock_client = Mock(spec=DurableServiceClient)
+    mock_output = CheckpointOutput(
+        checkpoint_token="new_token",  # noqa: S106
+        new_execution_state=CheckpointUpdatedExecutionState(),
+    )
+    mock_client.checkpoint.return_value = mock_output
+
+    plugin = _RecordingPlugin()
+
+    @durable_execution(plugins=[plugin])
+    def test_handler(event: Any, context: DurableContext) -> dict:
+        raise StepError("step failed")
 
     result = test_handler(
         _make_invocation_input(mock_client),


### PR DESCRIPTION
## Summary

- report raw uncaught handler errors to instrumentation as `RETRY` while preserving the terminal `FAILED` durable execution response
- mark `RETRY` invocation spans with OpenTelemetry `ERROR` status
- add regression coverage that keeps durable operation failures classified as `FAILED`

## Root cause

The execution wrapper converts an uncaught handler exception into a `FAILED` durable output before `PluginExecutor` emits the invocation-end event. Instrumentation therefore received `FAILED`, and the OTel plugin also treated an explicit `RETRY` event as `UNSET` rather than `ERROR`.

This caused [OTEL-19](https://github.com/aws/aws-durable-execution-conformance-tests/actions/runs/30063461310/job/89389613751?pr=24) to export an invocation span with `durable.invocation.status: FAILED` instead of the required `RETRY` value.

## Testing

- `hatch run test:all` (`2980 passed, 2 skipped`)
- `hatch run types:check`
- `hatch fmt --check` in the core package
- `hatch fmt --check` in the OTel package
- `hatch run python .github/scripts/lintcommit.py`

The hosted conformance fixture installs the SDK from `main`, so OTEL-19 will consume this fix once the fixture points at this branch or the change lands.

## CI note

The hosted `child`, `map`, and `parallel` conformance jobs fail on the initial run and a targeted rerun. They fail on custom-serdes output and cloud history assertions unrelated to invocation instrumentation. The immediately preceding unrelated PR run [30064400076](https://github.com/aws/aws-durable-execution-sdk-python/actions/runs/30064400076) has the same three failing jobs. All other PR checks pass.
