### PR TITLE
docs: clarify local variable annotations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -218,14 +218,27 @@ good reason to break pattern.
    it easier for you to spot mistaken assumptions that the LLMs might make about the code. The other reason is that it makes the
    experience of developers much easier with intelligent and context-aware autocomplete hints in an IDE.
 
-4. Declare a type definition wherever you declare a variable, even within a function scope and even where it's implied. For example,
-   even though the `str` might be _implied_ because of the `call` return type, make it explicit:
+4. Annotate function and method parameters and return types, including `-> None`, so that mypy checks their bodies. For local
+   variables, rely on type inference when it is precise and evident from the initializer:
 
-```
+```python
 def my_function() -> str:
-  my_var: str = arb.call(1, 2, 3)
-  return f"arb result: {my_var}"
+    my_var = arb.call(1, 2, 3)
+    return f"arb result: {my_var}"
 ```
+
+   Add an explicit local annotation when inference is unavailable, produces `Any`, is too narrow for the intended use, or when
+   the annotation expresses an intentional contract that is not evident from the initializer. Common examples include empty
+   collections, values initialized with `None`, and values returned by untyped dependencies:
+
+```python
+results: list[str] = []
+response: Response | None = None
+payload: Payload = untyped_dependency.load()
+```
+
+   This follows [mypy's documented type inference](https://mypy.readthedocs.io/en/stable/type_inference_and_annotations.html#type-inference)
+   and the [Google Python Style Guide's guidance for internal variables](https://google.github.io/styleguide/pyguide.html#typing-variables).
 
 5. To update a field in a frozen dataclass, prefer to use a `clone` or `with_field` class method constructor or reinitialization,
    rather than dataclass `replace`. There is no big technical reason for this, it's more a soft pattern. The philosophy of an update

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -237,9 +237,6 @@ response: Response | None = None
 payload: Payload = untyped_dependency.load()
 ```
 
-   This follows [mypy's documented type inference](https://mypy.readthedocs.io/en/stable/type_inference_and_annotations.html#type-inference)
-   and the [Google Python Style Guide's guidance for internal variables](https://google.github.io/styleguide/pyguide.html#typing-variables).
-
 5. To update a field in a frozen dataclass, prefer to use a `clone` or `with_field` class method constructor or reinitialization,
    rather than dataclass `replace`. There is no big technical reason for this, it's more a soft pattern. The philosophy of an update
    should be more about thoughfully and purposefully creating a _new_ instance than "in-place editing" an existing one.
@@ -585,3 +582,20 @@ If you discover a potential security issue in this project we ask that you notif
 ## Licensing
 
 See the [LICENSE](LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
+
+## References
+
+- [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct) and
+  [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq)
+- [AWS SAM remote execution command reference](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-cli-command-reference-sam-remote-execution.html)
+- [AWS Security vulnerability reporting](http://aws.amazon.com/security/vulnerability-reporting/)
+- [boto3 documentation](https://boto3.amazonaws.com/)
+- [Conventional Commits](https://www.conventionalcommits.org/)
+- GitHub documentation for [forking a repository](https://help.github.com/articles/fork-a-repo/) and
+  [creating a pull request](https://help.github.com/articles/creating-a-pull-request/)
+- [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html), including its
+  [guidance for internal variables](https://google.github.io/styleguide/pyguide.html#typing-variables)
+- [Hatch installation guide](https://hatch.pypa.io/dev/install/)
+- [Mypy type inference documentation](https://mypy.readthedocs.io/en/stable/type_inference_and_annotations.html#type-inference)
+- [Ruff documentation](https://docs.astral.sh/ruff/) and
+  [Ruff extension for Visual Studio Code](https://github.com/astral-sh/ruff-vscode)


### PR DESCRIPTION
## Summary

This PR revises the contribution guideline that currently requires an explicit
type annotation for every variable, including local variables whose types are
already directly and precisely inferred.

The updated guidance:

- requires annotated function and method signatures so mypy checks their bodies;
- relies on local type inference when it is precise and evident;
- retains explicit local annotations when inference is unavailable, produces
  `Any`, is too narrow, or does not communicate an intentional contract; and
- provides examples and links to the corresponding mypy and Google Python Style
  Guide documentation.

## Rationale

The existing review guidance is consistent with the repository's current
`CONTRIBUTING.md`, so this change is about the rule itself rather than any
reviewer or contributor. The issue surfaced in the review discussion on
[#582](https://github.com/aws/aws-durable-execution-sdk-python/pull/582#discussion_r3643233294).

Requiring an explicit annotation for every local variable, including variables
whose types are directly and precisely inferred, is contrary to normal Python
typing practice and adds verbosity without necessarily improving type safety.

Mypy explicitly documents local type inference:

> For most variables, if you do not explicitly specify its type, mypy will
> infer the correct type based on what is initially assigned to the variable.

Source:
[Mypy: Type inference and type annotations](https://mypy.readthedocs.io/en/stable/type_inference_and_annotations.html#type-inference)

For example, in a checked function:

```python
msg = "Invalid input data"
```

Mypy infers `msg` as `str`. It reports errors if `msg` is subsequently assigned
an incompatible value or used in an operation that does not accept `str`.
Writing:

```python
msg: str = "Invalid input data"
```

normally gives the checker no additional information. An explicit annotation
can serve as an intentional constraint on future changes to the initializer,
but that is useful selectively; it does not justify requiring an annotation on
every local.

The Google Python Style Guide, which this repository's contributing guide says
it generally follows, gives more selective guidance:

> If an internal variable has a type that is hard or impossible to infer,
> specify its type with an annotated assignment.

Source:
[Google Python Style Guide: Typing Variables](https://google.github.io/styleguide/pyguide.html#typing-variables)

That guidance treats local annotations as useful when inference is
insufficient, not as mandatory duplication when the inferred type is already
precise.

The variables discussed in #582 illustrate the distinction:

```python
msg = "Invalid input data"
result = context.parallel([branch])
inner_error = StepError(...)
```

`msg` is inferred directly as `str`. `result` should be inferred from the
annotated return type of `context.parallel()`. `inner_error` is inferred
directly from the `StepError` constructor.

There is a separate consideration for functions without annotated signatures.
By default, mypy does not fully check the bodies of untyped functions. If the
goal is comprehensive checking, the more effective solution is to annotate the
function:

```python
def test_child_handler_preserves_data_across_nested_boundaries() -> None:
```

Alternatively, a project can enable mypy's `check_untyped_defs` setting.
Annotating one local inside an otherwise unchecked function gives much narrower
coverage than making the function itself checked.

More generally, blanket local annotations have several costs:

- They duplicate information already produced by the type checker.
- They add visual noise and make meaningful annotations harder to identify.
- They increase maintenance burden during routine refactoring.
- They can unnecessarily constrain a variable to a concrete implementation
  type when inference or an intentionally selected abstraction would be more
  appropriate.
- They encourage measuring typing quality by annotation density rather than by
  whether interfaces and checked code paths are correctly typed.

Explicit local annotations remain valuable for cases such as empty
collections, initial `None` values, values originating from `Any` or untyped
libraries, intentionally widened interface types, unions across branches, and
expressions whose inferred type is unclear or too narrow. The revised guideline
retains and documents these cases.

## AI-assisted development

Explicit type annotations can help AI tools understand code when they add
information that is not evident from the implementation. They are particularly
useful at API boundaries and for ambiguous values, unions, callbacks, values
originating from `Any`, empty collections, and intentionally broader interface
types.

For obvious locals such as:

```python
msg: str = "Invalid input data"
error: StepError = StepError(...)
```

the annotation repeats information already present in the initializer. Modern
AI models can infer these straightforward types, just as mypy does. Requiring
this repetition for every local also consumes context, adds visual noise, and
can mislead both developers and AI tools if an annotation becomes stale or
diverges from the implementation.

For AI comprehension, descriptive names, typed function signatures, precise
domain models, and documented invariants provide substantially more useful
semantic information. There is no established evidence that annotating every
obvious local materially improves AI understanding, so AI assistance is not a
strong basis for a blanket requirement. The inference-first guideline preserves
annotations where they provide meaningful signal without treating annotation
density as a proxy for code clarity.

This is also consistent with Python's gradual-typing philosophy. PEP 484
states:

> Python will remain a dynamically typed language, and the authors have no
> desire to ever make type hints mandatory, even by convention.

Source: [PEP 484: Non-goals](https://peps.python.org/pep-0484/#non-goals)

That statement does not prevent a repository from adopting a stricter house
style, but it does show that annotating every variable is not a general Python
typing principle.

## Validation

- `git diff --check`
- `hatch run python .github/scripts/lintcommit.py`
