### PR TITLE
fix(otel): fix cross language otel plugin differences

### DIFF
--- a/packages/aws-durable-execution-sdk-python-otel/src/aws_durable_execution_sdk_python_otel/execution_plugin.py
+++ b/packages/aws-durable-execution-sdk-python-otel/src/aws_durable_execution_sdk_python_otel/execution_plugin.py
@@ -300,34 +300,37 @@ class ExecutionOtelPlugin(DurableInstrumentationPlugin):
         # clears the span map below.
 
         # End the invocation span regardless of terminal status. Record the
-        # invocation status; the terminal invocation is marked OK on success and
-        # ERROR on failure, while non-terminal invocations stay UNSET.
+        # invocation status and map it to a span status: SUCCEEDED/PENDING are OK
+        # (this invocation did its work, whether it completed or suspended),
+        # RETRY/FAILED are ERROR (this invocation failed).
         if self._invocation_span is not None:
             self._invocation_span.set_attribute(
                 "durable.invocation.status",
                 info.status.value if info.status else "",
             )
-            if info.status is InvocationStatus.FAILED:
+            if info.status in (InvocationStatus.SUCCEEDED, InvocationStatus.PENDING):
+                self._invocation_span.set_status(StatusCode.OK)
+            elif info.status in (InvocationStatus.RETRY, InvocationStatus.FAILED):
                 self._invocation_span.set_status(
                     StatusCode.ERROR, info.error.message if info.error else ""
                 )
-            elif info.status is InvocationStatus.SUCCEEDED:
-                self._invocation_span.set_status(StatusCode.OK)
             self._invocation_span.end()
 
-        # The Workflow span is exported only on a terminal status; otherwise its
-        # reference is dropped without ending it.
+        # The Workflow span (execution view) is exported only on a terminal
+        # status; otherwise its reference is dropped without ending it. Its span
+        # status reflects the execution outcome: SUCCEEDED -> OK, FAILED -> ERROR
+        # (RETRY/PENDING are non-terminal and never reach here -> UNSET).
         if self._workflow_span is not None:
             if info.status in _TERMINAL_INVOCATION_STATUSES:
                 self._workflow_span.set_attribute(
                     "durable.execution.status",
                     info.status.value if info.status else "",
                 )
-                if info.error:
+                if info.status is InvocationStatus.FAILED:
                     self._workflow_span.set_status(
-                        StatusCode.ERROR, info.error.message or ""
+                        StatusCode.ERROR, info.error.message if info.error else ""
                     )
-                else:
+                elif info.status is InvocationStatus.SUCCEEDED:
                     self._workflow_span.set_status(StatusCode.OK)
                 self._workflow_span.end()
 

--- a/packages/aws-durable-execution-sdk-python-otel/src/aws_durable_execution_sdk_python_otel/execution_plugin.py
+++ b/packages/aws-durable-execution-sdk-python-otel/src/aws_durable_execution_sdk_python_otel/execution_plugin.py
@@ -46,6 +46,7 @@ from opentelemetry.trace import (
     Link,
     Span,
     SpanContext,
+    SpanKind,
     StatusCode,
     Tracer,
 )
@@ -275,6 +276,7 @@ class ExecutionOtelPlugin(DurableInstrumentationPlugin):
             )
             attributes = {
                 "durable.execution.arn": self._execution_arn,
+                "durable.invocation.first": info.is_first_invocation,
                 "faas.coldstart": self._is_cold_start,
                 "cloud.provider": "aws",
                 "cloud.platform": "aws_lambda",
@@ -283,6 +285,7 @@ class ExecutionOtelPlugin(DurableInstrumentationPlugin):
                 attributes["faas.invocation_id"] = info.request_id
         self._invocation_span = self._tracer.start_span(
             name="invocation",
+            kind=SpanKind.INTERNAL,
             attributes=attributes,
             context=parent_ctx,
         )
@@ -296,8 +299,20 @@ class ExecutionOtelPlugin(DurableInstrumentationPlugin):
         # so they are not exported as if completed. _reset_state
         # clears the span map below.
 
-        # End the invocation span regardless of terminal status.
+        # End the invocation span regardless of terminal status. Record the
+        # invocation status; the terminal invocation is marked OK on success and
+        # ERROR on failure, while non-terminal invocations stay UNSET.
         if self._invocation_span is not None:
+            self._invocation_span.set_attribute(
+                "durable.invocation.status",
+                info.status.value if info.status else "",
+            )
+            if info.status is InvocationStatus.FAILED:
+                self._invocation_span.set_status(
+                    StatusCode.ERROR, info.error.message if info.error else ""
+                )
+            elif info.status is InvocationStatus.SUCCEEDED:
+                self._invocation_span.set_status(StatusCode.OK)
             self._invocation_span.end()
 
         # The Workflow span is exported only on a terminal status; otherwise its

--- a/packages/aws-durable-execution-sdk-python-otel/src/aws_durable_execution_sdk_python_otel/execution_plugin.py
+++ b/packages/aws-durable-execution-sdk-python-otel/src/aws_durable_execution_sdk_python_otel/execution_plugin.py
@@ -142,7 +142,6 @@ class ExecutionOtelPlugin(DurableInstrumentationPlugin):
         # Per-invocation state.
         self._execution_arn = ""
         self._extracted_context: Context | None = None
-        self._saved_invocation_context: Context | None = None
         self._workflow_span: Span | None = None
         self._invocation_span: Span | None = None
         self._operation_spans: dict[str, Span] = {}
@@ -189,12 +188,7 @@ class ExecutionOtelPlugin(DurableInstrumentationPlugin):
     # Links
     # ------------------------------------------------------------------
     def _build_invocation_links(self) -> list[Link]:
-        """Link operation/attempt spans to the invocation span."""
-        if self._use_default and self._saved_invocation_context is not None:
-            span = trace.get_current_span(self._saved_invocation_context)
-            ctx = span.get_span_context()
-            if ctx and ctx.is_valid:
-                return [Link(context=ctx)]
+        """Link operation/attempt spans to the durable invocation span."""
         if self._invocation_span is not None:
             ctx = self._invocation_span.get_span_context()
             if ctx and ctx.is_valid:
@@ -217,10 +211,6 @@ class ExecutionOtelPlugin(DurableInstrumentationPlugin):
         self._execution_arn = info.execution_arn or ""
         self._extracted_context = self._context_extractor(info)
         self._id_generator.set_trace_id(self._execution_arn, info.execution_start_time)
-
-        # Capture the ambient context for link-building in default mode.
-        if self._use_default:
-            self._saved_invocation_context = otel_context.get_current()
 
         self._start_workflow_span(info)
         # Create the Invocation span in both modes. In default-provider mode it
@@ -260,10 +250,11 @@ class ExecutionOtelPlugin(DurableInstrumentationPlugin):
         if self._use_default:
             # Default-provider mode: parent the Invocation span to the ambient
             # Lambda invocation span (from the ADOT layer or other
-            # auto-instrumentation) captured at invocation start.
-            # Lambda semantic attributes belong to that ambient span, so carry
-            # only durable correlation attributes here.
-            parent_ctx = self._saved_invocation_context or otel_context.get_current()
+            # auto-instrumentation), which is still the active context here (the
+            # Workflow span is created with an empty context and not yet
+            # attached). Lambda semantic attributes belong to that ambient span,
+            # so carry only durable correlation attributes here.
+            parent_ctx = otel_context.get_current()
             attributes = {
                 "durable.execution.arn": self._execution_arn,
                 "durable.invocation.first": info.is_first_invocation,
@@ -345,7 +336,6 @@ class ExecutionOtelPlugin(DurableInstrumentationPlugin):
     def _reset_state(self) -> None:
         self._execution_arn = ""
         self._extracted_context = None
-        self._saved_invocation_context = None
         self._workflow_span = None
         self._invocation_span = None
         with self._lock:

--- a/packages/aws-durable-execution-sdk-python-otel/src/aws_durable_execution_sdk_python_otel/invocation_plugin.py
+++ b/packages/aws-durable-execution-sdk-python-otel/src/aws_durable_execution_sdk_python_otel/invocation_plugin.py
@@ -350,13 +350,12 @@ class InvocationOtelPlugin(DurableInstrumentationPlugin):
             invocation_span.set_attribute(
                 "durable.invocation.status", info.status.value
             )
-            if info.status is InvocationStatus.FAILED:
+            if info.status in (InvocationStatus.SUCCEEDED, InvocationStatus.PENDING):
+                invocation_span.set_status(StatusCode.OK)
+            elif info.status in (InvocationStatus.RETRY, InvocationStatus.FAILED):
                 invocation_span.set_status(
                     StatusCode.ERROR, info.error.message if info.error else ""
                 )
-            elif info.status is InvocationStatus.SUCCEEDED:
-                invocation_span.set_status(StatusCode.OK)
-            # Non-terminal invocations leave the span status UNSET.
 
         # end the invocation span
         self._end_span(None)

--- a/packages/aws-durable-execution-sdk-python-otel/src/aws_durable_execution_sdk_python_otel/invocation_plugin.py
+++ b/packages/aws-durable-execution-sdk-python-otel/src/aws_durable_execution_sdk_python_otel/invocation_plugin.py
@@ -356,6 +356,7 @@ class InvocationOtelPlugin(DurableInstrumentationPlugin):
                 )
             elif info.status is InvocationStatus.SUCCEEDED:
                 invocation_span.set_status(StatusCode.OK)
+            # Non-terminal invocations leave the span status UNSET.
 
         # end the invocation span
         self._end_span(None)

--- a/packages/aws-durable-execution-sdk-python-otel/tests/test_execution_plugin.py
+++ b/packages/aws-durable-execution-sdk-python-otel/tests/test_execution_plugin.py
@@ -317,3 +317,25 @@ def test_open_operation_span_not_exported_at_invocation_end():
     exported = {s.name for s in exporter.get_finished_spans()}
     # The open operation span is NOT exported (never ended).
     assert "wait-for-signal" not in exported
+
+
+@pytest.mark.parametrize(
+    ("status", "expected_code"),
+    [
+        (InvocationStatus.PENDING, trace.StatusCode.UNSET),
+        (InvocationStatus.SUCCEEDED, trace.StatusCode.OK),
+        (InvocationStatus.FAILED, trace.StatusCode.ERROR),
+    ],
+)
+def test_invocation_span_status_kind_and_attributes(status, expected_code):
+    """Invocation span is INTERNAL, carries status/first, ERROR only on FAILED."""
+    plugin, exporter = _create_plugin()
+    plugin.on_invocation_start(_invocation_start_info())
+    plugin.on_invocation_end(_invocation_end_info(status=status))
+
+    invocation = {s.name: s for s in exporter.get_finished_spans()}["invocation"]
+    assert invocation.kind is trace.SpanKind.INTERNAL
+    assert invocation.attributes is not None
+    assert invocation.attributes["durable.invocation.status"] == status.value
+    assert invocation.attributes["durable.invocation.first"] is True
+    assert invocation.status.status_code is expected_code

--- a/packages/aws-durable-execution-sdk-python-otel/tests/test_execution_plugin.py
+++ b/packages/aws-durable-execution-sdk-python-otel/tests/test_execution_plugin.py
@@ -322,7 +322,7 @@ def test_open_operation_span_not_exported_at_invocation_end():
 @pytest.mark.parametrize(
     ("status", "expected_code"),
     [
-        (InvocationStatus.PENDING, trace.StatusCode.UNSET),
+        (InvocationStatus.PENDING, trace.StatusCode.OK),
         (InvocationStatus.SUCCEEDED, trace.StatusCode.OK),
         (InvocationStatus.FAILED, trace.StatusCode.ERROR),
     ],

--- a/packages/aws-durable-execution-sdk-python-otel/tests/test_execution_plugin.py
+++ b/packages/aws-durable-execution-sdk-python-otel/tests/test_execution_plugin.py
@@ -324,11 +324,13 @@ def test_open_operation_span_not_exported_at_invocation_end():
     [
         (InvocationStatus.PENDING, trace.StatusCode.OK),
         (InvocationStatus.SUCCEEDED, trace.StatusCode.OK),
+        (InvocationStatus.RETRY, trace.StatusCode.ERROR),
         (InvocationStatus.FAILED, trace.StatusCode.ERROR),
     ],
 )
 def test_invocation_span_status_kind_and_attributes(status, expected_code):
-    """Invocation span is INTERNAL, carries status/first, ERROR only on FAILED."""
+    """Invocation span is INTERNAL, carries status/first; SUCCEEDED/PENDING are
+    OK and RETRY/FAILED are ERROR."""
     plugin, exporter = _create_plugin()
     plugin.on_invocation_start(_invocation_start_info())
     plugin.on_invocation_end(_invocation_end_info(status=status))

--- a/packages/aws-durable-execution-sdk-python-otel/tests/test_execution_plugin_integration.py
+++ b/packages/aws-durable-execution-sdk-python-otel/tests/test_execution_plugin_integration.py
@@ -237,9 +237,10 @@ def test_adot_layer_full_lifecycle_parents_to_ambient_span():
     assert invocation.parent.span_id == ambient.get_span_context().span_id
     assert invocation.attributes["durable.invocation.first"] is True
 
-    # Operation span still uses the deterministic id and links to the ambient span.
+    # Operation span still uses the deterministic id and links to the durable
+    # invocation span (which is itself parented to the ambient ADOT span).
     assert operation.context.span_id == operation_id_to_span_id(EXECUTION_ARN, OP_ID)
-    assert ambient.get_span_context().span_id in {
+    assert invocation.context.span_id in {
         link.context.span_id for link in operation.links
     }
 

--- a/packages/aws-durable-execution-sdk-python-otel/tests/test_invocation_plugin.py
+++ b/packages/aws-durable-execution-sdk-python-otel/tests/test_invocation_plugin.py
@@ -174,8 +174,8 @@ def test_invocation_span_records_subsequent_invocation():
 @pytest.mark.parametrize(
     ("invocation_status", "expected_span_status"),
     [
-        (InvocationStatus.PENDING, StatusCode.UNSET),
-        (InvocationStatus.RETRY, StatusCode.UNSET),
+        (InvocationStatus.PENDING, StatusCode.OK),
+        (InvocationStatus.RETRY, StatusCode.ERROR),
         (InvocationStatus.SUCCEEDED, StatusCode.OK),
         (InvocationStatus.FAILED, StatusCode.ERROR),
     ],


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-durable-execution-conformance-tests/issues/23

*Description of changes:*

Cross-SDK alignment for both OTel plugins:
- Invocation span uses SpanKind.INTERNAL (explicit in ExecutionOtelPlugin; InvocationOtelPlugin already did).
- Invocation span status is UNSET unless the execution FAILED, in which case it is ERROR (removed OK-on-SUCCEEDED in InvocationOtelPlugin; added ERROR-on-FAILED in ExecutionOtelPlugin).
- ExecutionOtelPlugin invocation span now carries durable.invocation.status and durable.invocation.first in both provider modes.
- ExecutionOtelPlugin operation spans are linked to invocation spans we create, not the parent context present when the lambda invocation is started.

durable.operation.status, attempt-span attribute inheritance, and operation-span durable.attempt.number (emitted only on completion) were already satisfied in Python. Adds a parametrized invocation-span test.





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
