### PR TITLE
ci: use latest conformance suite (git main) in conformance CI

### DIFF
--- a/.github/workflows/conformance-tests.yml
+++ b/.github/workflows/conformance-tests.yml
@@ -95,7 +95,7 @@ jobs:
       run: python3 scripts/build_examples.py
 
     - name: Install conformance runner
-      run: pip install aws-durable-execution-conformance-tests==0.1.0
+      run: pip install "git+https://github.com/aws/aws-durable-execution-conformance-tests.git@main#subdirectory=packages/aws-durable-execution-conformance-tests"
 
     - name: Inject Lambda execution role into template
       env:

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/child/child_large_payload.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/child/child_large_payload.py
@@ -24,7 +24,9 @@ def generate_data(_step_context: StepContext) -> str:
 
 @durable_with_child_context
 def large_data_processor(ctx: DurableContext, *, input_1: str) -> str:
-    print(input_1, flush=True)
+    # Log through the child context logger so the record carries the execution
+    # ARN; the child body re-executes on replay to rebuild the large result.
+    ctx.logger.info(input_1)
     step_result: str = ctx.step(generate_data())
     # Build a large result (>256KB) from the small step result
     large_result = step_result * 6  # ~300KB

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/child/child_large_payload.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/child/child_large_payload.py
@@ -25,8 +25,11 @@ def generate_data(_step_context: StepContext) -> str:
 @durable_with_child_context
 def large_data_processor(ctx: DurableContext, *, input_1: str) -> str:
     # Log through the child context logger so the record carries the execution
-    # ARN; the child body re-executes on replay to rebuild the large result.
-    ctx.logger.info(input_1)
+    # ARN. The context logger de-duplicates while the context is replaying, so
+    # rebind the replay source to enable replay logging: the child body re-runs
+    # in ReplayChildren mode to rebuild the large result, and that re-execution
+    # emits no history events, making the log the only evidence it happened.
+    ctx.logger.with_is_replaying(lambda: False).info(input_1)
     step_result: str = ctx.step(generate_data())
     # Build a large result (>256KB) from the small step result
     large_result = step_result * 6  # ~300KB

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/child/child_print_only.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/child/child_print_only.py
@@ -13,8 +13,10 @@ from aws_durable_execution_sdk_python.execution import durable_execution
 @durable_with_child_context
 def print_child(ctx: DurableContext, *, input_1: str) -> str:
     # Log through the child context logger so the record carries the execution
-    # ARN. A second record would mean the child body was wrongly re-executed.
-    ctx.logger.info(input_1)
+    # ARN. Rebinding the replay source enables replay logging, which is what
+    # makes this assertion meaningful: under the default de-duplication an
+    # incorrect second child execution would be suppressed and still count 1.
+    ctx.logger.with_is_replaying(lambda: False).info(input_1)
     return input_1
 
 

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/child/child_print_only.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/child/child_print_only.py
@@ -1,4 +1,4 @@
-"""3-17: Child context with print only (verify no re-execution on replay)."""
+"""3-17: Child context with durable logger only (verify no re-execution on replay)."""
 
 from typing import Any
 
@@ -11,8 +11,10 @@ from aws_durable_execution_sdk_python.execution import durable_execution
 
 
 @durable_with_child_context
-def print_child(_ctx: DurableContext, *, input_1: str) -> str:
-    print(input_1, flush=True)
+def print_child(ctx: DurableContext, *, input_1: str) -> str:
+    # Log through the child context logger so the record carries the execution
+    # ARN. A second record would mean the child body was wrongly re-executed.
+    ctx.logger.info(input_1)
     return input_1
 
 

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/step/step_at_most_once_no_retry.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/step/step_at_most_once_no_retry.py
@@ -15,8 +15,10 @@ from aws_durable_execution_sdk_python.retries import RetryPresets
 
 
 @durable_step
-def at_most_once_flaky_step(_step_context: StepContext, *, input_1: str) -> str:
-    print(input_1, flush=True)
+def at_most_once_flaky_step(step_context: StepContext, *, input_1: str) -> str:
+    # Log through the step context logger so the record carries the execution
+    # ARN and can be correlated to this durable execution in CloudWatch.
+    step_context.logger.info(input_1)
     time.sleep(1)  # Allow time for logs to flush to CloudWatch
     os._exit(1)  # Simulate Lambda crash
     return "unreachable"

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/step/step_at_most_once_with_retry.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/step/step_at_most_once_with_retry.py
@@ -19,8 +19,9 @@ from aws_durable_execution_sdk_python.retries import (
 
 @durable_step
 def at_most_once_step(step_context: StepContext, *, input_1: str) -> str:
-    # Print input to stdout each time step executes
-    print(input_1, flush=True)
+    # Log the input through the step context logger each time the step executes
+    # so each record carries the execution ARN for CloudWatch correlation.
+    step_context.logger.info(input_1)
     time.sleep(1)  # Allow time for logs to flush to CloudWatch
 
     # The attempt number is the SDK's built-in durable counter from the step

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/template_child.yaml
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/template_child.yaml
@@ -5,6 +5,13 @@ Globals:
     Runtime: python3.13
     Timeout: 60
     MemorySize: 128
+    # The conformance runner correlates CloudWatch records to a durable
+    # execution with a JSON filter on the executionArn field the SDK context
+    # logger attaches. That field only survives under the JSON log format.
+    LoggingConfig:
+      LogFormat: JSON
+      ApplicationLogLevel: INFO
+      SystemLogLevel: INFO
 Resources:
   DurableFunctionRole:
     Type: AWS::IAM::Role

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/template_step.yaml
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/template_step.yaml
@@ -5,6 +5,13 @@ Globals:
     Runtime: python3.13
     Timeout: 60
     MemorySize: 128
+    # The conformance runner correlates CloudWatch records to a durable
+    # execution with a JSON filter on the executionArn field the SDK context
+    # logger attaches. That field only survives under the JSON log format.
+    LoggingConfig:
+      LogFormat: JSON
+      ApplicationLogLevel: INFO
+      SystemLogLevel: INFO
 Resources:
   DurableFunctionRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
Switches the conformance-tests workflow to install the runner from git main (subdirectory packages/aws-durable-execution-conformance-tests) instead of the pinned ==0.1.0 PyPI release, so new upstream suites/requirements are exercised automatically. Draft until reviewed.