### PR TITLE
fix(testing): honor history reverse order

### DIFF
--- a/packages/aws-durable-execution-sdk-python-testing/src/aws_durable_execution_sdk_python_testing/web/handlers.py
+++ b/packages/aws-durable-execution-sdk-python-testing/src/aws_durable_execution_sdk_python_testing/web/handlers.py
@@ -502,12 +502,18 @@ class GetDurableExecutionHistoryHandler(EndpointHandler):
                 if include_execution_data_str
                 else False
             )
+            reverse_order_str: str | None = self._parse_query_param(
+                request, "ReverseOrder"
+            )
+            reverse_order: bool = (
+                reverse_order_str == "true" if reverse_order_str else False
+            )
 
             history_response: GetDurableExecutionHistoryResponse = (
                 self.executor.get_execution_history(
                     execution_arn,
                     include_execution_data=include_execution_data,
-                    reverse_order=False,
+                    reverse_order=reverse_order,
                     marker=marker,
                     max_items=int(max_items) if max_items else None,
                 )

--- a/packages/aws-durable-execution-sdk-python-testing/tests/web/handlers_test.py
+++ b/packages/aws-durable-execution-sdk-python-testing/tests/web/handlers_test.py
@@ -1377,6 +1377,53 @@ def test_get_durable_execution_history_handler_with_include_execution_data_false
     )
 
 
+@pytest.mark.parametrize(
+    ("reverse_order_param", "expected_reverse_order"),
+    [
+        (None, False),
+        ("false", False),
+        ("true", True),
+    ],
+)
+def test_get_durable_execution_history_handler_with_reverse_order(
+    reverse_order_param: str | None, expected_reverse_order: bool
+):
+    """Test GetDurableExecutionHistoryHandler with ReverseOrder."""
+
+    executor = Mock()
+    handler = GetDurableExecutionHistoryHandler(executor)
+    executor.get_execution_history.return_value = GetDurableExecutionHistoryResponse(
+        events=[], next_marker=None
+    )
+
+    router = Router()
+    typed_route = router.find_route(
+        "/2025-12-01/durable-executions/test-arn/history", "GET"
+    )
+    query_params: dict[str, list[str]] = {}
+    if reverse_order_param is not None:
+        query_params["ReverseOrder"] = [reverse_order_param]
+    request = HTTPRequest(
+        method="GET",
+        path=typed_route,
+        headers={},
+        query_params=query_params,
+        body={},
+    )
+
+    response = handler.handle(typed_route, request)
+
+    assert response.status_code == 200
+    assert response.body == {"Events": []}
+    executor.get_execution_history.assert_called_once_with(
+        "test-arn",
+        include_execution_data=False,
+        reverse_order=expected_reverse_order,
+        marker=None,
+        max_items=None,
+    )
+
+
 def test_list_durable_executions_handler_success():
     """Test ListDurableExecutionsHandler with successful execution listing."""
     executor = Mock()


### PR DESCRIPTION
## Summary

- parse the `ReverseOrder` query parameter in the testing WebServer
- forward the parsed value to `get_execution_history`
- cover omitted, `false`, and `true` values with a regression test

## Root cause

The WebServer handler hard-coded `reverse_order=False`, even though the executor already supports reverse-order history and pagination.

## Testing

- `hatch run dev-testing:test` (1,365 passed)
- `hatch run dev-testing:typecheck`
- `hatch fmt --check`
- focused history-handler tests (8 passed)

Fixes #594
