### PR TITLE
feat(otel): use semconv SERVICE_NAME for service.name

### DIFF
--- a/packages/aws-durable-execution-sdk-python-otel/pyproject.toml
+++ b/packages/aws-durable-execution-sdk-python-otel/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
   "aws-durable-execution-sdk-python>=1.5.0",
   "opentelemetry-api>=1.20.0,<=1.42.1",
   "opentelemetry-sdk>=1.20.0,<=1.42.1",
+  "opentelemetry-semantic-conventions>=0.41b0,<=0.63b1",
   "opentelemetry-exporter-otlp<=1.42.1",
   "opentelemetry-propagator-aws-xray",
 ]

--- a/packages/aws-durable-execution-sdk-python-otel/src/aws_durable_execution_sdk_python_otel/provider.py
+++ b/packages/aws-durable-execution-sdk-python-otel/src/aws_durable_execution_sdk_python_otel/provider.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from opentelemetry import propagate, trace
+from opentelemetry.semconv.attributes.service_attributes import SERVICE_NAME
 from opentelemetry.propagators.composite import CompositePropagator
 
 from aws_durable_execution_sdk_python_otel.otel_plugin_config import (
@@ -93,7 +94,7 @@ def _build_resource():
     if not function_name:
         return None
     attributes: dict[str, str] = {
-        "service.name": function_name,
+        SERVICE_NAME: function_name,
         "faas.name": function_name,
         "cloud.provider": "aws",
         "cloud.platform": "aws_lambda",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Replace the raw "service.name" literal in provider._build_resource() with the stable OpenTelemetry semantic-conventions constant (opentelemetry.semconv.attributes.service_attributes.SERVICE_NAME), matching the Java SDK's ServiceAttributes.SERVICE_NAME. Declare opentelemetry-semantic-conventions explicitly (already a pinned transitive dep of opentelemetry-sdk). faas.*/cloud.* stay raw as they are incubating.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
