### PR TITLE
fix(otel): reuse deterministic ID generator

### DIFF
--- a/packages/aws-durable-execution-sdk-python-otel/src/aws_durable_execution_sdk_python_otel/deterministic_id_generator.py
+++ b/packages/aws-durable-execution-sdk-python-otel/src/aws_durable_execution_sdk_python_otel/deterministic_id_generator.py
@@ -7,8 +7,13 @@ import hashlib
 import os
 import re
 from datetime import UTC, datetime
+from typing import TYPE_CHECKING
 
 from opentelemetry.sdk.trace import IdGenerator, RandomIdGenerator
+
+
+if TYPE_CHECKING:
+    from opentelemetry.sdk.trace import TracerProvider
 
 
 HASHED_ID_PATTERN = re.compile(r"^[0-9a-f]{16}$")
@@ -126,6 +131,23 @@ class DeterministicIdGenerator(RandomIdGenerator):
     def __init__(self, fallback_id_generator: IdGenerator | None = None) -> None:
         self._execution_trace_id: int | None = None
         self._fallback_id_generator = fallback_id_generator or RandomIdGenerator()
+
+    @classmethod
+    def install_on_provider(cls, provider: TracerProvider) -> DeterministicIdGenerator:
+        """Return the provider's deterministic generator, installing one if needed.
+
+        OpenTelemetry tracers capture the provider's ID generator when they are
+        created. Reusing an installed generator ensures multiple plugin instances
+        with the same instrumentation scope configure the generator referenced by
+        the provider's cached tracer.
+        """
+        current_generator = provider.id_generator
+        if isinstance(current_generator, cls):
+            return current_generator
+
+        generator = cls(fallback_id_generator=current_generator)
+        provider.id_generator = generator
+        return generator
 
     def set_next_span_id(self, span_id: int | None) -> None:
         """Set the operation ID to use for the next span's ID.

--- a/packages/aws-durable-execution-sdk-python-otel/src/aws_durable_execution_sdk_python_otel/execution_plugin.py
+++ b/packages/aws-durable-execution-sdk-python-otel/src/aws_durable_execution_sdk_python_otel/execution_plugin.py
@@ -116,10 +116,9 @@ class ExecutionOtelPlugin(DurableInstrumentationPlugin):
         from opentelemetry.sdk.trace import TracerProvider as SdkTracerProvider
 
         if isinstance(self._provider, SdkTracerProvider):
-            self._id_generator = DeterministicIdGenerator(
-                fallback_id_generator=getattr(self._provider, "id_generator", None)
+            self._id_generator = DeterministicIdGenerator.install_on_provider(
+                self._provider
             )
-            self._provider.id_generator = self._id_generator
         else:
             logger.warning(
                 "ExecutionOtelPlugin expected an SDK TracerProvider but got %s; "

--- a/packages/aws-durable-execution-sdk-python-otel/src/aws_durable_execution_sdk_python_otel/invocation_plugin.py
+++ b/packages/aws-durable-execution-sdk-python-otel/src/aws_durable_execution_sdk_python_otel/invocation_plugin.py
@@ -116,9 +116,6 @@ class InvocationOtelPlugin(DurableInstrumentationPlugin):
         )
 
         self._provider = trace_provider or trace.get_tracer_provider()
-        self._id_generator: DeterministicIdGenerator = DeterministicIdGenerator(
-            fallback_id_generator=getattr(self._provider, "id_generator", None)
-        )
         # Deterministic trace stitching requires the SDK TracerProvider, which
         # exposes id_generator/sampler. The API's default ProxyTracerProvider
         # (returned before an SDK provider is configured) does not. Rather than
@@ -127,8 +124,11 @@ class InvocationOtelPlugin(DurableInstrumentationPlugin):
         # provider is configured later). In a Lambda OTel/ADOT deployment the
         # layer configures a real SDK provider before the handler imports.
         if isinstance(self._provider, SdkTracerProvider):
-            self._provider.id_generator = self._id_generator
+            self._id_generator = DeterministicIdGenerator.install_on_provider(
+                self._provider
+            )
         else:
+            self._id_generator = DeterministicIdGenerator()
             logger.warning(
                 "InvocationOtelPlugin expected an SDK TracerProvider "
                 "(opentelemetry.sdk.trace.TracerProvider) but got %s. Spans will "

--- a/packages/aws-durable-execution-sdk-python-otel/tests/test_execution_plugin_integration.py
+++ b/packages/aws-durable-execution-sdk-python-otel/tests/test_execution_plugin_integration.py
@@ -50,6 +50,10 @@ END_TIME = datetime(2024, 1, 2, 3, 4, 6, tzinfo=UTC)
 EXECUTION_ARN = "arn:aws:lambda:us-west-2:123456789012:function:workflow:$LATEST"
 OP_ID = "step-1"
 OP_NAME = "fetch-user"
+XRAY_TRACE_HEADER = (
+    "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1"
+)
+XRAY_TRACE_ID = int("5759e988bd862e3fe1be46a994272793", 16)
 
 
 @pytest.fixture(autouse=True)
@@ -246,3 +250,26 @@ def test_adot_layer_full_lifecycle_parents_to_ambient_span():
 
     # The operation span is exported exactly once.
     assert len([s for s in finished if s.name == OP_NAME]) == 1
+
+
+def test_second_plugin_configures_cached_tracer_generator(monkeypatch):
+    """A second handler's Workflow span uses its deterministic trace ID."""
+    provider, exporter = _provider()
+    config = OtelPluginConfig(
+        tracer_provider=provider,
+        use_default_tracer_provider=True,
+        context_extractor=lambda _: Context(),
+        enrich_logger=False,
+    )
+    first_plugin = ExecutionOtelPlugin(config)
+    target_plugin = ExecutionOtelPlugin(config)
+    monkeypatch.setenv("_X_AMZN_TRACE_ID", XRAY_TRACE_HEADER)
+
+    assert target_plugin._tracer is first_plugin._tracer
+    target_plugin.on_invocation_start(_invocation_start())
+    target_plugin.on_invocation_end(_invocation_end())
+
+    workflow = next(
+        span for span in exporter.get_finished_spans() if span.name == "Workflow"
+    )
+    assert workflow.context.trace_id == XRAY_TRACE_ID

--- a/packages/aws-durable-execution-sdk-python-otel/tests/test_invocation_plugin_integration.py
+++ b/packages/aws-durable-execution-sdk-python-otel/tests/test_invocation_plugin_integration.py
@@ -52,6 +52,10 @@ END_TIME = datetime(2024, 1, 2, 3, 4, 6, tzinfo=UTC)
 EXECUTION_ARN = "arn:aws:lambda:us-west-2:123456789012:function:workflow:$LATEST"
 OP_ID = "step-1"
 OP_NAME = "fetch-user"
+XRAY_TRACE_HEADER = (
+    "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1"
+)
+XRAY_TRACE_ID = int("5759e988bd862e3fe1be46a994272793", 16)
 
 
 @pytest.fixture(autouse=True)
@@ -215,3 +219,28 @@ def test_adot_layer_full_lifecycle_uses_global_provider(monkeypatch):
 
     # Spans were produced against the (monkeypatched) global provider's exporter.
     _assert_hierarchy(exporter)
+
+
+def test_second_plugin_configures_cached_tracer_generator(monkeypatch):
+    """A second handler's Workflow span uses its deterministic trace ID."""
+    provider, exporter = _provider()
+    first_plugin = InvocationOtelPlugin(
+        trace_provider=provider,
+        context_extractor=lambda _: Context(),
+        enrich_logger=False,
+    )
+    target_plugin = InvocationOtelPlugin(
+        trace_provider=provider,
+        context_extractor=lambda _: Context(),
+        enrich_logger=False,
+    )
+    monkeypatch.setenv("_X_AMZN_TRACE_ID", XRAY_TRACE_HEADER)
+
+    assert target_plugin._tracer is first_plugin._tracer
+    target_plugin.on_invocation_start(_invocation_start())
+    target_plugin.on_invocation_end(_invocation_end())
+
+    workflow = next(
+        span for span in exporter.get_finished_spans() if span.name == "Workflow"
+    )
+    assert workflow.context.trace_id == XRAY_TRACE_ID


### PR DESCRIPTION
## Summary
- install the deterministic ID generator on a tracer provider only once, then reuse it across plugin instances
- apply the shared-generator behavior to both `InvocationOtelPlugin` and `ExecutionOtelPlugin`
- add chained-handler regressions that invoke only the second plugin instance

## Problem
Chained-invoke modules can define both `handler` and `target_handler` in the same module. Each decorator creates its own OTel plugin during module import, so both plugins resolve the same tracer provider and instrumentation scope.

OpenTelemetry caches tracers by instrumentation scope, and each tracer captures the provider ID generator when that tracer is created. Previously the initialization sequence was:

1. The first plugin installed its deterministic generator and created the cached tracer.
2. The second plugin installed a different deterministic generator, but received the already-cached tracer.
3. The target handler configured the second generator while its `Workflow` span was created by a tracer that still referenced the first generator.

Only the target plugin receives lifecycle callbacks in the target Lambda. Its `Invocation` span can still inherit the propagated X-Ray context correctly, while its parentless `Workflow` span falls back to a different trace ID. Modules with one plugin instance do not encounter the mismatch.

## Fix
`DeterministicIdGenerator.install_on_provider` now reuses an existing deterministic generator or installs one when the provider still has its original generator. Both OTel plugins use this path before requesting their tracer.

As a result, every plugin instance sharing a provider also shares the generator already captured by the cached tracer. The original provider generator remains the fallback when the deterministic generator is installed for the first time.

## Regression coverage
The invocation-view and execution-view integration suites each create two plugins with the same provider and instrumentation scope, verify that OpenTelemetry returns the cached tracer, invoke only the second plugin, and assert that its `Workflow` span uses the propagated X-Ray trace ID. This mirrors the source/target handler import order in the chained-invoke conformance example.

## Testing
- `hatch run dev-otel:test` (101 passed)
- `hatch run types:check`
- `hatch fmt --check` (OTel package)