### PR TITLE
ci: reuse OpenTelemetry conformance workflow

### DIFF
--- a/.github/workflows/opentelemetry-conformance-tests.yml
+++ b/.github/workflows/opentelemetry-conformance-tests.yml
@@ -38,6 +38,11 @@ on:
         description: OTLP ingest endpoint for community-layer jobs
         required: false
         type: string
+      conformance_test_ref:
+        description: Conformance test commit SHA or branch name
+        required: true
+        default: main
+        type: string
 
 permissions: {}
 
@@ -47,12 +52,13 @@ jobs:
       actions: write
       contents: read
       id-token: write
-    uses: aws/aws-durable-execution-conformance-tests/.github/workflows/python-opentelemetry.yml@47ea5921fe6a5542843318a0f8a851b69e93b03d
+    uses: aws/aws-durable-execution-conformance-tests/.github/workflows/python-opentelemetry.yml@3071832ab55c1baf96a5c21c6d526bcaad2a0345
     with:
       phase: ${{ inputs.phase || 'short' }}
       delay_seconds: ${{ inputs.delay_seconds || '82800' }}
       aws_region: ${{ inputs.aws_region || 'us-west-2' }}
       otlp_endpoint: ${{ inputs.otlp_endpoint || '' }}
+      conformance_test_ref: ${{ inputs.conformance_test_ref || 'main' }}
       python_sdk_ref: ${{ github.event.pull_request.head.sha || github.sha }}
     secrets:
       CONFORMANCE_TEST_ROLE_ARN: ${{ secrets.TEST_ROLE_ARN }}

--- a/.github/workflows/opentelemetry-conformance-tests.yml
+++ b/.github/workflows/opentelemetry-conformance-tests.yml
@@ -47,7 +47,7 @@ jobs:
       actions: write
       contents: read
       id-token: write
-    uses: aws/aws-durable-execution-conformance-tests/.github/workflows/python-opentelemetry.yml@11169d80e32ff68d40f1985fb3d401f9ca01eeb6
+    uses: aws/aws-durable-execution-conformance-tests/.github/workflows/python-opentelemetry.yml@6c43f7573d8734be801341c87a76bc76b351bcb7
     with:
       phase: ${{ inputs.phase || 'short' }}
       delay_seconds: ${{ inputs.delay_seconds || '82800' }}

--- a/.github/workflows/opentelemetry-conformance-tests.yml
+++ b/.github/workflows/opentelemetry-conformance-tests.yml
@@ -47,7 +47,7 @@ jobs:
       actions: write
       contents: read
       id-token: write
-    uses: aws/aws-durable-execution-conformance-tests/.github/workflows/python-opentelemetry.yml@6c43f7573d8734be801341c87a76bc76b351bcb7
+    uses: aws/aws-durable-execution-conformance-tests/.github/workflows/python-opentelemetry.yml@d155cb3801e85722ba9c7cc468b8ec20c6687576
     with:
       phase: ${{ inputs.phase || 'short' }}
       delay_seconds: ${{ inputs.delay_seconds || '82800' }}
@@ -55,9 +55,9 @@ jobs:
       otlp_endpoint: ${{ inputs.otlp_endpoint || '' }}
       python_sdk_ref: ${{ github.event.pull_request.head.sha || github.sha }}
     secrets:
-      PYTHON_TEST_ROLE_ARN: ${{ secrets.TEST_ROLE_ARN }}
-      PYTHON_TEST_ACCOUNT_ID: ${{ secrets.TEST_ACCOUNT_ID }}
-      PYTHON_TEST_LAMBDA_EXECUTION_ROLE_ARN: ${{ secrets.TEST_LAMBDA_EXECUTION_ROLE_ARN }}
+      CONFORMANCE_TEST_ROLE_ARN: ${{ secrets.TEST_ROLE_ARN }}
+      CONFORMANCE_TEST_ACCOUNT_ID: ${{ secrets.TEST_ACCOUNT_ID }}
+      CONFORMANCE_TEST_LAMBDA_EXECUTION_ROLE_ARN: ${{ secrets.TEST_LAMBDA_EXECUTION_ROLE_ARN }}
       DASH0_AUTH_TOKEN: ${{ secrets.DASH0_AUTH_TOKEN }}
       DD_API_KEY: ${{ secrets.DD_API_KEY }}
       DD_APPLICATION_KEY: ${{ secrets.DD_APPLICATION_KEY }}

--- a/.github/workflows/opentelemetry-conformance-tests.yml
+++ b/.github/workflows/opentelemetry-conformance-tests.yml
@@ -1,0 +1,64 @@
+name: OpenTelemetry Conformance Tests
+
+on:
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "packages/aws-durable-execution-sdk-python/**"
+      - "packages/aws-durable-execution-sdk-python-otel/**"
+      - ".github/workflows/opentelemetry-conformance-tests.yml"
+  push:
+    branches: ["main"]
+    paths:
+      - "packages/aws-durable-execution-sdk-python/**"
+      - "packages/aws-durable-execution-sdk-python-otel/**"
+      - ".github/workflows/opentelemetry-conformance-tests.yml"
+  workflow_dispatch:
+    inputs:
+      phase:
+        description: Run short tests, launch a long run, or check the active long run
+        required: true
+        default: short
+        type: choice
+        options:
+          - short
+          - launch
+          - check
+      delay_seconds:
+        description: Durable delay in seconds (1-86400, launch only)
+        required: true
+        default: "82800"
+        type: string
+      aws_region:
+        description: AWS region
+        required: true
+        default: us-west-2
+        type: string
+      otlp_endpoint:
+        description: OTLP ingest endpoint for community-layer jobs
+        required: false
+        type: string
+
+permissions: {}
+
+jobs:
+  opentelemetry:
+    permissions:
+      actions: write
+      contents: read
+      id-token: write
+    uses: aws/aws-durable-execution-conformance-tests/.github/workflows/python-opentelemetry.yml@11169d80e32ff68d40f1985fb3d401f9ca01eeb6
+    with:
+      phase: ${{ inputs.phase || 'short' }}
+      delay_seconds: ${{ inputs.delay_seconds || '82800' }}
+      aws_region: ${{ inputs.aws_region || 'us-west-2' }}
+      otlp_endpoint: ${{ inputs.otlp_endpoint || '' }}
+      python_sdk_ref: ${{ github.event.pull_request.head.sha || github.sha }}
+    secrets:
+      PYTHON_TEST_ROLE_ARN: ${{ secrets.TEST_ROLE_ARN }}
+      PYTHON_TEST_ACCOUNT_ID: ${{ secrets.TEST_ACCOUNT_ID }}
+      PYTHON_TEST_LAMBDA_EXECUTION_ROLE_ARN: ${{ secrets.TEST_LAMBDA_EXECUTION_ROLE_ARN }}
+      DASH0_AUTH_TOKEN: ${{ secrets.DASH0_AUTH_TOKEN }}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      DD_APPLICATION_KEY: ${{ secrets.DD_APPLICATION_KEY }}
+      DATADOG_OTLP_HEADERS: ${{ secrets.DATADOG_OTLP_HEADERS }}

--- a/.github/workflows/opentelemetry-conformance-tests.yml
+++ b/.github/workflows/opentelemetry-conformance-tests.yml
@@ -47,7 +47,7 @@ jobs:
       actions: write
       contents: read
       id-token: write
-    uses: aws/aws-durable-execution-conformance-tests/.github/workflows/python-opentelemetry.yml@5a31b277b014d688b4d7002f346cf9c01047e026
+    uses: aws/aws-durable-execution-conformance-tests/.github/workflows/python-opentelemetry.yml@47ea5921fe6a5542843318a0f8a851b69e93b03d
     with:
       phase: ${{ inputs.phase || 'short' }}
       delay_seconds: ${{ inputs.delay_seconds || '82800' }}

--- a/.github/workflows/opentelemetry-conformance-tests.yml
+++ b/.github/workflows/opentelemetry-conformance-tests.yml
@@ -47,7 +47,7 @@ jobs:
       actions: write
       contents: read
       id-token: write
-    uses: aws/aws-durable-execution-conformance-tests/.github/workflows/python-opentelemetry.yml@d155cb3801e85722ba9c7cc468b8ec20c6687576
+    uses: aws/aws-durable-execution-conformance-tests/.github/workflows/python-opentelemetry.yml@5a31b277b014d688b4d7002f346cf9c01047e026
     with:
       phase: ${{ inputs.phase || 'short' }}
       delay_seconds: ${{ inputs.delay_seconds || '82800' }}

--- a/.github/workflows/opentelemetry-conformance-tests.yml
+++ b/.github/workflows/opentelemetry-conformance-tests.yml
@@ -52,7 +52,7 @@ jobs:
       actions: write
       contents: read
       id-token: write
-    uses: aws/aws-durable-execution-conformance-tests/.github/workflows/python-opentelemetry.yml@8d6fa1c6ac72fbd326a0657c3f2fc2391cd1cb22
+    uses: aws/aws-durable-execution-conformance-tests/.github/workflows/python-opentelemetry.yml@810cc12607fc28edf2d7864859ca08db42ff069a
     with:
       phase: ${{ inputs.phase || 'short' }}
       delay_seconds: ${{ inputs.delay_seconds || '82800' }}

--- a/.github/workflows/opentelemetry-conformance-tests.yml
+++ b/.github/workflows/opentelemetry-conformance-tests.yml
@@ -52,7 +52,7 @@ jobs:
       actions: write
       contents: read
       id-token: write
-    uses: aws/aws-durable-execution-conformance-tests/.github/workflows/python-opentelemetry.yml@3071832ab55c1baf96a5c21c6d526bcaad2a0345
+    uses: aws/aws-durable-execution-conformance-tests/.github/workflows/python-opentelemetry.yml@8d6fa1c6ac72fbd326a0657c3f2fc2391cd1cb22
     with:
       phase: ${{ inputs.phase || 'short' }}
       delay_seconds: ${{ inputs.delay_seconds || '82800' }}


### PR DESCRIPTION
## Summary
- add a thin caller for the shared Python OpenTelemetry conformance workflow
- test the exact SDK PR head commit on relevant core and OTel changes
- preserve manual short, launch, and check phases without copying test jobs
- map the language repository's AWS test credentials to the shared workflow contract

## Dependency
Depends on aws/aws-durable-execution-conformance-tests#56. The caller is pinned to that PR's immutable commit.

## Testing
- parsed `.github/workflows/opentelemetry-conformance-tests.yml` with Ruby Psych
- verified the pinned upstream commit is available through the GitHub API
- upstream contract suite: 55 passed