### PR TITLE
fix(otel): remove OpenTelemetry upper bounds

### DIFF
--- a/packages/aws-durable-execution-sdk-python-otel/README.md
+++ b/packages/aws-durable-execution-sdk-python-otel/README.md
@@ -286,6 +286,7 @@ setups.
 - `aws-durable-execution-sdk-python` >= 1.5.0
 - `opentelemetry-api` >= 1.20.0
 - `opentelemetry-sdk` >= 1.20.0
+- `opentelemetry-exporter-otlp`
 
 ## License
 

--- a/packages/aws-durable-execution-sdk-python-otel/README.md
+++ b/packages/aws-durable-execution-sdk-python-otel/README.md
@@ -284,9 +284,8 @@ setups.
 
 - Python >= 3.11
 - `aws-durable-execution-sdk-python` >= 1.5.0
-- `opentelemetry-api` >= 1.20.0, <= 1.42.1
-- `opentelemetry-sdk` >= 1.20.0, <= 1.42.1
-- `opentelemetry-exporter-otlp` <= 1.42.1
+- `opentelemetry-api` >= 1.20.0
+- `opentelemetry-sdk` >= 1.20.0
 
 ## License
 

--- a/packages/aws-durable-execution-sdk-python-otel/pyproject.toml
+++ b/packages/aws-durable-execution-sdk-python-otel/pyproject.toml
@@ -23,9 +23,9 @@ classifiers = [
 ]
 dependencies = [
   "aws-durable-execution-sdk-python>=1.5.0",
-  "opentelemetry-api>=1.20.0,<=1.42.1",
-  "opentelemetry-sdk>=1.20.0,<=1.42.1",
-  "opentelemetry-exporter-otlp<=1.42.1",
+  "opentelemetry-api>=1.20.0",
+  "opentelemetry-sdk>=1.20.0",
+  "opentelemetry-exporter-otlp",
   "opentelemetry-propagator-aws-xray",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
   "pytest",
   "pytest-cov",
   "pytest-xdist",
-  "opentelemetry-sdk>=1.20.0,<=1.42.1",
+  "opentelemetry-sdk>=1.20.0",
   "aws-durable-execution-sdk-python-testing",
   "PyYAML==6.0.2",
 ]
@@ -48,7 +48,7 @@ extra-dependencies = [
   "mypy>=1.0.0",
   "pytest",
   "boto3-stubs[lambda]",
-  "opentelemetry-sdk>=1.20.0,<=1.42.1",
+  "opentelemetry-sdk>=1.20.0",
   "opentelemetry-instrumentation-botocore",
   "opentelemetry-instrumentation-urllib3",
 ]
@@ -81,7 +81,7 @@ dependencies = [
   "pytest",
   "pytest-cov",
   "coverage[toml]",
-  "opentelemetry-sdk>=1.20.0,<=1.42.1",
+  "opentelemetry-sdk>=1.20.0",
   "mypy>=1.0.0",
 ]
 
@@ -125,7 +125,7 @@ test = "pytest packages/aws-durable-execution-sdk-python-examples/test {args}"
 [tool.hatch.envs.test-pypi-otel]
 dependencies = [
   "aws-durable-execution-sdk-python",
-  "opentelemetry-sdk>=1.20.0,<=1.42.1",
+  "opentelemetry-sdk>=1.20.0",
   "pytest",
   "pytest-cov",
   "coverage[toml]",


### PR DESCRIPTION
## Summary

- remove the temporary OpenTelemetry `<=1.42.1` upper bounds from package dependencies
- remove the same cap from Hatch test and type-check environments
- update the OTel package requirements documentation

## Why

The cap was added to remain compatible with the ADOT Lambda layer. Upstream fixed the incompatibility in [AWS OTel Python instrumentation v0.19.0](https://github.com/aws-observability/aws-otel-python-instrumentation/releases/tag/v0.19.0), so retaining the restriction would unnecessarily prevent consumers and development environments from resolving newer OpenTelemetry releases.

## Impact

Consumers can use OpenTelemetry versions newer than 1.42.1 while the existing minimum API and SDK version remains 1.20.0.

## Validation

- `hatch run dev-otel:test` (105 passed)
