### PR TITLE
ci: exclude conflict-affected regions

### DIFF
--- a/.github/scripts/tests/test_lambda_layer_publish_workflow.py
+++ b/.github/scripts/tests/test_lambda_layer_publish_workflow.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+
+import yaml
+
+
+COMMERCIAL_REGIONS = {
+    "af-south-1",
+    "ap-east-1",
+    "ap-east-2",
+    "ap-northeast-1",
+    "ap-northeast-2",
+    "ap-northeast-3",
+    "ap-south-1",
+    "ap-south-2",
+    "ap-southeast-1",
+    "ap-southeast-2",
+    "ap-southeast-3",
+    "ap-southeast-4",
+    "ap-southeast-5",
+    "ap-southeast-6",
+    "ap-southeast-7",
+    "ca-central-1",
+    "ca-west-1",
+    "eu-central-1",
+    "eu-central-2",
+    "eu-north-1",
+    "eu-south-1",
+    "eu-south-2",
+    "eu-west-1",
+    "eu-west-2",
+    "eu-west-3",
+    "il-central-1",
+    "me-central-1",
+    "me-south-1",
+    "mx-central-1",
+    "sa-east-1",
+    "us-east-1",
+    "us-east-2",
+    "us-west-1",
+    "us-west-2",
+}
+CONFLICT_AFFECTED_REGIONS = {"me-central-1", "me-south-1"}
+
+
+def test_default_layer_regions_exclude_conflict_affected_regions() -> None:
+    workflow_path = Path(__file__).parents[2] / "workflows" / "lambda-layer-publish.yml"
+    workflow = yaml.safe_load(workflow_path.read_text())
+    configured_regions = {
+        region.strip()
+        for region in workflow["env"]["DEFAULT_LAYER_REGIONS"].split(",")
+        if region.strip()
+    }
+
+    assert configured_regions == COMMERCIAL_REGIONS - CONFLICT_AFFECTED_REGIONS

--- a/.github/workflows/lambda-layer-publish.yml
+++ b/.github/workflows/lambda-layer-publish.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       regions:
-        description: "Comma-separated AWS Regions; defaults to all commercial Regions"
+        description: "Comma-separated AWS Regions; defaults to available commercial Regions"
         required: false
         type: string
 
@@ -47,8 +47,6 @@ env:
     eu-west-2,
     eu-west-3,
     il-central-1,
-    me-central-1,
-    me-south-1,
     mx-central-1,
     sa-east-1,
     us-east-1,

--- a/.github/workflows/test-parser.yml
+++ b/.github/workflows/test-parser.yml
@@ -6,12 +6,14 @@ on:
       - '.github/scripts/build_lambda_layer.py'
       - '.github/scripts/parse_sdk_branch.py'
       - '.github/scripts/tests/**'
+      - '.github/workflows/lambda-layer-publish.yml'
   push:
     branches: [ main ]
     paths:
       - '.github/scripts/build_lambda_layer.py'
       - '.github/scripts/parse_sdk_branch.py'
       - '.github/scripts/tests/**'
+      - '.github/workflows/lambda-layer-publish.yml'
 
 permissions:
   contents: read
@@ -23,10 +25,11 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
     - name: Install test dependencies
-      run: python -m pip install pytest
+      run: python -m pip install pytest PyYAML==6.0.2
 
     - name: Run script tests
       run: |
         python -m pytest \
           .github/scripts/tests/test_build_lambda_layer.py \
+          .github/scripts/tests/test_lambda_layer_publish_workflow.py \
           .github/scripts/tests/test_parse_sdk_branch.py

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -71,9 +71,10 @@ The workflow runs on the `release: [published]` event, so it fires whenever a re
 
 Releases containing an `otel-v` tag also trigger the
 [`lambda-layer-publish.yml`](.github/workflows/lambda-layer-publish.yml)
-workflow. It builds the SDK and OTel plugin into Lambda layers for each
-supported Python runtime and architecture, then publishes public versions of the
-`aws-durable-execution-sdk-python-otel-plugin` layer.
+workflow. It builds the SDK and OTel plugin into a universal Lambda layer, then
+publishes public versions of the
+`aws-durable-execution-sdk-python-otel-plugin` layer compatible with every
+supported Python runtime and architecture.
 For OTel-only releases, the workflow downloads the exact SDK version pinned by
 `layer.sdk-version` in `.github/lambda-layer-publish.toml`; that version must
 already be published to PyPI. Combined SDK and OTel releases require the pin to
@@ -82,12 +83,14 @@ match the new SDK version and build both distributions from the tagged source.
 The publishing job uses the `lambda-layer-publish` GitHub environment and its
 `LAYER_PUBLISH_ROLE_ARN` secret. Set the optional `LAYER_PUBLISH_REGIONS`
 environment variable to a comma-separated list of AWS Regions. When unset, the
-workflow publishes to every commercial AWS Region supported by Lambda.
+workflow publishes to commercial AWS Regions except `me-central-1` and
+`me-south-1`, which are temporarily excluded while AWS reports service
+disruptions caused by the conflict in the Middle East.
 The workflow can also be run manually from the Actions tab on `main`; its
 optional `regions` input overrides `LAYER_PUBLISH_REGIONS` for that run.
-Each runtime and architecture layer archive is built once and retained as a
-workflow artifact so retries publish the exact same resolved dependencies. Its
-SHA-256 is included in the layer description and verified before reuse.
+The universal layer archive is built once and retained as a workflow artifact
+so retries publish the exact same distributions. Its SHA-256 is included in the
+layer description and verified before reuse.
 The publishing role must allow `lambda:PublishLayerVersion` and
 `lambda:AddLayerVersionPermission`, as well as `lambda:ListLayerVersions` and
 `lambda:GetLayerVersion` for identity-checked, idempotent release retries.


### PR DESCRIPTION
## Summary
- temporarily exclude `me-central-1` and `me-south-1` from default layer publishing while AWS reports conflict-related service disruption
- continue publishing to every other commercial Region, including opt-in Regions
- retain the workflow input and environment variable overrides for explicitly targeting excluded Regions after recovery
- update release documentation for the universal layer and temporary Region policy
- add a test that locks the default Region set to all commercial Regions except the two conflict-affected Regions

## Testing
- `hatch run test:all .github/scripts/tests/test_lambda_layer_publish_workflow.py .github/scripts/tests/test_build_lambda_layer.py .github/scripts/tests/test_parse_sdk_branch.py .github/scripts/tests/test_resolve_layer_sdk_version.py`
- `hatch fmt --check .github/scripts/tests/test_lambda_layer_publish_workflow.py`
- parsed both modified workflow YAML files