### PR TITLE
fix(testing): reject blank execution ARNs

### DIFF
--- a/packages/aws-durable-execution-sdk-python-testing/src/aws_durable_execution_sdk_python_testing/executor.py
+++ b/packages/aws-durable-execution-sdk-python-testing/src/aws_durable_execution_sdk_python_testing/executor.py
@@ -196,6 +196,22 @@ class Executor(ExecutionObserver):
             execution_arn=execution.durable_execution_arn
         )
 
+    @staticmethod
+    def _require_valid_arn(execution_arn: str) -> None:
+        """Reject a blank or non-string execution ARN before it reaches the registry or store.
+
+        This runner's execution ARNs are opaque local identifiers, not
+        real AWS ARNs (see ``Execution.new``), so this only rules out
+        empty/malformed input rather than checking AWS ARN shape.
+
+        Raises:
+            InvalidParameterValueException: If the ARN is not a
+                non-empty string.
+        """
+        if not isinstance(execution_arn, str) or not execution_arn.strip():
+            msg: str = f"Invalid execution ARN: {execution_arn!r}"
+            raise InvalidParameterValueException(msg)
+
     def get_execution(self, execution_arn: str) -> Execution:
         """Get execution by ARN.
 
@@ -206,8 +222,10 @@ class Executor(ExecutionObserver):
             Execution: The execution object
 
         Raises:
+            InvalidParameterValueException: If the ARN is blank.
             ResourceNotFoundException: If execution does not exist
         """
+        self._require_valid_arn(execution_arn)
         try:
             return self._store.load(execution_arn)
         except KeyError as e:
@@ -376,8 +394,10 @@ class Executor(ExecutionObserver):
             StopDurableExecutionResponse: Response containing end timestamp
 
         Raises:
+            InvalidParameterValueException: If the ARN is blank.
             ResourceNotFoundException: If execution does not exist
         """
+        self._require_valid_arn(execution_arn)
         return self._registry.submit(
             execution_arn,
             CallableTask(lambda: self._apply_stop(execution_arn, error)),
@@ -415,7 +435,12 @@ class Executor(ExecutionObserver):
         marker: str | None = None,
         max_items: int | None = None,
     ) -> GetDurableExecutionStateResponse:
-        """Return a page of operations, serialized on the execution's worker."""
+        """Return a page of operations, serialized on the execution's worker.
+
+        Raises:
+            InvalidParameterValueException: If the ARN is blank.
+        """
+        self._require_valid_arn(execution_arn)
         return self._registry.submit(
             execution_arn,
             CallableTask(
@@ -795,7 +820,11 @@ class Executor(ExecutionObserver):
 
         Routes through the per-execution worker so checkpoints for one
         execution never overlap.
+
+        Raises:
+            InvalidParameterValueException: If the ARN is blank.
         """
+        self._require_valid_arn(execution_arn)
         return self._registry.submit(
             execution_arn,
             CallableTask(

--- a/packages/aws-durable-execution-sdk-python-testing/src/aws_durable_execution_sdk_python_testing/executor.py
+++ b/packages/aws-durable-execution-sdk-python-testing/src/aws_durable_execution_sdk_python_testing/executor.py
@@ -197,7 +197,7 @@ class Executor(ExecutionObserver):
         )
 
     @staticmethod
-    def _require_valid_arn(execution_arn: str) -> None:
+    def _validate_execution_arn(execution_arn: str) -> None:
         """Reject a blank or non-string execution ARN before it reaches the registry or store.
 
         This runner's execution ARNs are opaque local identifiers, not
@@ -209,7 +209,7 @@ class Executor(ExecutionObserver):
                 non-empty string.
         """
         if not isinstance(execution_arn, str) or not execution_arn.strip():
-            msg: str = f"Invalid execution ARN: {execution_arn!r}"
+            msg: str = "Invalid Durable Execution ARN"
             raise InvalidParameterValueException(msg)
 
     def get_execution(self, execution_arn: str) -> Execution:
@@ -225,7 +225,7 @@ class Executor(ExecutionObserver):
             InvalidParameterValueException: If the ARN is blank.
             ResourceNotFoundException: If execution does not exist
         """
-        self._require_valid_arn(execution_arn)
+        self._validate_execution_arn(execution_arn)
         try:
             return self._store.load(execution_arn)
         except KeyError as e:
@@ -397,7 +397,7 @@ class Executor(ExecutionObserver):
             InvalidParameterValueException: If the ARN is blank.
             ResourceNotFoundException: If execution does not exist
         """
-        self._require_valid_arn(execution_arn)
+        self._validate_execution_arn(execution_arn)
         return self._registry.submit(
             execution_arn,
             CallableTask(lambda: self._apply_stop(execution_arn, error)),
@@ -440,7 +440,7 @@ class Executor(ExecutionObserver):
         Raises:
             InvalidParameterValueException: If the ARN is blank.
         """
-        self._require_valid_arn(execution_arn)
+        self._validate_execution_arn(execution_arn)
         return self._registry.submit(
             execution_arn,
             CallableTask(
@@ -824,7 +824,7 @@ class Executor(ExecutionObserver):
         Raises:
             InvalidParameterValueException: If the ARN is blank.
         """
-        self._require_valid_arn(execution_arn)
+        self._validate_execution_arn(execution_arn)
         return self._registry.submit(
             execution_arn,
             CallableTask(

--- a/packages/aws-durable-execution-sdk-python-testing/tests/executor_test.py
+++ b/packages/aws-durable-execution-sdk-python-testing/tests/executor_test.py
@@ -1846,6 +1846,44 @@ def test_get_execution_not_found(executor, mock_store):
         executor.get_execution("test-arn")
 
 
+@pytest.mark.parametrize("blank_arn", ["", "   ", None])
+def test_get_execution_rejects_blank_arn(executor, mock_store, blank_arn):
+    with pytest.raises(InvalidParameterValueException):
+        executor.get_execution(blank_arn)
+
+    mock_store.load.assert_not_called()
+
+
+@pytest.mark.parametrize("blank_arn", ["", "   ", None])
+def test_stop_execution_rejects_blank_arn(executor, mock_store, blank_arn):
+    """A blank ARN must be rejected before it reaches the registry, so it
+    never creates a permanent phantom worker for an execution that was
+    never going to exist."""
+    with pytest.raises(InvalidParameterValueException):
+        executor.stop_execution(blank_arn)
+
+    mock_store.load.assert_not_called()
+    assert executor._registry.active_count() == 0  # noqa: SLF001
+
+
+@pytest.mark.parametrize("blank_arn", ["", "   ", None])
+def test_get_execution_state_rejects_blank_arn(executor, mock_store, blank_arn):
+    with pytest.raises(InvalidParameterValueException):
+        executor.get_execution_state(blank_arn, checkpoint_token="token")
+
+    mock_store.load.assert_not_called()
+    assert executor._registry.active_count() == 0  # noqa: SLF001
+
+
+@pytest.mark.parametrize("blank_arn", ["", "   ", None])
+def test_checkpoint_execution_rejects_blank_arn(executor, mock_store, blank_arn):
+    with pytest.raises(InvalidParameterValueException):
+        executor.checkpoint_execution(blank_arn, checkpoint_token="token")
+
+    mock_store.load.assert_not_called()
+    assert executor._registry.active_count() == 0  # noqa: SLF001
+
+
 def test_get_execution_state(mock_scheduler, mock_invoker, mock_checkpoint_processor):
     """GetDurableExecutionState is a pure read from the pinned
     snapshot, bounded by the configured byte cap. Uses a real store


### PR DESCRIPTION
*Issue #, if available:*: #461

*Description of changes:*

This PR adds execution ARN validation to the in-memory `Executor` used by the local test runner. Two things were missing:

- No input sanitation: a `None`/empty/whitespace-only `execution_arn` was never rejected before reaching store/registry internals.
- `get_execution_state`, `stop_execution`, and `checkpoint_execution` all call `self._registry.submit(execution_arn, ...)`, which calls `get_or_create()`,  so a bad ARN silently registered a permanent phantom worker (with its own thread/lane) *before* the existence check inside the task body ever ran and raised `ResourceNotFoundException`.

Note on scope: this runner's execution ARNs are opaque local identifiers (`Execution.new()` generates `f"{uuid4()}/{invocation_id}"`), not real AWS ARNs — confirmed by checking that neither the runtime code nor the existing test fixtures (e.g. `executor_test.py`) use the real `arn:aws:lambda:...:function:.../durable-execution/.../...` shape. So this
validates blank/non-string input rather than checking AWS ARN structure, which would have rejected legitimate executions.

Changes:
- `Executor._require_valid_arn()`: raises `InvalidParameterValueException` for a blank/non-string ARN
- Wired into `get_execution`, `stop_execution`, `get_execution_state`, `checkpoint_execution`, before `registry.submit()` in the latter three, closing the phantom-worker leak
- 12 new tests (4 methods x 3 blank-input variants), including assertions that `registry.active_count() == 0` after a rejected call


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.