### PR TITLE
ci: reuse shared AI Slack notification summaries

### DIFF
--- a/.github/scripts/tests/test_notify_workflow.py
+++ b/.github/scripts/tests/test_notify_workflow.py
@@ -1,0 +1,25 @@
+import re
+from pathlib import Path
+
+
+WORKFLOW_PATH = Path(__file__).parents[2] / "workflows" / "notify.yml"
+SHARED_WORKFLOW_SHA = "d69a436185c855810c6806c8e1fd76e5f0b8ff9b"
+
+
+def test_notify_workflow_reuses_pinned_shared_implementation() -> None:
+    workflow = WORKFLOW_PATH.read_text()
+    match = re.search(r"(?ms)^  notify:\n(.*)\Z", workflow)
+
+    assert match is not None
+    notify_job = match.group(1)
+    assert (
+        "uses: aws/aws-durable-execution-ci/.github/workflows/notify.yml@"
+        f"{SHARED_WORKFLOW_SHA}"
+    ) in notify_job
+    assert "contents: read" in notify_job
+    assert "models: read" in notify_job
+    assert "runs-on:" not in notify_job
+    assert "summarize_notification.py" not in notify_job
+    assert "SLACK_WEBHOOK_URL_PR" in notify_job
+    assert "SLACK_WEBHOOK_URL_ISSUE" in notify_job
+    assert "SLACK_WEBHOOK_URL_RELEASE" in notify_job

--- a/.github/scripts/tests/test_notify_workflow.py
+++ b/.github/scripts/tests/test_notify_workflow.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 
 WORKFLOW_PATH = Path(__file__).parents[2] / "workflows" / "notify.yml"
-SHARED_WORKFLOW_SHA = "d69a436185c855810c6806c8e1fd76e5f0b8ff9b"
+SHARED_WORKFLOW_SHA = "6cade565b59817027aa0fe4949d5923286b6675c"
 
 
 def test_notify_workflow_reuses_pinned_shared_implementation() -> None:

--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: read
       models: read
-    uses: aws/aws-durable-execution-ci/.github/workflows/notify.yml@d69a436185c855810c6806c8e1fd76e5f0b8ff9b
+    uses: aws/aws-durable-execution-ci/.github/workflows/notify.yml@6cade565b59817027aa0fe4949d5923286b6675c
     secrets:
       SLACK_WEBHOOK_URL_PR: ${{ secrets.SLACK_WEBHOOK_URL_PR }}
       SLACK_WEBHOOK_URL_ISSUE: ${{ secrets.SLACK_WEBHOOK_URL_ISSUE }}

--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -12,7 +12,10 @@ permissions: {}
 
 jobs:
   notify:
-    uses: aws/aws-durable-execution-ci/.github/workflows/notify.yml@71259cf476e37255752d8f9445a1a48ec92be1df
+    permissions:
+      contents: read
+      models: read
+    uses: aws/aws-durable-execution-ci/.github/workflows/notify.yml@d69a436185c855810c6806c8e1fd76e5f0b8ff9b
     secrets:
       SLACK_WEBHOOK_URL_PR: ${{ secrets.SLACK_WEBHOOK_URL_PR }}
       SLACK_WEBHOOK_URL_ISSUE: ${{ secrets.SLACK_WEBHOOK_URL_ISSUE }}

--- a/.github/workflows/test-parser.yml
+++ b/.github/workflows/test-parser.yml
@@ -6,12 +6,14 @@ on:
       - '.github/scripts/build_lambda_layer.py'
       - '.github/scripts/parse_sdk_branch.py'
       - '.github/scripts/tests/**'
+      - '.github/workflows/notify.yml'
   push:
     branches: [ main ]
     paths:
       - '.github/scripts/build_lambda_layer.py'
       - '.github/scripts/parse_sdk_branch.py'
       - '.github/scripts/tests/**'
+      - '.github/workflows/notify.yml'
 
 permissions:
   contents: read
@@ -29,4 +31,5 @@ jobs:
       run: |
         python -m pytest \
           .github/scripts/tests/test_build_lambda_layer.py \
+          .github/scripts/tests/test_notify_workflow.py \
           .github/scripts/tests/test_parse_sdk_branch.py


### PR DESCRIPTION
## Summary
- grant the reusable Slack workflow `contents: read` and `models: read`
- pin the AI summary implementation from `aws/aws-durable-execution-ci#14`
- add a regression test that keeps this repository as a thin caller

Depends on aws/aws-durable-execution-ci#14. The workflow pin currently references that PR's head commit and must be updated to the merged commit before this PR is marked ready.

## Testing
- `hatch run test:all .github/scripts/tests/test_build_lambda_layer.py .github/scripts/tests/test_notify_workflow.py .github/scripts/tests/test_parse_sdk_branch.py` (7 tests)
- `hatch fmt --check .github/scripts/tests/test_notify_workflow.py`
- actionlint on `.github/workflows/notify.yml` and `.github/workflows/test-parser.yml`
- `git diff --check`