### PR TITLE
Update shared CI workflows to v0.2.0

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -12,7 +12,7 @@ jobs:
       contents: read
       id-token: write
       pull-requests: write
-    uses: aws/aws-durable-execution-ci/.github/workflows/ai-pr-review.yml@71259cf476e37255752d8f9445a1a48ec92be1df
+    uses: aws/aws-durable-execution-ci/.github/workflows/ai-pr-review.yml@ac55d9f4b027e193aba9fa5a69c70bfa1bdc38ed
     with:
       prompt-path: .github/prompts/ai-pr-review.md
     secrets: inherit

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -9,5 +9,8 @@ permissions: {}
 jobs:
   triage:
     permissions:
+      contents: read
+      id-token: write
       issues: write
-    uses: aws/aws-durable-execution-ci/.github/workflows/issue-triage.yml@71259cf476e37255752d8f9445a1a48ec92be1df
+    uses: aws/aws-durable-execution-ci/.github/workflows/issue-triage.yml@ac55d9f4b027e193aba9fa5a69c70bfa1bdc38ed
+    secrets: inherit

--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -12,7 +12,10 @@ permissions: {}
 
 jobs:
   notify:
-    uses: aws/aws-durable-execution-ci/.github/workflows/notify.yml@71259cf476e37255752d8f9445a1a48ec92be1df
+    permissions:
+      contents: read
+      models: read
+    uses: aws/aws-durable-execution-ci/.github/workflows/notify.yml@ac55d9f4b027e193aba9fa5a69c70bfa1bdc38ed
     secrets:
       SLACK_WEBHOOK_URL_PR: ${{ secrets.SLACK_WEBHOOK_URL_PR }}
       SLACK_WEBHOOK_URL_ISSUE: ${{ secrets.SLACK_WEBHOOK_URL_ISSUE }}


### PR DESCRIPTION
## Summary

- Pin the shared AI review, issue triage, and Slack notification workflows to the immutable `v0.2.0` commit.
- Grant GitHub Models read access for AI-generated Slack summaries.
- Grant the Bedrock issue-triage workflow OIDC and contents access, and inherit the `ai-pr-review-runtime` environment secret.

## Testing

- Parsed the changed workflow files with PyYAML.
- Ran `git diff --check`.