### PR TITLE
ci: schedule long-running OTel conformance tests

### DIFF
--- a/.github/scripts/tests/test_opentelemetry_conformance_workflow.py
+++ b/.github/scripts/tests/test_opentelemetry_conformance_workflow.py
@@ -13,6 +13,8 @@ EXAMPLES_DIR = (
 def test_opentelemetry_conformance_caller_uses_current_workflow_contract() -> None:
     workflow = WORKFLOW_PATH.read_text()
 
+    assert '  schedule:\n    - cron: "0 7 * * *"' in workflow
+
     orchestrator = (
         "uses: aws/aws-durable-execution-conformance-tests/.github/workflows/"
         f"opentelemetry-orchestrator.yml@{ORCHESTRATOR_REVISION}"

--- a/.github/scripts/tests/test_opentelemetry_conformance_workflow.py
+++ b/.github/scripts/tests/test_opentelemetry_conformance_workflow.py
@@ -4,7 +4,7 @@ from pathlib import Path
 WORKFLOW_PATH = (
     Path(__file__).parents[2] / "workflows" / "opentelemetry-conformance-tests.yml"
 )
-ORCHESTRATOR_REVISION = "8de1bbfdccfeb36d5f9ccee99f21533f0bcb1d72"
+ORCHESTRATOR_REVISION = "91740c98b496409fa9f1bb8e8e6c329ca8b0185f"
 EXAMPLES_DIR = (
     ".build/durable-sdk/packages/aws-durable-execution-sdk-python-conformance-tests-otel"
 )

--- a/.github/workflows/opentelemetry-conformance-tests.yml
+++ b/.github/workflows/opentelemetry-conformance-tests.yml
@@ -58,7 +58,7 @@ jobs:
       actions: write
       contents: read
       id-token: write
-    uses: aws/aws-durable-execution-conformance-tests/.github/workflows/opentelemetry-orchestrator.yml@8de1bbfdccfeb36d5f9ccee99f21533f0bcb1d72
+    uses: aws/aws-durable-execution-conformance-tests/.github/workflows/opentelemetry-orchestrator.yml@91740c98b496409fa9f1bb8e8e6c329ca8b0185f
     with:
       language: python
       resource_prefix: p

--- a/.github/workflows/opentelemetry-conformance-tests.yml
+++ b/.github/workflows/opentelemetry-conformance-tests.yml
@@ -21,6 +21,8 @@ on:
       - "packages/aws-durable-execution-sdk-python-otel/**"
       - "packages/aws-durable-execution-sdk-python-conformance-tests-otel/**"
       - ".github/workflows/opentelemetry-conformance-tests.yml"
+  schedule:
+    - cron: "0 7 * * *"
   workflow_dispatch:
     inputs:
       phase:


### PR DESCRIPTION
## Summary

- restore the daily 07:00 UTC trigger from the former shared Python OpenTelemetry workflow
- let scheduled events drive the reusable orchestrator's automatic long-running check/launch cycle
- cover the schedule in the existing workflow contract test

Related issue: aws/aws-durable-execution-conformance-tests#90

Related PRs:

- aws/aws-durable-execution-sdk-java#639
- aws/aws-durable-execution-sdk-js#843

## Testing

- executed `test_opentelemetry_conformance_caller_uses_current_workflow_contract` directly
- parsed `.github/workflows/opentelemetry-conformance-tests.yml` successfully with Ruby YAML
- `git diff --check`
