### PR TITLE
ci: run conformance tests on pushes to main

### DIFF
--- a/.github/workflows/conformance-tests.yml
+++ b/.github/workflows/conformance-tests.yml
@@ -5,6 +5,8 @@ name: Conformance Tests
 # as its own parallel matrix job with the pinned language-agnostic runner.
 
 on:
+  push:
+    branches: ["main"]
   pull_request:
     branches: ["main"]
     paths:


### PR DESCRIPTION
## Summary
Adds a `push` trigger for the `main` branch to the Conformance Tests workflow so the suite also runs after commits land on `main`, not only on pull requests.

## Change
Under `on:`, a `push: { branches: ["main"] }` trigger is added immediately before the existing `pull_request` trigger.

## Behavior
- Conformance now runs on every push to `main` (e.g. after a PR merges), providing post-merge validation of the integrated state.
- The existing `pull_request` trigger and its `paths` filters are unchanged, so PR-time path filtering behaves exactly as before.
- `workflow_dispatch`, concurrency, and all jobs are untouched.

Note: the `push` trigger intentionally has no `paths` filter, so any push to `main` runs the suite.