### PR TITLE
fix(ci): grant AI review contents write permission

### DIFF
--- a/.github/scripts/tests/test_ai_pr_review_workflow.py
+++ b/.github/scripts/tests/test_ai_pr_review_workflow.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+
+WORKFLOW_PATH = Path(__file__).parents[2] / "workflows" / "ai-pr-review.yml"
+
+
+def test_ai_pr_review_caller_grants_reusable_workflow_permissions() -> None:
+    workflow = WORKFLOW_PATH.read_text()
+
+    required_permissions = (
+        "  ai-pr-review:\n"
+        "    permissions:\n"
+        "      contents: write\n"
+        "      id-token: write\n"
+        "      pull-requests: write\n"
+    )
+    assert required_permissions in workflow

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -9,7 +9,7 @@ permissions: {}
 jobs:
   ai-pr-review:
     permissions:
-      contents: read
+      contents: write
       id-token: write
       pull-requests: write
     uses: aws/aws-durable-execution-ci/.github/workflows/ai-pr-review.yml@8de63fa646c1b7b778829126cf53b7874074795e

--- a/.github/workflows/test-parser.yml
+++ b/.github/workflows/test-parser.yml
@@ -7,6 +7,7 @@ on:
       - '.github/scripts/check_otel_wheel_dependencies.py'
       - '.github/scripts/parse_sdk_branch.py'
       - '.github/scripts/tests/**'
+      - '.github/workflows/ai-pr-review.yml'
       - '.github/workflows/opentelemetry-conformance-tests.yml'
       - 'packages/aws-durable-execution-sdk-python-otel/pyproject.toml'
   push:
@@ -16,6 +17,7 @@ on:
       - '.github/scripts/check_otel_wheel_dependencies.py'
       - '.github/scripts/parse_sdk_branch.py'
       - '.github/scripts/tests/**'
+      - '.github/workflows/ai-pr-review.yml'
       - '.github/workflows/opentelemetry-conformance-tests.yml'
       - 'packages/aws-durable-execution-sdk-python-otel/pyproject.toml'
 
@@ -34,6 +36,7 @@ jobs:
     - name: Run script tests
       run: |
         python -m pytest \
+          .github/scripts/tests/test_ai_pr_review_workflow.py \
           .github/scripts/tests/test_build_lambda_layer.py \
           .github/scripts/tests/test_check_otel_wheel_dependencies.py \
           .github/scripts/tests/test_opentelemetry_conformance_workflow.py \


### PR DESCRIPTION
## Summary

- grant the reusable AI review workflow the `contents: write` permission required by its v0.3.0 telemetry job
- add a regression test for the caller permission contract
- run the GitHub script tests when the AI review workflow changes

This fixes the startup failure in https://github.com/aws/aws-durable-execution-sdk-python/actions/runs/33423069291.

> [!NOTE]
> This PR's own `AI PR Review` run is expected to have the same startup failure
> because `pull_request_target` evaluates the workflow from the base branch.
> The corrected permission takes effect after this change reaches `main`.

## Validation

- parsed the modified workflows with PyYAML
- ran the new regression assertion directly
- ran `git diff --check`
- ran `.github/scripts/lintcommit.py`

The full script-test command was not run locally because `pytest` is not installed in the workspace; the updated `Test GitHub Scripts` workflow will run it in CI.
