### PR TITLE
feat(ci): enable AI review commands and activity events

### DIFF
--- a/.github/scripts/tests/test_ai_pr_review_workflow.py
+++ b/.github/scripts/tests/test_ai_pr_review_workflow.py
@@ -4,6 +4,23 @@ from pathlib import Path
 WORKFLOW_PATH = Path(__file__).parents[2] / "workflows" / "ai-pr-review.yml"
 
 
+def test_ai_pr_review_caller_subscribes_to_supported_events() -> None:
+    workflow = WORKFLOW_PATH.read_text()
+
+    supported_events = (
+        "on:\n"
+        "  pull_request_target:\n"
+        "    types: [opened, synchronize, reopened, ready_for_review]\n"
+        "  pull_request_review:\n"
+        "    types: [submitted, edited, dismissed]\n"
+        "  pull_request_review_comment:\n"
+        "    types: [created, edited, deleted]\n"
+        "  issue_comment:\n"
+        "    types: [created]\n"
+    )
+    assert supported_events in workflow
+
+
 def test_ai_pr_review_caller_grants_reusable_workflow_permissions() -> None:
     workflow = WORKFLOW_PATH.read_text()
 

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -3,6 +3,12 @@ name: AI PR Review
 on:
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+  pull_request_review_comment:
+    types: [created, edited, deleted]
+  issue_comment:
+    types: [created]
 
 permissions: {}
 


### PR DESCRIPTION
## Summary

- mirror the pinned reusable AI review workflow's supported event triggers
- enable authorized `/ai review` commands through pull request issue comments
- record activity for submitted, edited, or dismissed reviews and created, edited, or deleted review comments
- add regression coverage for the caller event contract

Follow-up to #695.

## Validation

- parsed the modified workflow with PyYAML
- ran both AI review workflow regression assertions directly
- ran `git diff --check`
- ran `.github/scripts/lintcommit.py`
