### PR TITLE
test: add replay identity conformance case

### DIFF
--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/general/__init__.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/general/__init__.py
@@ -1,0 +1,1 @@
+"""General cross-cutting conformance handlers."""

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/general/replay_operation_identity.py
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/handlers/general/replay_operation_identity.py
@@ -1,0 +1,29 @@
+"""11-1: Replay rejects an operation-type mismatch."""
+
+from typing import Any
+
+from aws_durable_execution_sdk_python.config import Duration
+from aws_durable_execution_sdk_python.context import (
+    DurableContext,
+    StepContext,
+    durable_step,
+)
+from aws_durable_execution_sdk_python.execution import durable_execution
+
+
+@durable_step
+def unexpected_step(step_context: StepContext) -> str:
+    step_context.logger.info("DETERMINISM_STEP_BODY_EXECUTED")
+    return "unexpected"
+
+
+@durable_execution
+def handler(_event: Any, context: DurableContext) -> str | None:
+    replay_logger = context.logger.with_is_replaying(lambda: False)
+
+    if context.is_replaying():
+        replay_logger.info("DETERMINISM_REPLAY_CANARY")
+        return context.step(unexpected_step(), name="identity-slot")
+
+    context.wait(Duration.from_seconds(1), name="identity-slot")
+    return None

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/template_general.yaml
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/template_general.yaml
@@ -1,0 +1,49 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Globals:
+  Function:
+    Runtime: python3.13
+    Timeout: 60
+    MemorySize: 128
+    LoggingConfig:
+      LogFormat: JSON
+      ApplicationLogLevel: INFO
+      SystemLogLevel: INFO
+Resources:
+  DurableFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: lambda.amazonaws.com
+          Action: sts:AssumeRole
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+      - PolicyName: DurableExecutionPolicy
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - lambda:CheckpointDurableExecution
+            - lambda:GetDurableExecutionState
+            Resource: '*'
+  ReplayOperationIdentity:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["11-1"]
+    Properties:
+      CodeUri: lambda-build/
+      Handler: general.replay_operation_identity.handler
+      Description: Replay rejects an operation-type mismatch
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300


### PR DESCRIPTION
## Summary

- add the `general` conformance suite and handler for requirement `11-1`
- emit a named `WAIT` on the first invocation and a named `STEP` at the same replay position
- enable replay-visible canary logging and prove the mismatched step body never executes
- make replay-identity diagnostics identify checkpointed values as expected and emitted values as current

## Dependencies

- stacked on #698, which adds replay operation-identity validation
- implements https://github.com/aws/aws-durable-execution-conformance-tests/pull/111

## Testing

- `python3 packages/aws-durable-execution-sdk-python-conformance-tests/scripts/discover_suites.py`
- `python3 packages/aws-durable-execution-sdk-python-conformance-tests/scripts/build_examples.py`
- focused state tests: 4 passed
- focused execution tests: 3 passed
- `hatch run dev-core:typecheck`
- Ruff check and format verification for changed Python files
- `git diff --check`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
