### PR TITLE
Add comment/review triggers to AI PR review

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -3,6 +3,12 @@ name: AI PR Review
 on:
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+  pull_request_review_comment:
+    types: [created, edited, deleted]
+  issue_comment:
+    types: [created]
 
 permissions: {}
 


### PR DESCRIPTION
Adds `pull_request_review`, `pull_request_review_comment`, and `issue_comment` triggers to the AI PR review workflow, matching the Java SDK repo's configuration.

Currently the Python repo only auto-triggers on `pull_request_target` events, so a `/ai review` comment does nothing and draft PRs cannot be reviewed on demand (the reusable workflow's draft guard only skips auto-triggered reviews, not command-requested ones). Adding `issue_comment` enables the `/ai review` command, and the review/review-comment triggers keep telemetry consistent with Java.

Same reusable workflow and pinned SHA (`8de63fa`) are unchanged.