### PR TITLE
docs(insight): fix scheduler comment

### DIFF
--- a/packages/aws-durable-execution-sdk-python-insight/src/aws_durable_execution_sdk_python_insight/plugin.py
+++ b/packages/aws-durable-execution-sdk-python-insight/src/aws_durable_execution_sdk_python_insight/plugin.py
@@ -342,9 +342,9 @@ class WorkflowInsightPlugin(DurableInstrumentationPlugin):
         if should_emit:
             # Only terminal (SUCCEEDED/FAILED) records carry an end time; a
             # PENDING/RETRY invocation end maps to RUNNING (still in flight) and
-            # must omit endTime/durationMs. Passing end_time=None makes _emit
-            # drop both fields. Output and error likewise belong only to a
-            # terminal record.
+            # must omit endTime/durationMs. Passing end_time=None makes
+            # _schedule_record drop both fields. Output and error likewise
+            # belong only to a terminal record.
             self._schedule_record(
                 arn,
                 state,


### PR DESCRIPTION
## Summary

Fix the stale `_emit` method reference in a Workflow Insight comment after the method was split into `_build_record` and `_schedule_record`.

Stacked on #702.

## Comment audit

- Timed-out barrier accumulation: fixed in `6c723ba`; thread is outdated.
- Implicit `RLock`: fixed in `6c723ba`; thread resolved.
- Duplicate exporter instance: fixed in `7ba7520`; thread resolved.
- Unlocked scheduled flag: fixed in `7ba7520`; thread resolved.
- Latest Codex review: no actionable findings.
- Latest Claude review: only this documentation nit remained.

## Validation

- Insight package Ruff lint and format passed.
- Commit lint passed.
- Source behavior is unchanged; no tests or conformance rerun needed.