### PR TITLE
chore(release): bump sdk to 2.0.0

### DIFF
--- a/.github/lambda-layer-publish.toml
+++ b/.github/lambda-layer-publish.toml
@@ -1,2 +1,2 @@
 [layer]
-sdk-version = "1.8.0"
+sdk-version = "2.0.0"

--- a/packages/aws-durable-execution-sdk-python-conformance-tests-otel/pyproject.toml
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests-otel/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.0.0"
 description = "OpenTelemetry conformance test handlers for the AWS Durable Execution SDK for Python, exercised by the aws-durable-execution-conformance-tests OTel suites."
 requires-python = ">=3.11"
 dependencies = [
-  "aws-durable-execution-sdk-python==1.8.0",
+  "aws-durable-execution-sdk-python==2.0.0",
   "aws-durable-execution-sdk-python-otel==0.4.0",
 ]
 

--- a/packages/aws-durable-execution-sdk-python-conformance-tests/pyproject.toml
+++ b/packages/aws-durable-execution-sdk-python-conformance-tests/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.0.0"
 description = "Cross-SDK conformance test handlers for the AWS Durable Execution SDK for Python, exercised by the aws-durable-execution-conformance-tests runner."
 requires-python = ">=3.11"
 dependencies = [
-  "aws-durable-execution-sdk-python==1.8.0",
+  "aws-durable-execution-sdk-python==2.0.0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/packages/aws-durable-execution-sdk-python-insight/pyproject.toml
+++ b/packages/aws-durable-execution-sdk-python-insight/pyproject.toml
@@ -21,9 +21,9 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [
-  # >=1.8.0: first release carrying the plugin invocation-hook fields
+  # >=2.0.0: first published release carrying the plugin invocation-hook fields
   # (InvocationInfo.execution_input / InvocationEndInfo.execution_result).
-  "aws-durable-execution-sdk-python>=1.8.0",
+  "aws-durable-execution-sdk-python>=2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/packages/aws-durable-execution-sdk-python-otel/README.md
+++ b/packages/aws-durable-execution-sdk-python-otel/README.md
@@ -397,7 +397,7 @@ setups.
 ## Requirements
 
 - Python >= 3.11
-- `aws-durable-execution-sdk-python` >= 1.8.0
+- `aws-durable-execution-sdk-python` >= 2.0.0
 - An ADOT/community OpenTelemetry Lambda layer, or the `standalone` extra
 
 ## License

--- a/packages/aws-durable-execution-sdk-python-otel/pyproject.toml
+++ b/packages/aws-durable-execution-sdk-python-otel/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "aws-durable-execution-sdk-python>=1.8.0",
+  "aws-durable-execution-sdk-python>=2.0.0",
 ]
 
 [project.entry-points."aws_durable_execution.plugins"]

--- a/packages/aws-durable-execution-sdk-python-otel/tests/test_package_metadata.py
+++ b/packages/aws-durable-execution-sdk-python-otel/tests/test_package_metadata.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 PACKAGE_ROOT = Path(__file__).resolve().parents[1]
 REPOSITORY_ROOT = PACKAGE_ROOT.parents[1]
-CORE_DEPENDENCY = "aws-durable-execution-sdk-python>=1.8.0"
+CORE_DEPENDENCY = "aws-durable-execution-sdk-python>=2.0.0"
 TEST_OTEL_DEPENDENCIES = {
     "opentelemetry-sdk>=1.20.0",
     "opentelemetry-propagator-aws-xray",

--- a/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/__about__.py
+++ b/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2025-present Amazon.com, Inc. or its affiliates.
 #
 # SPDX-License-Identifier: Apache-2.0
-__version__ = "1.8.0"
+__version__ = "2.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,7 +129,7 @@ test = "pytest packages/aws-durable-execution-sdk-python-examples/test {args}"
 
 [tool.hatch.envs.test-pypi-otel]
 dependencies = [
-  "aws-durable-execution-sdk-python>=1.8.0",
+  "aws-durable-execution-sdk-python>=2.0.0",
   "opentelemetry-sdk>=1.20.0",
   "opentelemetry-propagator-aws-xray",
   "pytest",


### PR DESCRIPTION
Bumps `aws-durable-execution-sdk-python` from 1.8.0 (unreleased; last published release is 1.7.0) to 2.0.0, and aligns every reference to the never-published 1.8.0: conformance test exact pins, the otel and insight SDK floors (both build against the 2.0 plugin interface), the test-pypi-otel hatch env, and the lambda-layer sdk-version pin. SDK-only release: otel and testing package versions are unchanged.

The [migration guide](https://github.com/aws/aws-durable-execution-sdk-python/blob/main/docs/migration-1.x-to-2.0.md) covers every change below (merged in #655).

## Changes since sdk-v1.7.0

### Breaking Changes

- Typed per-operation error hierarchy; `CallableRuntimeError`, `UserlandError`, `CallableRuntimeErrorSerializableDetails` removed (136976d, #540)
- Graded callback errors; `CallbackError` out of the termination tree (c089f9f, #563)
- Serdes failures raise `SerDesError` instead of `ExecutionError`; first-run serialize/deserialize round trip for step, child contexts, map/parallel, and wait_for_condition; `RetryableSerDesError` added (d527f19 #543, caa57ad #550)
- `map`/`parallel`: `max_concurrency` bounds in-flight branches, config validation at construction and call time, `all_completed()` now tolerates all failures, `BatchResult.all` omits never-started branches, summary payloads use an SDK-owned envelope (fdc952b)
- Replay validates operation identity (`type`, `sub_type`, `name`, `parent_id`); mismatches raise `NonDeterministicExecutionError` (38d94dc, #698)
- `wait_for_condition` raises `WaitForConditionError` on exhaustion; `WaitDecision` and `WaitStrategyConfig.timeout` removed (e77a53e)
- `wait_for_condition` fails on unreadable polling state instead of restarting from `initial_state` (c183ec8)
- `InvokeConfig.timeout` / `timeout_seconds` removed (a982efa, #340)
- Removed 1.x-only names: `ItemBatcher`, `ItemsPerBatchUnit`, `BatchedInput`, `TerminationMode`, `StepFuture`, `MapConfig.item_batcher`, `ChildConfig.item_serdes`, `ChainedInvoke*` enums (6a89b70)

### Features

- `should_complete` custom completion predicate for `map`/`parallel`, with `complete_batch`/`continue_batch`, `CompletionOutcome`, `CompletionStatus`, and `BatchCompletionError` (d4090f1, #605)
- `attempt` exposed on `StepContext` and `WaitForConditionCheckContext` (6aa6a02, #549)
- Plugin auto-discovery and `PluginLoadError` (808e9a8, #620); plugin interface stabilization (c93073f, #625) — interface remains experimental

### Bug Fixes

- Empty-string payloads preserved when serializing (b448f3e, #555)
- Orphan checkpoint race rejected (ae73e73, #690)
- Missing checkpoint token from service handled (432cf07, #571)

### Docs

- 1.x to 2.0 migration guide (#655)

## Release checklist context (RELEASING.md)

- [x] Version bumped in `__about__.py`
- [x] Conformance test pins moved to `==2.0.0`; otel/insight/dev-env floors to `>=2.0.0`; layer pin to `2.0.0`
- [ ] After merge: create GitHub Release with tag `sdk-v2.0.0` to trigger PyPI publish
- Note: a future testing package release should tighten its SDK floor (currently `>=1.0.0`), since published testing 1.x accepts SDK 2.0.0 where removed 1.x names no longer exist.

