### PR TITLE
ci: remove scheduled OpenTelemetry runs

### DIFF
--- a/.github/scripts/tests/test_opentelemetry_conformance_workflow.py
+++ b/.github/scripts/tests/test_opentelemetry_conformance_workflow.py
@@ -12,7 +12,7 @@ EXAMPLES_DIR = (
 def test_opentelemetry_conformance_caller_uses_current_workflow_contract() -> None:
     workflow = WORKFLOW_PATH.read_text()
 
-    assert '  schedule:\n    - cron: "0 7 * * *"' in workflow
+    assert "\n  schedule:" not in workflow
 
     orchestrator = (
         "uses: aws/aws-durable-execution-conformance-tests/.github/workflows/"

--- a/.github/workflows/opentelemetry-conformance-tests.yml
+++ b/.github/workflows/opentelemetry-conformance-tests.yml
@@ -21,8 +21,6 @@ on:
       - "packages/aws-durable-execution-sdk-python-otel/**"
       - "packages/aws-durable-execution-sdk-python-conformance-tests-otel/**"
       - ".github/workflows/opentelemetry-conformance-tests.yml"
-  schedule:
-    - cron: "0 7 * * *"
   workflow_dispatch:
     inputs:
       phase:


### PR DESCRIPTION
## Summary

- remove the daily schedule from the OpenTelemetry conformance workflow
- keep pull request, push, and manual dispatch triggers
- update the workflow contract test to prevent scheduled runs from being reintroduced

This stops automatic runs such as https://github.com/aws/aws-durable-execution-sdk-python/actions/runs/34323141348.

## Testing

- 15 GitHub script tests passed, including test_opentelemetry_conformance_workflow.py