### PR TITLE
ci: bump AI review workflow to v0.3.1

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -18,7 +18,8 @@ jobs:
       contents: write
       id-token: write
       pull-requests: write
-    uses: aws/aws-durable-execution-ci/.github/workflows/ai-pr-review.yml@8de63fa646c1b7b778829126cf53b7874074795e
+    uses: aws/aws-durable-execution-ci/.github/workflows/ai-pr-review.yml@d6b017da14385908951d23e26c790b28a4e5f9f0
     with:
       prompt-path: .github/prompts/ai-pr-review.md
+      run-claude: false
     secrets: inherit


### PR DESCRIPTION
### Summary

- Pin the reusable AI PR review workflow to commit `d6b017da14385908951d23e26c790b28a4e5f9f0` (`v0.3.1`).
- Explicitly set `run-claude: false` so Claude AI review remains disabled.

### Testing

- `git diff --check`
- Parsed `.github/workflows/ai-pr-review.yml` with PyYAML