### PR TITLE
fix: match invalid checkpoint token casing

### DIFF
--- a/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/exceptions.py
+++ b/packages/aws-durable-execution-sdk-python/src/aws_durable_execution_sdk_python/exceptions.py
@@ -13,7 +13,7 @@ BAD_REQUEST_ERROR: int = 400
 TOO_MANY_REQUESTS_ERROR: int = 429
 SERVICE_ERROR: int = 500
 INVALID_PARAMETER_VALUE_EXCEPTION: str = "InvalidParameterValueException"
-INVALID_CHECKPOINT_TOKEN_PREFIX: str = "Invalid Checkpoint Token"
+INVALID_CHECKPOINT_TOKEN_PREFIX: str = "invalid checkpoint token"
 
 # Non-retryable customer error codes that arrive as non-4xx (e.g. HTTP 502) from Lambda.
 # Unlike typical 5xx errors, these require customer intervention (e.g., fixing
@@ -162,7 +162,7 @@ class BotoClientError(InvocationError):
           These arrive as HTTP 502 but require customer intervention to fix.
         - 4xx errors → EXECUTION, except:
           - 429 (TooManyRequests) → INVOCATION (throttling is transient)
-          - InvalidParameterValueException with "Invalid Checkpoint Token" → INVOCATION
+          - InvalidParameterValueException with "Invalid checkpoint token" (case-insensitive) → INVOCATION
             (stale token from a concurrent checkpoint; next invocation gets a fresh token)
         - 5xx, network errors → INVOCATION
         """
@@ -180,9 +180,9 @@ class BotoClientError(InvocationError):
             and error
             and not (
                 (error.get("Code") or "") == INVALID_PARAMETER_VALUE_EXCEPTION
-                and (error.get("Message") or "").startswith(
-                    INVALID_CHECKPOINT_TOKEN_PREFIX
-                )
+                and (error.get("Message") or "")
+                .casefold()
+                .startswith(INVALID_CHECKPOINT_TOKEN_PREFIX)
             )
         ):
             return DurableApiErrorCategory.EXECUTION

--- a/packages/aws-durable-execution-sdk-python/tests/exceptions_test.py
+++ b/packages/aws-durable-execution-sdk-python/tests/exceptions_test.py
@@ -65,12 +65,19 @@ def test_checkpoint_error():
     assert error.termination_reason == TerminationReason.CHECKPOINT_FAILED
 
 
-def test_checkpoint_error_classification_invalid_token_invocation():
-    """Test 4xx InvalidParameterValueException with Invalid Checkpoint Token is invocation error."""
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Invalid checkpoint token: token expired",
+        "Invalid Checkpoint Token: token expired",
+    ],
+)
+def test_checkpoint_error_classification_invalid_token_invocation(message: str):
+    """Service emits lowercase 'checkpoint token'; match case-insensitively as invocation."""
     error_response = {
         "Error": {
             "Code": "InvalidParameterValueException",
-            "Message": "Invalid Checkpoint Token: token expired",
+            "Message": message,
         },
         "ResponseMetadata": {"HTTPStatusCode": 400},
     }


### PR DESCRIPTION
*Issue #, if available:*: #721

*Description of changes:*

The service emits `Invalid checkpoint token` (lowercase). The SDK matched a Title Case prefix, so a stale checkpoint token was classified as a non-retryable execution failure instead of a retryable invocation failure.

- Compare the message prefix case-insensitively
- Cover both the service casing and the previous Title Case string in unit tests

*Testing:*

- `hatch run dev-core:test`: 1670 passed
- `hatch fmt --check` in the core package: passed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.